### PR TITLE
Fix AA day/night sync on initial connect by reseeding UI mode at session start

### DIFF
--- a/app/src/main/java/com/openautolink/app/MainActivity.kt
+++ b/app/src/main/java/com/openautolink/app/MainActivity.kt
@@ -88,6 +88,10 @@ class MainActivity : ComponentActivity() {
             }
         }
 
+        // Seed SessionManager with the current AAOS day/night state even when
+        // no configuration change event has fired yet.
+        publishCurrentUiNightMode("onCreate")
+
         // User tapped "Exit" in the AA app launcher on the phone. Background
         // our app fully — both the MainActivity task and the hidden
         // CarAppActivity task (templates host for cluster). User re-enters by
@@ -140,6 +144,7 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         com.openautolink.app.diagnostics.DiagnosticLog.i("lifecycle", "MainActivity.onResume")
+        publishCurrentUiNightMode("onResume")
         // On AAOS, resume after car sleep leaves TCP sockets dead.
         // SessionManager dedupes against the SCREEN_ON broadcast receiver
         // (which empirically does not fire on this car) and emits a wake
@@ -200,7 +205,24 @@ class MainActivity : ComponentActivity() {
             nightMask == android.content.res.Configuration.UI_MODE_NIGHT_NO) {
             val isNight = nightMask == android.content.res.Configuration.UI_MODE_NIGHT_YES
             com.openautolink.app.session.SessionManager.instanceOrNull()?.onUiNightModeChanged(isNight)
+            com.openautolink.app.session.SessionManager.noteUiNightMode(isNight)
         }
+    }
+
+    private fun publishCurrentUiNightMode(reason: String) {
+        val nightMask = resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK
+        if (nightMask != android.content.res.Configuration.UI_MODE_NIGHT_YES &&
+            nightMask != android.content.res.Configuration.UI_MODE_NIGHT_NO
+        ) {
+            return
+        }
+        val isNight = nightMask == android.content.res.Configuration.UI_MODE_NIGHT_YES
+        com.openautolink.app.session.SessionManager.noteUiNightMode(isNight)
+        com.openautolink.app.session.SessionManager.instanceOrNull()?.onUiNightModeChanged(isNight)
+        com.openautolink.app.diagnostics.DiagnosticLog.i(
+            "lifecycle",
+            "publishCurrentUiNightMode[$reason]: night=$isNight"
+        )
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -1,5 +1,6 @@
 ﻿package com.openautolink.app.session
 
+import android.content.res.Configuration
 import android.content.Context
 import android.media.AudioManager
 import android.os.SystemClock
@@ -327,7 +328,8 @@ class SessionManager(
     // tick is wasted IPC at best, and at worst it might cause the phone to
     // re-render UI (e.g. NIGHT_MODE → AA theme change) too frequently. We
     // only forward to native when the value differs from the last sent.
-    // Reset to null on session start so the very first tick always fires.
+    // Reset to null on every new phone session so the very first tick always fires.
+    @Volatile private var lastKnownUiNightMode: Boolean? = currentUiNightMode()
     @Volatile private var lastSentNightMode: Boolean? = null
     @Volatile private var lastSentParkingBrake: Boolean? = null
     @Volatile private var lastSentDriving: Boolean? = null
@@ -379,6 +381,37 @@ class SessionManager(
 
     /** SCREEN_OFF/_ON receiver registration tracker. */
     private var screenReceiver: android.content.BroadcastReceiver? = null
+
+    private fun currentUiNightMode(): Boolean? {
+        val nightMask = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
+            ?: return null
+        return when (nightMask) {
+            Configuration.UI_MODE_NIGHT_YES -> true
+            Configuration.UI_MODE_NIGHT_NO -> false
+            else -> null
+        }
+    }
+
+    private fun resetLatchedVehicleSensorState(reason: String) {
+        lastSentNightMode = null
+        lastSentParkingBrake = null
+        lastSentDriving = null
+        lastSentGearRaw = null
+        OalLog.d(TAG, "Reset latched vehicle sensor state: $reason")
+    }
+
+    private fun seedCurrentUiNightMode(reason: String) {
+        val night = currentUiNightMode() ?: lastKnownUiNightMode
+        if (night == null) {
+            OalLog.d(TAG, "UI night mode unknown — skipping seed ($reason)")
+            return
+        }
+        lastKnownUiNightMode = night
+        val session = aasdkSession ?: return
+        lastSentNightMode = night
+        OalLog.i(TAG, "UI night mode → $night (reason=$reason)")
+        session.sendNightMode(night)
+    }
 
     fun start(
         codecPreference: String = "h264",
@@ -454,10 +487,7 @@ class SessionManager(
         // Reset edge-trigger memory so the first tick of the new session
         // unconditionally publishes nightMode / parking / driving / gear to
         // the phone — the phone has no prior state from us.
-        lastSentNightMode = null
-        lastSentParkingBrake = null
-        lastSentDriving = null
-        lastSentGearRaw = null
+        resetLatchedVehicleSensorState("start_session")
         _vehicleDataForwarder = context?.let { ctx ->
             VehicleDataForwarderImpl(
                 ctx,
@@ -1272,6 +1302,7 @@ class SessionManager(
      * occasional duplicate event to the phone is harmless.
      */
     fun onUiNightModeChanged(night: Boolean) {
+        lastKnownUiNightMode = night
         val session = aasdkSession ?: return
         lastSentNightMode = night
         OalLog.i(TAG, "UI night mode → $night (forwarding to phone)")
@@ -1642,6 +1673,8 @@ class SessionManager(
         when (message) {
             is ControlMessage.PhoneConnected -> {
                 _remoteDiagnostics?.log(DiagnosticLevel.INFO, "session", "Phone connected: ${message.phoneName}")
+                resetLatchedVehicleSensorState("phone_connected")
+                seedCurrentUiNightMode("phone_connected")
                 _sessionState.value = SessionState.STREAMING
                 _statusMessage.value = "Streaming"
                 aasdkSession?.let { startLocationForwarding(it) }

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -67,6 +67,11 @@ class SessionManager(
     companion object {
         private const val TAG = "SessionManager"
 
+        // Activity-sourced UI-mode snapshot that can be published before
+        // SessionManager exists (ViewModel lazy creation path).
+        @Volatile
+        private var bootUiNightModeSnapshot: Boolean? = null
+
         @Volatile
         private var instance: SessionManager? = null
 
@@ -77,6 +82,11 @@ class SessionManager(
         }
 
         fun instanceOrNull(): SessionManager? = instance
+
+        fun noteUiNightMode(night: Boolean) {
+            bootUiNightModeSnapshot = night
+            instance?.lastKnownUiNightMode = night
+        }
     }
 
     private val scope = CoroutineScope(SupervisorJob() + kotlinx.coroutines.Dispatchers.Main)
@@ -329,7 +339,7 @@ class SessionManager(
     // re-render UI (e.g. NIGHT_MODE → AA theme change) too frequently. We
     // only forward to native when the value differs from the last sent.
     // Reset to null on every new phone session so the very first tick always fires.
-    @Volatile private var lastKnownUiNightMode: Boolean? = currentUiNightMode()
+    @Volatile private var lastKnownUiNightMode: Boolean? = bootUiNightModeSnapshot
     @Volatile private var lastSentNightMode: Boolean? = null
     @Volatile private var lastSentParkingBrake: Boolean? = null
     @Volatile private var lastSentDriving: Boolean? = null
@@ -401,7 +411,9 @@ class SessionManager(
     }
 
     private fun seedCurrentUiNightMode(reason: String) {
-        val night = currentUiNightMode() ?: lastKnownUiNightMode
+        // Prefer Activity-reported state. Application-context config can be
+        // stale on AAOS and default to day mode until a config callback fires.
+        val night = lastKnownUiNightMode ?: currentUiNightMode()
         if (night == null) {
             OalLog.d(TAG, "UI night mode unknown — skipping seed ($reason)")
             return


### PR DESCRIPTION
## Why

I noticed after `dc0a010466b0ab256507babea636fcb846dac568`, Android Auto projection could start in **day/light** mode even when AAOS was already in **night/dark** mode.  
I could manually toggle the car theme (night -> day -> night) to get AA on the phone/projection updated correctly.

This is a visible regression in startup/session behavior and breaks expected AAOS -> AA theme synchronization.

## Root Cause

Commit `dc0a010466b0ab256507babea636fcb846dac568` introduced edge-triggered dedupe for low-cadence vehicle booleans (including `nightMode`) to reduce repeated sends.

That optimization was correct for steady-state transitions, but it created a reconnect/startup gap:
- phone-side AA sessions are effectively fresh on connect/reconnect,
- while app-side dedupe/latch state could suppress an initial resend,
- and initial night mode seeding relied on context/config paths that can be stale at startup (defaulting to day until a config-change event arrives).

Result: no correct night signal is guaranteed at initial connection, so projection may remain light until a manual OS theme toggle generates a new event.

## What This PR Changes

### 1) Session-level reseed + latch reset
In `app/src/main/java/com/openautolink/app/session/SessionManager.kt`:
- reset latched low-cadence vehicle sensor state on new phone session,
- explicitly seed current UI night mode on `PhoneConnected`,
- prefer the last known Activity-reported UI mode for seeding, with fallback to config lookup.

### 2) Activity lifecycle publication of current UI mode
In `app/src/main/java/com/openautolink/app/MainActivity.kt`:
- publish current UI night mode during `onCreate` and `onResume`,
- continue updating on `onConfigurationChanged`,
- provide an early snapshot path so `SessionManager` can use correct mode even before full reactive config change events occur.

## Result

AA now receives the correct day/night state at initial connect/reconnect without requiring a manual car-theme toggle.

## Validation

- Tested in-vehicle with car set to dark mode.
- Kotlin compile and unit tests pass for `:app` in local verification.