### PR TITLE
fix(media): scope MediaSession to process lifetime to fix frozen cluster after phone switch

### DIFF
--- a/app/src/main/java/com/openautolink/app/OalApplication.kt
+++ b/app/src/main/java/com/openautolink/app/OalApplication.kt
@@ -42,6 +42,28 @@ class OalApplication : Application() {
         // auto-connect. Without this, the "ghost wake" AAOS dispatches during
         // shutdown burns a 45s timeout into a dead WiFi.
         com.openautolink.app.input.IgnitionMonitor.start(this)
+
+        // Create the process-wide MediaSession and publish its token to the
+        // MediaBrowserService exactly once, at process start. The GM AAOS
+        // cluster media widget binds a MediaController to this token, and
+        // MediaBrowserServiceCompat.setSessionToken only accepts a token once
+        // per service instance. Creating the session here (process scope) —
+        // rather than per-connection in SessionManager — guarantees the token
+        // is published once and stays valid across every connect/disconnect,
+        // sleep/wake, and phone-identity switch. This is the fix for the
+        // "music cluster frozen after switching phones" bug: a per-session
+        // MediaSession was being recreated on switch, and its new token could
+        // never reach the already-bound cluster.
+        try {
+            val media = com.openautolink.app.media.OalMediaSessionManager.getInstance(this)
+            media.initialize()
+            media.getSessionToken()?.let { token ->
+                com.openautolink.app.media.OalMediaBrowserService.updateSessionToken(token)
+            }
+            Log.i("OAL-App", "Process-wide MediaSession initialized and token published")
+        } catch (e: Throwable) {
+            Log.w("OAL-App", "Failed to initialize MediaSession: ${e.message}")
+        }
     }
 
     /**

--- a/app/src/main/java/com/openautolink/app/media/OalMediaBrowserService.kt
+++ b/app/src/main/java/com/openautolink/app/media/OalMediaBrowserService.kt
@@ -23,18 +23,38 @@ class OalMediaBrowserService : MediaBrowserServiceCompat() {
         var mediaSessionToken: MediaSessionCompat.Token? = null
 
         /**
-         * Push session token to a running service instance.
-         * Called from SessionManager after MediaSession is initialized.
+         * Publish the process-wide MediaSession token to a running service
+         * instance. Called once from [com.openautolink.app.OalApplication] at
+         * process start, after the singleton MediaSession is initialized.
+         *
+         * The token is process-stable (the MediaSession is never recreated —
+         * see [OalMediaSessionManager]), so this is effectively a one-shot.
+         * `MediaBrowserServiceCompat.setSessionToken` throws
+         * `IllegalStateException` if a token was already set on this service
+         * instance; that is benign only when it's the *same* token (idempotent
+         * republish). A throw while attempting to set a *different* token would
+         * mean a second MediaSession leaked into the process — a real bug — so
+         * we log it at WARN rather than swallowing it silently.
          */
         fun updateSessionToken(token: MediaSessionCompat.Token) {
+            val previous = mediaSessionToken
             mediaSessionToken = token
             instance?.let { service ->
                 try {
                     service.setSessionToken(token)
-                    Log.d(TAG, "Session token pushed to running service")
+                    Log.d(TAG, "Session token published to running service")
                 } catch (e: IllegalStateException) {
-                    // Already set (reinit) — safe to ignore
-                    Log.d(TAG, "Session token already set, ignoring")
+                    if (previous == token) {
+                        // Same token re-published (e.g. service restarted and
+                        // re-read the static token in onCreate). Harmless.
+                        Log.d(TAG, "Session token already set (same token), ignoring")
+                    } else {
+                        // A different token can never reach the cluster on this
+                        // service instance — the MediaSession should be a
+                        // process singleton. Surface it instead of hiding it.
+                        Log.w(TAG, "setSessionToken rejected a NEW token; cluster will keep the old binding. " +
+                            "This indicates the MediaSession was recreated — it must be process-scoped.")
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
@@ -15,15 +15,46 @@ import android.util.Log
  * Manages a MediaSession that publishes now-playing metadata from the bridge
  * to AAOS system UI, cluster widgets, and steering wheel controls.
  *
+ * **Process-scoped singleton.** The MediaSession is created exactly once per
+ * process and lives for the whole process lifetime — see [getInstance]. This
+ * is deliberate: GM's AAOS cluster media widget binds a `MediaController` to
+ * the token published via [OalMediaBrowserService], and that framework
+ * (`MediaBrowserServiceCompat.setSessionToken`) only accepts a token **once**
+ * per service instance (it throws `IllegalStateException` on any later call —
+ * verified in GM's decompiled `com.gm.rhmi`). If we destroyed and recreated
+ * the MediaSession on a session boundary (e.g. a phone-identity switch across
+ * a car sleep/wake), the new token could never be published, and the cluster
+ * would stay bound to the dead session — the "music cluster frozen after
+ * switching phones" bug. Keeping one session for the process lifetime means
+ * the token is published once and stays valid forever; session boundaries
+ * only push new metadata/playback state via [updateMetadata] /
+ * [updatePlaybackState], or clear the now-playing tile via [resetToIdle].
+ *
  * Thread safety: all public methods may be called from coroutine dispatchers.
  * MediaSession is guarded by [sessionLock].
  */
-class OalMediaSessionManager(private val context: Context) {
+class OalMediaSessionManager private constructor(private val context: Context) {
 
     companion object {
         private const val TAG = "OalMediaSession"
         /** Max album art dimension — keeps Binder IPC under transaction limit. */
         private const val MAX_ART_SIZE = 320
+
+        @Volatile
+        private var instance: OalMediaSessionManager? = null
+
+        /**
+         * Process-wide singleton. Always uses the application context so the
+         * long-lived MediaSession never holds an Activity reference. Safe to
+         * call from any thread; construction is double-checked-locked.
+         */
+        fun getInstance(context: Context): OalMediaSessionManager {
+            return instance ?: synchronized(this) {
+                instance ?: OalMediaSessionManager(context.applicationContext).also { instance = it }
+            }
+        }
+
+        fun instanceOrNull(): OalMediaSessionManager? = instance
     }
 
     private var mediaSession: MediaSessionCompat? = null
@@ -101,6 +132,32 @@ class OalMediaSessionManager(private val context: Context) {
             cachedBitmap = null
             lastPushedPlaying = null
             Log.i(TAG, "MediaSession released")
+        }
+        instance = null
+    }
+
+    /**
+     * Reset the now-playing tile to an idle "Not connected" state **without**
+     * destroying the MediaSession or invalidating its token. Called on session
+     * teardown (e.g. [com.openautolink.app.session.SessionManager.stop]) so the
+     * cluster doesn't keep showing the previous phone's track, while the token
+     * stays valid for the next session — see the class kdoc for why the session
+     * must outlive individual connections.
+     */
+    fun resetToIdle() {
+        synchronized(sessionLock) {
+            val session = mediaSession ?: return
+            cachedArtHash = 0
+            cachedBitmap = null
+            lastPushedPlaying = false
+            session.setMetadata(
+                MediaMetadataCompat.Builder()
+                    .putString(MediaMetadataCompat.METADATA_KEY_TITLE, "OpenAutoLink")
+                    .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, "Not connected")
+                    .build()
+            )
+            session.setPlaybackState(buildPlaybackState(PlaybackStateCompat.STATE_NONE, 0))
+            Log.i(TAG, "MediaSession reset to idle")
         }
     }
 

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -329,7 +329,11 @@ class SessionManager(
         stop()
     }
 
-    // Media session
+    // Media session. Holds a reference to the process-wide singleton (created
+    // in OalApplication, not here). SessionManager only pushes metadata /
+    // playback updates and resets the tile to idle on teardown — it never
+    // creates or releases the session, so the cluster's token binding survives
+    // across connects, sleep/wake, and phone switches.
     private var _mediaSessionManager: OalMediaSessionManager? = null
     /** Cache of the most recently observed [ControlMessage.MediaMetadata] so
      *  we can replay it to the cluster on reconnect. The phone sends metadata
@@ -602,32 +606,30 @@ class SessionManager(
             }
         }
 
-        // Create media session for AAOS system UI integration.
-        // Only construct once per SessionManager lifetime: recreating the
-        // MediaSession invalidates the cluster widget's MediaController
-        // binding (GM cluster doesn't rebind cleanly), which is why the
-        // user previously saw stale album art after a Save & Reconnect or
-        // post-wake reconnect cycle. The session lives until SessionManager
-        // is fully torn down in stop().
-        if (_mediaSessionManager == null) {
-            _mediaSessionManager = context?.let { OalMediaSessionManager(it) }
-            _mediaSessionManager?.initialize()
-            _mediaSessionManager?.getSessionToken()?.let { token ->
+        // Bind to the process-wide MediaSession (created in OalApplication).
+        // We never create or release it here — the GM cluster's MediaController
+        // binds to the token published once at process start, and recreating
+        // the session would orphan that binding (the "music cluster frozen
+        // after switching phones" bug). getInstance() is idempotent; the
+        // initialize()/token-publish below are defensive no-ops that also cover
+        // the rare path where a session starts before OalApplication finished.
+        _mediaSessionManager = context?.let { OalMediaSessionManager.getInstance(it) }
+        _mediaSessionManager?.let { media ->
+            media.initialize()
+            media.getSessionToken()?.let { token ->
                 OalMediaBrowserService.updateSessionToken(token)
             }
-        } else {
-            // Replay the most-recent metadata + playback state in case the
-            // cluster widget needs nudging after a reconnect. Cheap; setMetadata
-            // is a binder call but the data is identical to what's already set
-            // so the cluster either updates from this or no-ops.
+            // Replay the most-recent metadata + playback state so the cluster
+            // tile reflects the current (or freshly reconnected/switched) phone
+            // rather than the idle placeholder or a previous phone's track.
             lastMediaMetadata?.let { m ->
-                _mediaSessionManager?.updateMetadata(
+                media.updateMetadata(
                     title = m.title, artist = m.artist, album = m.album,
                     durationMs = m.durationMs, albumArtBase64 = m.albumArtBase64,
                 )
             }
             lastMediaPlaybackState?.let { p ->
-                _mediaSessionManager?.updatePlaybackState(p.playing, p.positionMs)
+                media.updatePlaybackState(p.playing, p.positionMs)
             }
         }
 
@@ -1112,8 +1114,11 @@ class SessionManager(
         _imuForwarder = null
         _navigationDisplay.clear()
         ClusterNavigationState.clear()
-        _mediaSessionManager?.release()
-        _mediaSessionManager = null
+        // Do NOT release the MediaSession — it's the process-wide singleton and
+        // the GM cluster is bound to its token. Just reset the now-playing tile
+        // to idle so we don't keep showing the disconnected phone's track. The
+        // reference is left intact; the next start() reuses the same singleton.
+        _mediaSessionManager?.resetToIdle()
         lastMediaMetadata = null
         lastMediaPlaybackState = null
         _clusterManager?.release()


### PR DESCRIPTION
## Summary

Fixes the cluster **now-playing (music) tile freezing** after a phone-identity switch across a car sleep/wake cycle — the reported scenario being: a non-default phone drives the car, the car is turned off, and later the default phone connects on a new drive. Navigation cluster icons keep working; only force-closing the app recovers the music tile.

## Root cause

`MediaBrowserServiceCompat.setSessionToken()` accepts a session token **exactly once per service instance** — it throws `IllegalStateException` on any later call (verified in GM's decompiled `com.gm.rhmi` copy of `androidx/media/MediaBrowserServiceCompat.java`).

The `MediaSession` was created **per-connection** in `SessionManager`:

- A phone-identity switch runs `SessionManager.stop()` (which `release()`d + nulled the `MediaSession`) then `start()` (which built a **new** session with a **new** token).
- The token re-publish hit the once-only `setSessionToken` throw, which `OalMediaBrowserService.updateSessionToken` **silently swallowed**, leaving GM's cluster `MediaController` bound to the **released** session.
- Same-phone car-off→on goes through `AasdkSession.forceReconnect()`, which restarts transport without `stop()`, so the session/token survive — which is why it only reproduces on a phone swap, not on solo drives.

The app process survives car-off (the head unit only suspends), so the stale binding persists until the process is killed — hence force-close being the only fix.

## Fix — process-scoped MediaSession

- Create the `MediaSession` **once** in `OalApplication.onCreate` and publish its token there. The token is now process-stable and the GM cluster binds to it for the process lifetime.
- `OalMediaSessionManager` becomes a `getInstance()` singleton (uses the application context, never an Activity). Adds `resetToIdle()` to clear the now-playing tile **without** destroying the session/token.
- `SessionManager` no longer creates/releases the session: `start()` only pushes metadata + replays last-known state; `stop()` calls `resetToIdle()`.
- `OalMediaBrowserService.updateSessionToken` now logs a **WARN** (instead of silently swallowing) if a *different* token is ever rejected — a tripwire for any future regression that reintroduces per-session creation.

## Test plan

- [ ] CI builds (no JDK/Android SDK in the authoring environment — relying on CI to compile).
- [ ] On-car: non-default phone drives → car off → default phone connects on a new drive → confirm the music cluster tile tracks the new phone (no freeze, no force-close needed).
- [ ] Confirm navigation cluster still works across the same cycle.
- [ ] Confirm same-phone car sleep/wake still updates the tile normally.

> Diagnostic tell if it ever regresses: `OalMediaBrowser` logs `setSessionToken rejected a NEW token …` exactly when reconnecting a different phone.
