### PR TITLE
feat(diagnostics): maintainer-only log upload (car + companion)

### DIFF
--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -86,6 +86,16 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val FILE_LOGGING_AUTOSTART_USB = booleanPreferencesKey("file_logging_autostart_usb")
         val LOGCAT_CAPTURE_ENABLED = booleanPreferencesKey("logcat_capture_enabled")
 
+        // Maintainer-only diagnostic log upload. OFF by default. When enabled,
+        // the user supplies their own endpoint URL + bearer token + a device
+        // label; the floating Upload button on the projection screen zips the
+        // recent log files and POSTs them. Never imposed on other users — the
+        // button and the feature are entirely gated behind LOG_UPLOAD_ENABLED.
+        val LOG_UPLOAD_ENABLED = booleanPreferencesKey("log_upload_enabled")
+        val LOG_UPLOAD_URL = stringPreferencesKey("log_upload_url")
+        val LOG_UPLOAD_TOKEN = stringPreferencesKey("log_upload_token")
+        val LOG_UPLOAD_DEVICE_LABEL = stringPreferencesKey("log_upload_device_label")
+
         // AA safe area (stable) insets — maps render, UI stays inside
         val SAFE_AREA_TOP = intPreferencesKey("safe_area_top")
         val SAFE_AREA_BOTTOM = intPreferencesKey("safe_area_bottom")
@@ -213,6 +223,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_FILE_LOGGING_ENABLED = false
         const val DEFAULT_FILE_LOGGING_AUTOSTART_USB = false
         const val DEFAULT_LOGCAT_CAPTURE_ENABLED = false
+        const val DEFAULT_LOG_UPLOAD_ENABLED = false
+        const val DEFAULT_LOG_UPLOAD_URL = ""
+        const val DEFAULT_LOG_UPLOAD_TOKEN = ""
+        const val DEFAULT_LOG_UPLOAD_DEVICE_LABEL = "" // empty -> Build.MODEL fallback at runtime
         const val DEFAULT_SAFE_AREA_TOP = 0
         const val DEFAULT_SAFE_AREA_BOTTOM = 0
         const val DEFAULT_SAFE_AREA_LEFT = 0
@@ -406,6 +420,22 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         prefs[LOGCAT_CAPTURE_ENABLED] ?: DEFAULT_LOGCAT_CAPTURE_ENABLED
     }
 
+    val logUploadEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[LOG_UPLOAD_ENABLED] ?: DEFAULT_LOG_UPLOAD_ENABLED
+    }
+
+    val logUploadUrl: Flow<String> = dataStore.data.map { prefs ->
+        prefs[LOG_UPLOAD_URL] ?: DEFAULT_LOG_UPLOAD_URL
+    }
+
+    val logUploadToken: Flow<String> = dataStore.data.map { prefs ->
+        prefs[LOG_UPLOAD_TOKEN] ?: DEFAULT_LOG_UPLOAD_TOKEN
+    }
+
+    val logUploadDeviceLabel: Flow<String> = dataStore.data.map { prefs ->
+        prefs[LOG_UPLOAD_DEVICE_LABEL] ?: DEFAULT_LOG_UPLOAD_DEVICE_LABEL
+    }
+
     val safeAreaTop: Flow<Int> = dataStore.data.map { prefs ->
         prefs[SAFE_AREA_TOP] ?: DEFAULT_SAFE_AREA_TOP
     }
@@ -496,6 +526,22 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setVideoAutoNegotiate(enabled: Boolean) {
         dataStore.edit { it[VIDEO_AUTO_NEGOTIATE] = enabled }
+    }
+
+    suspend fun setLogUploadEnabled(value: Boolean) {
+        dataStore.edit { it[LOG_UPLOAD_ENABLED] = value }
+    }
+
+    suspend fun setLogUploadUrl(value: String) {
+        dataStore.edit { it[LOG_UPLOAD_URL] = value.trim() }
+    }
+
+    suspend fun setLogUploadToken(value: String) {
+        dataStore.edit { it[LOG_UPLOAD_TOKEN] = value.trim() }
+    }
+
+    suspend fun setLogUploadDeviceLabel(value: String) {
+        dataStore.edit { it[LOG_UPLOAD_DEVICE_LABEL] = value.trim() }
     }
 
     suspend fun setVideoCodec(codec: String) {

--- a/app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt
@@ -1,0 +1,144 @@
+package com.openautolink.app.diagnostics
+
+import android.content.Context
+import android.os.Build
+import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/** Result of an upload attempt. */
+sealed class UploadResult {
+    data class Success(val storedBytes: Int, val fileCount: Int) : UploadResult()
+    data class Failure(val reason: String) : UploadResult()
+}
+
+/**
+ * Bundles recent OAL log files into a zip and POSTs it to the maintainer's
+ * upload endpoint.
+ *
+ * This is an OFF-BY-DEFAULT, maintainer-only feature (gated by
+ * [AppPreferences.logUploadEnabled]); callers must pass a non-blank url +
+ * token. No new dependencies: pure java.net + java.util.zip.
+ *
+ * Because the app cannot reliably know when a drive session ends, "recent"
+ * means every log file modified within [RECENT_WINDOW_MS]; the server +
+ * Hermes pipeline dedup overlapping uploads by content, so re-tapping Upload
+ * across consecutive drives never double-counts.
+ */
+class LogUploader(private val context: Context) {
+
+    companion object {
+        private const val TAG = "LogUploader"
+        private const val DIR_NAME = "openautolink/logs"
+        private const val RECENT_WINDOW_MS = 6L * 60 * 60 * 1000   // 6 h
+        private const val MAX_ZIP_BYTES = 25L * 1024 * 1024        // 25 MB cap
+        private const val CONNECT_TIMEOUT_MS = 15_000
+        private const val READ_TIMEOUT_MS = 60_000
+    }
+
+    /** Collect log dirs across all external volumes (USB stick + primary). */
+    private fun logDirs(): List<File> {
+        val out = mutableListOf<File>()
+        context.getExternalFilesDirs(null).forEach { base ->
+            if (base != null) {
+                val d = File(base, DIR_NAME)
+                if (d.isDirectory) out += d
+            }
+        }
+        return out
+    }
+
+    private fun allLogFiles(): List<File> =
+        logDirs().flatMap { it.listFiles()?.toList() ?: emptyList() }
+            .filter { it.isFile }
+
+    /** Files modified within the recent window, newest first, size-capped.
+     *  Falls back to the single newest file if nothing is in the window. */
+    private fun recentFiles(): List<File> {
+        val cutoff = System.currentTimeMillis() - RECENT_WINDOW_MS
+        val recent = allLogFiles()
+            .filter { it.lastModified() >= cutoff }
+            .sortedByDescending { it.lastModified() }
+        val picked = mutableListOf<File>()
+        var total = 0L
+        for (f in recent) {
+            if (total + f.length() > MAX_ZIP_BYTES) continue
+            picked += f
+            total += f.length()
+        }
+        if (picked.isEmpty()) {
+            allLogFiles().maxByOrNull { it.lastModified() }?.let { picked += it }
+        }
+        return picked
+    }
+
+    private fun zipBytes(files: List<File>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(BufferedOutputStream(bos)).use { zos ->
+            for (f in files) {
+                zos.putNextEntry(ZipEntry(f.name))
+                f.inputStream().use { it.copyTo(zos) }
+                zos.closeEntry()
+            }
+        }
+        return bos.toByteArray()
+    }
+
+    private fun deviceLabel(explicit: String): String =
+        explicit.ifBlank { "${Build.MANUFACTURER}-${Build.MODEL}".take(64) }
+
+    /**
+     * Zip recent logs and POST them. Blocking network call — invoke from
+     * Dispatchers.IO. Returns a [UploadResult].
+     */
+    fun upload(url: String, token: String, deviceLabelPref: String): UploadResult {
+        if (url.isBlank() || token.isBlank()) {
+            return UploadResult.Failure("upload not configured")
+        }
+        val files = recentFiles()
+        if (files.isEmpty()) return UploadResult.Failure("no log files to upload")
+
+        val payload = try {
+            zipBytes(files)
+        } catch (e: Exception) {
+            return UploadResult.Failure("zip failed: ${e.message}")
+        }
+
+        val stamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())
+        val origName = "oal_car_$stamp.zip"
+
+        return try {
+            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                doOutput = true
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                setRequestProperty("Content-Type", "application/zip")
+                setRequestProperty("X-Upload-Token", token)
+                setRequestProperty("X-Device-Label", deviceLabel(deviceLabelPref))
+                setRequestProperty("X-Orig-Name", origName)
+                setFixedLengthStreamingMode(payload.size)
+            }
+            conn.outputStream.use { it.write(payload) }
+            val code = conn.responseCode
+            conn.disconnect()
+            if (code in 200..299) {
+                OalLog.i(TAG, "Uploaded ${files.size} file(s), ${payload.size} bytes -> HTTP $code")
+                UploadResult.Success(payload.size, files.size)
+            } else {
+                OalLog.w(TAG, "Upload rejected: HTTP $code")
+                UploadResult.Failure("server HTTP $code")
+            }
+        } catch (e: Exception) {
+            OalLog.e(TAG, "Upload failed: ${e.message}")
+            UploadResult.Failure(e.message ?: "network error")
+        }
+    }
+}

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
@@ -30,6 +30,9 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.CloudDone
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Settings
@@ -598,6 +601,43 @@ fun ProjectionScreen(
                     maxBoundsY = maxBoundsY,
                 )
                 } // end fileLoggingEnabled
+
+                // Upload Logs button — maintainer-only, shown when the feature
+                // is enabled in Settings. Color states: amber (uploading),
+                // green (success), red (error), default surface (idle). Appears
+                // whenever uploadEnabled so the user can fire it right after a
+                // drive while the just-written logs are still in the 6h window.
+                if (uiState.uploadEnabled) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val uploadContainer = when (uiState.uploadState) {
+                        LogUploadState.UPLOADING -> MaterialTheme.colorScheme.tertiary.copy(alpha = 0.85f)
+                        LogUploadState.SUCCESS -> Color(0xFF2E7D32).copy(alpha = 0.85f)
+                        LogUploadState.ERROR -> Color.Red.copy(alpha = 0.8f)
+                        LogUploadState.IDLE -> MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+                    }
+                    val uploadTint = if (uiState.uploadState == LogUploadState.IDLE) {
+                        MaterialTheme.colorScheme.onSurface
+                    } else {
+                        Color.White
+                    }
+                    val uploadIcon = when (uiState.uploadState) {
+                        LogUploadState.SUCCESS -> Icons.Default.CloudDone
+                        LogUploadState.ERROR -> Icons.Default.CloudOff
+                        else -> Icons.Default.CloudUpload
+                    }
+                    DraggableOverlayButton(
+                        icon = uploadIcon,
+                        contentDescription = "Upload Logs",
+                        onClick = { viewModel.uploadLogsNow() },
+                        positionKey = "overlay_upload_logs",
+                        containerColor = uploadContainer,
+                        tint = uploadTint,
+                        modifier = Modifier.testTag("uploadLogsButton"),
+                        maxBoundsX = maxBoundsX,
+                        maxBoundsY = maxBoundsY,
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -29,6 +29,8 @@ import com.openautolink.app.video.VideoStats
 import com.openautolink.app.diagnostics.OalLog
 import com.openautolink.app.diagnostics.DiagnosticLog
 import com.openautolink.app.diagnostics.FileLogWriter
+import com.openautolink.app.diagnostics.LogUploader
+import com.openautolink.app.diagnostics.UploadResult
 import com.openautolink.app.diagnostics.LogcatCapture
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -73,7 +75,12 @@ data class ProjectionUiState(
     val fileLoggingActive: Boolean = false,
     val fileLoggingPath: String? = null,
     val fileLoggingEnabled: Boolean = false,
+    val uploadEnabled: Boolean = false,
+    val uploadState: LogUploadState = LogUploadState.IDLE,
 )
+
+/** State of the maintainer log-upload action, drives the floating button color. */
+enum class LogUploadState { IDLE, UPLOADING, SUCCESS, ERROR }
 
 @OptIn(kotlinx.coroutines.FlowPreview::class)
 class ProjectionViewModel(application: Application) : AndroidViewModel(application) {
@@ -147,6 +154,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     private var fileLogWriter: FileLogWriter? = null
     private var logcatCapture: LogcatCapture? = null
 
+    // Maintainer log-upload action state (drives the floating Upload button color).
+    private val _uploadState = MutableStateFlow(LogUploadState.IDLE)
+
     // Pending surface — stored when surfaceCreated fires before decoder exists.
     // Attached to decoder on session start or when decoder becomes available.
     private var pendingSurface: Surface? = null
@@ -205,6 +215,8 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         _fileLoggingActive,
         _fileLoggingPath,
         preferences.fileLoggingEnabled,
+        preferences.logUploadEnabled,
+        _uploadState,
     ) { values ->
         ProjectionUiState(
             sessionState = values[0] as SessionState,
@@ -234,6 +246,8 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             fileLoggingActive = values[24] as Boolean,
             fileLoggingPath = values[25] as? String,
             fileLoggingEnabled = values[26] as Boolean,
+            uploadEnabled = values[27] as Boolean,
+            uploadState = values[28] as LogUploadState,
         )
     }.stateIn(
         viewModelScope,
@@ -1633,6 +1647,45 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      *  so the auto-start observer won't immediately restart it on the next USB
      *  mount event \u2014 they'll have to toggle the pref off/on or restart the app. */
     @Volatile private var autoUsbLoggingActive = false
+
+    /**
+     * Maintainer-only: zip recent logs and POST them to the configured
+     * endpoint. No-ops (with an ERROR flash) if the feature is unconfigured.
+     * Drives [ProjectionUiState.uploadState] so the floating button shows
+     * amber (uploading) -> green (success) / red (error), reverting after 3s.
+     */
+    fun uploadLogsNow() {
+        if (_uploadState.value == LogUploadState.UPLOADING) return
+        viewModelScope.launch {
+            val url = preferences.logUploadUrl.first()
+            val token = preferences.logUploadToken.first()
+            val label = preferences.logUploadDeviceLabel.first()
+            if (url.isBlank() || token.isBlank()) {
+                OalLog.w(TAG, "Upload tapped but URL/token not configured")
+                flashUpload(LogUploadState.ERROR)
+                return@launch
+            }
+            _uploadState.value = LogUploadState.UPLOADING
+            val result = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                LogUploader(getApplication()).upload(url, token, label)
+            }
+            flashUpload(
+                if (result is UploadResult.Success) LogUploadState.SUCCESS
+                else LogUploadState.ERROR
+            )
+        }
+    }
+
+    /** Set the upload state; auto-revert SUCCESS/ERROR to IDLE after 3s. */
+    private fun flashUpload(state: LogUploadState) {
+        _uploadState.value = state
+        if (state == LogUploadState.SUCCESS || state == LogUploadState.ERROR) {
+            viewModelScope.launch {
+                kotlinx.coroutines.delay(3000)
+                if (_uploadState.value == state) _uploadState.value = LogUploadState.IDLE
+            }
+        }
+    }
 
     fun toggleFileLogging() {
         synchronized(fileLogToggleLock) {

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
@@ -2444,6 +2445,57 @@ private fun DiagnosticsSettingsTab(
                 checked = uiState.logcatCaptureEnabled,
                 onCheckedChange = { viewModel.updateLogcatCaptureEnabled(it) },
                 modifier = Modifier.testTag("logcatCaptureToggle"),
+            )
+        }
+
+        // ── Log Upload (maintainer) ────────────────────────────────────
+        // OFF by default. Uploads recent diagnostic logs to the maintainer's
+        // own server. Only meant for the maintainer's own car + phones.
+        Row(
+            modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Upload Logs (maintainer)", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Off by default. When on, a floating Upload button appears on " +
+                        "the projection screen; tapping it zips recent logs and POSTs " +
+                        "them to your own server for analysis. Only enable on your own " +
+                        "devices — it never affects other users.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Switch(
+                checked = uiState.logUploadEnabled,
+                onCheckedChange = { viewModel.updateLogUploadEnabled(it) },
+                modifier = Modifier.testTag("logUploadToggle"),
+            )
+        }
+
+        if (uiState.logUploadEnabled) {
+            OutlinedTextField(
+                value = uiState.logUploadUrl,
+                onValueChange = { viewModel.updateLogUploadUrl(it) },
+                label = { Text("Upload URL") },
+                placeholder = { Text("https://oal-logs.example.com/upload") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 4.dp),
+            )
+            OutlinedTextField(
+                value = uiState.logUploadToken,
+                onValueChange = { viewModel.updateLogUploadToken(it) },
+                label = { Text("Upload token") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 4.dp),
+            )
+            OutlinedTextField(
+                value = uiState.logUploadDeviceLabel,
+                onValueChange = { viewModel.updateLogUploadDeviceLabel(it) },
+                label = { Text("Device label") },
+                placeholder = { Text("Blazer Car") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 4.dp),
             )
         }
     }

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -44,6 +44,11 @@ data class SettingsUiState(
     val fileLoggingEnabled: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_ENABLED,
     val fileLoggingAutoStartUsb: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_AUTOSTART_USB,
     val logcatCaptureEnabled: Boolean = AppPreferences.DEFAULT_LOGCAT_CAPTURE_ENABLED,
+    // Maintainer log upload (off by default)
+    val logUploadEnabled: Boolean = AppPreferences.DEFAULT_LOG_UPLOAD_ENABLED,
+    val logUploadUrl: String = AppPreferences.DEFAULT_LOG_UPLOAD_URL,
+    val logUploadToken: String = AppPreferences.DEFAULT_LOG_UPLOAD_TOKEN,
+    val logUploadDeviceLabel: String = AppPreferences.DEFAULT_LOG_UPLOAD_DEVICE_LABEL,
     // UI customization
     val syncAaTheme: Boolean = AppPreferences.DEFAULT_SYNC_AA_THEME,
     val hideAaClock: Boolean = AppPreferences.DEFAULT_HIDE_AA_CLOCK,
@@ -118,6 +123,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.manualIpEnabled,
         preferences.manualIpAddress,
         preferences.btMacOverride,
+        preferences.logUploadEnabled,
+        preferences.logUploadUrl,
+        preferences.logUploadToken,
+        preferences.logUploadDeviceLabel,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -161,6 +170,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             manualIpEnabled = values[38] as Boolean,
             manualIpAddress = values[39] as String,
             btMacOverride = values[40] as String,
+            logUploadEnabled = values[41] as Boolean,
+            logUploadUrl = values[42] as String,
+            logUploadToken = values[43] as String,
+            logUploadDeviceLabel = values[44] as String,
         )
     }.stateIn(
         viewModelScope,
@@ -383,6 +396,22 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateLogcatCaptureEnabled(enabled: Boolean) {
         viewModelScope.launch { preferences.setLogcatCaptureEnabled(enabled) }
+    }
+
+    fun updateLogUploadEnabled(enabled: Boolean) {
+        viewModelScope.launch { preferences.setLogUploadEnabled(enabled) }
+    }
+
+    fun updateLogUploadUrl(url: String) {
+        viewModelScope.launch { preferences.setLogUploadUrl(url) }
+    }
+
+    fun updateLogUploadToken(token: String) {
+        viewModelScope.launch { preferences.setLogUploadToken(token) }
+    }
+
+    fun updateLogUploadDeviceLabel(label: String) {
+        viewModelScope.launch { preferences.setLogUploadDeviceLabel(label) }
     }
 
     fun updateSyncAaTheme(enabled: Boolean) {

--- a/companion/src/main/AndroidManifest.xml
+++ b/companion/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
                 <action android:name="com.openautolink.companion.ACTION_START" />
                 <action android:name="com.openautolink.companion.ACTION_STOP" />
                 <action android:name="com.openautolink.companion.ACTION_PREWARM" />
+                <action android:name="com.openautolink.companion.ACTION_UPLOAD_LOGS" />
             </intent-filter>
         </service>
 

--- a/companion/src/main/java/com/openautolink/companion/MainActivity.kt
+++ b/companion/src/main/java/com/openautolink/companion/MainActivity.kt
@@ -147,6 +147,16 @@ object CompanionPrefs {
     const val PHONE_ID = "phone_id"             // stable UUID, generated on first launch
     const val PHONE_FRIENDLY_NAME = "phone_friendly_name"  // user-editable, defaults to Build.MODEL
 
+    // Maintainer-only diagnostic log upload. OFF by default. The user supplies
+    // their own endpoint URL + bearer token + device label; the in-app button
+    // and the notification action both zip recent logs and POST them. Never
+    // imposed on other users — everything is gated behind LOG_UPLOAD_ENABLED.
+    const val LOG_UPLOAD_ENABLED = "log_upload_enabled"
+    const val LOG_UPLOAD_URL = "log_upload_url"
+    const val LOG_UPLOAD_TOKEN = "log_upload_token"
+    const val LOG_UPLOAD_DEVICE_LABEL = "log_upload_device_label"
+    const val DEFAULT_LOG_UPLOAD_ENABLED = false
+
     /**
      * Returns the persistent phone UUID, generating one on first call.
      */

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
@@ -1,0 +1,132 @@
+package com.openautolink.companion.diagnostics
+
+import android.content.Context
+import android.os.Build
+import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/** Result of an upload attempt. */
+sealed class UploadResult {
+    data class Success(val bytes: Int, val fileCount: Int) : UploadResult()
+    data class Failure(val reason: String) : UploadResult()
+}
+
+/**
+ * Bundles recent companion log files into a zip and POSTs it to the
+ * maintainer's upload endpoint. OFF-BY-DEFAULT, maintainer-only (gated by
+ * CompanionPrefs.LOG_UPLOAD_ENABLED). Pure java.net + java.util.zip, no deps.
+ *
+ * Bundles both the companion's own log (oal_companion_*.log) and the captured
+ * logcat (logcat_companion_*.log) within the recent window. The server + the
+ * Hermes pipeline dedup overlapping uploads by content, so re-uploading across
+ * drives never double-counts.
+ */
+class LogUploader(private val context: Context) {
+
+    companion object {
+        private const val TAG = "OAL_Upload"
+        private const val DIR_NAME = "openautolink/logs"
+        private const val RECENT_WINDOW_MS = 6L * 60 * 60 * 1000   // 6 h
+        private const val MAX_ZIP_BYTES = 25L * 1024 * 1024        // 25 MB cap
+        private const val CONNECT_TIMEOUT_MS = 15_000
+        private const val READ_TIMEOUT_MS = 60_000
+    }
+
+    /** Resolve the log dir the same way CompanionFileLogger does. */
+    private fun logDir(): File? {
+        context.getExternalFilesDir(null)?.let {
+            val d = File(it, DIR_NAME)
+            if (d.isDirectory) return d
+        }
+        val internal = File(context.filesDir, DIR_NAME)
+        return if (internal.isDirectory) internal else null
+    }
+
+    private fun recentFiles(): List<File> {
+        val dir = logDir() ?: return emptyList()
+        val all = dir.listFiles()?.filter { it.isFile }
+            ?.sortedByDescending { it.lastModified() } ?: emptyList()
+        val cutoff = System.currentTimeMillis() - RECENT_WINDOW_MS
+        val recent = all.filter { it.lastModified() >= cutoff }
+        val source = recent.ifEmpty { all.take(2) }
+        val picked = mutableListOf<File>()
+        var total = 0L
+        for (f in source) {
+            if (total + f.length() > MAX_ZIP_BYTES) continue
+            picked += f
+            total += f.length()
+        }
+        return picked
+    }
+
+    private fun zipBytes(files: List<File>): ByteArray {
+        val bos = ByteArrayOutputStream()
+        ZipOutputStream(BufferedOutputStream(bos)).use { zos ->
+            for (f in files) {
+                zos.putNextEntry(ZipEntry(f.name))
+                f.inputStream().use { it.copyTo(zos) }
+                zos.closeEntry()
+            }
+        }
+        return bos.toByteArray()
+    }
+
+    private fun deviceLabel(explicit: String): String =
+        explicit.ifBlank { "${Build.MANUFACTURER}-${Build.MODEL}".take(64) }
+
+    /**
+     * Zip recent logs and POST them. Blocking — call from a background
+     * dispatcher (the service uses its IO scope). Returns a [UploadResult].
+     */
+    fun upload(url: String, token: String, deviceLabelPref: String): UploadResult {
+        if (url.isBlank() || token.isBlank()) {
+            return UploadResult.Failure("not configured")
+        }
+        val files = recentFiles()
+        if (files.isEmpty()) return UploadResult.Failure("no log files")
+
+        val payload = try {
+            zipBytes(files)
+        } catch (e: Exception) {
+            return UploadResult.Failure("zip failed: ${e.message}")
+        }
+
+        val stamp = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US).format(Date())
+        val origName = "oal_companion_$stamp.zip"
+
+        return try {
+            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = "POST"
+                doOutput = true
+                connectTimeout = CONNECT_TIMEOUT_MS
+                readTimeout = READ_TIMEOUT_MS
+                setRequestProperty("Content-Type", "application/zip")
+                setRequestProperty("X-Upload-Token", token)
+                setRequestProperty("X-Device-Label", deviceLabel(deviceLabelPref))
+                setRequestProperty("X-Orig-Name", origName)
+                setFixedLengthStreamingMode(payload.size)
+            }
+            conn.outputStream.use { it.write(payload) }
+            val code = conn.responseCode
+            conn.disconnect()
+            if (code in 200..299) {
+                CompanionLog.i(TAG, "Uploaded ${files.size} file(s), ${payload.size} bytes -> HTTP $code")
+                UploadResult.Success(payload.size, files.size)
+            } else {
+                CompanionLog.w(TAG, "Upload rejected: HTTP $code")
+                UploadResult.Failure("server HTTP $code")
+            }
+        } catch (e: Exception) {
+            CompanionLog.e(TAG, "Upload failed: ${e.message}")
+            UploadResult.Failure(e.message ?: "network error")
+        }
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -108,6 +108,12 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
                 tcpAdvertiser?.preWarmAaPipeline()
             }
 
+            ACTION_UPLOAD_LOGS -> {
+                CompanionLog.i(TAG, "Upload logs requested")
+                uploadLogs()
+                return START_STICKY
+            }
+
             else -> {
                 // System restart
                 if (_isRunning.value) {
@@ -233,14 +239,30 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             this, 0, openIntent, PendingIntent.FLAG_IMMUTABLE
         )
 
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle("OpenAutoLink Companion")
             .setContentText(text)
             .setSmallIcon(R.drawable.ic_notification)
             .setOngoing(true)
             .setContentIntent(openPending)
             .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Stop", stopPending)
-            .build()
+
+        // Maintainer-only: show an "Upload Logs" action straight from the
+        // notification, but ONLY when the feature is enabled — non-maintainer
+        // users never see it.
+        val uploadEnabled = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+            .getBoolean(CompanionPrefs.LOG_UPLOAD_ENABLED, CompanionPrefs.DEFAULT_LOG_UPLOAD_ENABLED)
+        if (uploadEnabled) {
+            val upIntent = Intent(this, CompanionService::class.java).apply {
+                action = ACTION_UPLOAD_LOGS
+            }
+            val upPending = PendingIntent.getService(
+                this, 1, upIntent, PendingIntent.FLAG_IMMUTABLE
+            )
+            builder.addAction(android.R.drawable.stat_sys_upload, "Upload Logs", upPending)
+        }
+
+        return builder.build()
     }
 
     private fun updateNotification(text: String) {
@@ -310,6 +332,46 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         _fileLoggingPath.value = null
     }
 
+    // ── Log upload (maintainer) ────────────────────────────────────────
+
+    /**
+     * Zip recent logs and POST them to the configured endpoint. No-ops (with a
+     * log line) if the feature is disabled or unconfigured. Updates
+     * [uploadState] ("uploading" -> "success"/"error" -> "idle") and reflects
+     * progress in the notification text. Runs on the service IO scope.
+     */
+    private fun uploadLogs() {
+        if (_uploadState.value == "uploading") return
+        val prefs = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+        if (!prefs.getBoolean(
+                CompanionPrefs.LOG_UPLOAD_ENABLED,
+                CompanionPrefs.DEFAULT_LOG_UPLOAD_ENABLED)) {
+            CompanionLog.w(TAG, "Upload requested but feature disabled")
+            return
+        }
+        val url = prefs.getString(CompanionPrefs.LOG_UPLOAD_URL, "") ?: ""
+        val token = prefs.getString(CompanionPrefs.LOG_UPLOAD_TOKEN, "") ?: ""
+        val label = prefs.getString(CompanionPrefs.LOG_UPLOAD_DEVICE_LABEL, "") ?: ""
+        if (url.isBlank() || token.isBlank()) {
+            CompanionLog.w(TAG, "Upload requested but URL/token not configured")
+            _uploadState.value = "error"
+            return
+        }
+        _uploadState.value = "uploading"
+        updateNotification("Uploading logs…")
+        serviceScope.launch {
+            val result = com.openautolink.companion.diagnostics.LogUploader(this@CompanionService)
+                .upload(url, token, label)
+            val ok = result is com.openautolink.companion.diagnostics.UploadResult.Success
+            _uploadState.value = if (ok) "success" else "error"
+            updateNotification(if (ok) "Logs uploaded ✓" else "Log upload failed")
+            delay(4000)
+            _uploadState.value = "idle"
+            updateNotification(
+                if (_isConnected.value) "Connected — AA active" else "Advertising…")
+        }
+    }
+
     companion object {
         private const val TAG = "OAL_Service"
         private const val CHANNEL_ID = "oal_companion_channel"
@@ -320,6 +382,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         const val ACTION_START = "com.openautolink.companion.ACTION_START"
         const val ACTION_STOP = "com.openautolink.companion.ACTION_STOP"
         const val ACTION_PREWARM = "com.openautolink.companion.ACTION_PREWARM"
+        /** Upload recent logs to the maintainer endpoint (off-by-default feature). */
+        const val ACTION_UPLOAD_LOGS = "com.openautolink.companion.ACTION_UPLOAD_LOGS"
         /** Optional extra on ACTION_START: also start file logging once the service is up. */
         const val EXTRA_START_LOGGING = "com.openautolink.companion.EXTRA_START_LOGGING"
 
@@ -338,6 +402,10 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
         private val _fileLoggingPath = MutableStateFlow<String?>(null)
         val fileLoggingPath: kotlinx.coroutines.flow.StateFlow<String?> = _fileLoggingPath
+
+        // Maintainer log-upload state: "idle" | "uploading" | "success" | "error".
+        private val _uploadState = MutableStateFlow("idle")
+        val uploadState: kotlinx.coroutines.flow.StateFlow<String> = _uploadState
 
         @Volatile
         private var _instance: CompanionService? = null

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -1358,6 +1359,119 @@ private fun FileLoggingSection() {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+        }
+    }
+
+    // ── Log Upload (maintainer) ────────────────────────────────────────
+    // OFF by default. Uploads recent logs to the maintainer's own server.
+    // Also available as an "Upload Logs" action in the foreground notification.
+    val prefs = remember { context.getSharedPreferences(CompanionPrefs.NAME, Context.MODE_PRIVATE) }
+    var uploadEnabled by remember {
+        mutableStateOf(prefs.getBoolean(CompanionPrefs.LOG_UPLOAD_ENABLED, CompanionPrefs.DEFAULT_LOG_UPLOAD_ENABLED))
+    }
+    var uploadUrl by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_URL, "") ?: "") }
+    var uploadToken by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_TOKEN, "") ?: "") }
+    var deviceLabel by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_DEVICE_LABEL, "") ?: "") }
+    val uploadState by CompanionService.uploadState.collectAsState()
+
+    Spacer(Modifier.height(20.dp))
+    Text(
+        text = "Log Upload (maintainer)",
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(Modifier.height(8.dp))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Enable log upload",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Switch(
+                    checked = uploadEnabled,
+                    onCheckedChange = { v ->
+                        uploadEnabled = v
+                        prefs.edit().putBoolean(CompanionPrefs.LOG_UPLOAD_ENABLED, v).apply()
+                    },
+                )
+            }
+
+            if (uploadEnabled) {
+                Spacer(Modifier.height(8.dp))
+                OutlinedTextField(
+                    value = uploadUrl,
+                    onValueChange = {
+                        uploadUrl = it
+                        prefs.edit().putString(CompanionPrefs.LOG_UPLOAD_URL, it.trim()).apply()
+                    },
+                    label = { Text("Upload URL") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = uploadToken,
+                    onValueChange = {
+                        uploadToken = it
+                        prefs.edit().putString(CompanionPrefs.LOG_UPLOAD_TOKEN, it.trim()).apply()
+                    },
+                    label = { Text("Upload token") },
+                    singleLine = true,
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                OutlinedTextField(
+                    value = deviceLabel,
+                    onValueChange = {
+                        deviceLabel = it
+                        prefs.edit().putString(CompanionPrefs.LOG_UPLOAD_DEVICE_LABEL, it.trim()).apply()
+                    },
+                    label = { Text("Device label (e.g. Pixel 7)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(12.dp))
+
+                val (btnLabel, btnColor) = when (uploadState) {
+                    "uploading" -> "Uploading…" to OalOrange
+                    "success" -> "Uploaded ✓" to OalGreen
+                    "error" -> "Upload failed — retry" to OalRed
+                    else -> "Upload logs now" to MaterialTheme.colorScheme.primary
+                }
+                Button(
+                    onClick = {
+                        val intent = android.content.Intent(context, CompanionService::class.java).apply {
+                            action = CompanionService.ACTION_UPLOAD_LOGS
+                        }
+                        androidx.core.content.ContextCompat.startForegroundService(context, intent)
+                    },
+                    enabled = uploadState != "uploading" && uploadUrl.isNotBlank() && uploadToken.isNotBlank(),
+                    colors = ButtonDefaults.buttonColors(containerColor = btnColor),
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text(btnLabel) }
+
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Off by default. Sends recent logs (companion + logcat) to your " +
+                        "own server for analysis. The same action is available from the " +
+                        "notification while the service runs.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Off-by-default diagnostic log upload for the maintainer's own car + phones, feeding a self-hosted analysis endpoint.\n\n## Apps\n**Car**: 4 DataStore prefs (default off), LogUploader (zips recent logs, 6h window/25MB cap, HttpURLConnection + token header), floating Upload overlay button with amber/green/red color states, Settings card.\n**Companion**: matching prefs, LogUploader (companion+logcat), CompanionService ACTION_UPLOAD_LOGS + uploadState + notification action (shown only when enabled), in-app upload card.\n\nBoth apps already hold INTERNET; the feature is fully gated behind the per-app enable toggle so it never affects other users. No new dependencies (java.net + java.util.zip).\n\n## Verified\n- :app:compileDebugKotlin — BUILD SUCCESSFUL\n- :companion:compileDebugKotlin — BUILD SUCCESSFUL\n\n## Server + AI loop (infra, not in this repo)\nA token-gated FastAPI intake behind Traefik writes uploads to a host folder; a daily Hermes triage job content-dedupes logs, fingerprints distinct faults, and files ai-triage GitHub issues (no duplicates across days). A manual auto-fix worker drafts PRs from issues.\n\nDraft — maintainer review before merge.\