### PR TITLE
fix(settings): LocalEchoTextField for log-upload fields (typing race regression)

### DIFF
--- a/app/src/main/java/com/openautolink/app/ui/components/LocalEchoTextField.kt
+++ b/app/src/main/java/com/openautolink/app/ui/components/LocalEchoTextField.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 
 /**
  * OutlinedTextField wrapper that fixes the IME-vs-DataStore typing race.
@@ -54,6 +55,7 @@ fun LocalEchoTextField(
     isError: Boolean = false,
     supportingText: @Composable (() -> Unit)? = null,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
 ) {
     var local by remember { mutableStateOf(TextFieldValue(value)) }
     var focused by remember { mutableStateOf(false) }
@@ -85,5 +87,6 @@ fun LocalEchoTextField(
         isError = isError,
         supportingText = supportingText,
         keyboardOptions = keyboardOptions,
+        visualTransformation = visualTransformation,
     )
 }

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
@@ -2473,7 +2472,7 @@ private fun DiagnosticsSettingsTab(
         }
 
         if (uiState.logUploadEnabled) {
-            OutlinedTextField(
+            LocalEchoTextField(
                 value = uiState.logUploadUrl,
                 onValueChange = { viewModel.updateLogUploadUrl(it) },
                 label = { Text("Upload URL") },
@@ -2481,7 +2480,7 @@ private fun DiagnosticsSettingsTab(
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 4.dp),
             )
-            OutlinedTextField(
+            LocalEchoTextField(
                 value = uiState.logUploadToken,
                 onValueChange = { viewModel.updateLogUploadToken(it) },
                 label = { Text("Upload token") },
@@ -2489,7 +2488,7 @@ private fun DiagnosticsSettingsTab(
                 visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 4.dp),
             )
-            OutlinedTextField(
+            LocalEchoTextField(
                 value = uiState.logUploadDeviceLabel,
                 onValueChange = { viewModel.updateLogUploadDeviceLabel(it) },
                 label = { Text("Device label") },


### PR DESCRIPTION
## Summary
Fixes a text-input typing bug in the app settings UI (not the projected AA surface).

**Symptom:** typing in any of the maintainer **Log Upload** fields (Upload URL / token / device label) on the car Settings → Diagnostics tab drops characters, loses focus until you re-tap, and the cursor jumps back so new characters land before the previous one.

**Root cause:** PR #25 (`d3120ca1`) added three raw `OutlinedTextField`s bound directly to DataStore-backed StateFlow. Each keystroke triggers a DataStore write → re-emit → Compose snaps the field back mid-IME-composition. This is the exact IME-vs-DataStore race that commit `7a4c6e38` already fixed everywhere else via the `LocalEchoTextField` wrapper — PR #25 reintroduced it on the three new fields.

## Fix
- Migrate the 3 log-upload fields to the existing `LocalEchoTextField` wrapper.
- Add a `visualTransformation` passthrough to the wrapper so the masked token field keeps its `PasswordVisualTransformation`.
- Remove the now-unused `OutlinedTextField` import.

## Scope / safety
- Only these 3 fields were affected. The other raw text inputs (SafeArea ×4, Diagnostics ping, all companion fields) display from local `mutableStateOf` and are structurally immune. The 6 previously-migrated fields were already correct. EV tab is sliders.
- No version bump in this commit — versioning is host-side `secrets/version.properties`, auto-incremented at release build.

## Verification
- `:app:compileDebugKotlin` → BUILD SUCCESSFUL (temurin-17, no warnings).
- Diff is exactly 4 changes: 3 call-site renames + 1 dead-import removal.
