### PR TITLE
feat(companion): persisted "Always log" mode for maintainer

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/MainActivity.kt
+++ b/companion/src/main/java/com/openautolink/companion/MainActivity.kt
@@ -157,6 +157,16 @@ object CompanionPrefs {
     const val LOG_UPLOAD_DEVICE_LABEL = "log_upload_device_label"
     const val DEFAULT_LOG_UPLOAD_ENABLED = false
 
+    // Maintainer-only "always log" mode. When enabled, file logging is started
+    // automatically whenever the service comes up (boot, app open, auto-start,
+    // OS-restart) and the 10-minute no-connection idle timeout is skipped, so
+    // logging stays on continuously across drives/disconnects until the user
+    // turns it off. Unlike the transient fileLoggingActive switch (which is
+    // service-scoped, connection-gated, and not persisted), this flag IS
+    // persisted in SharedPreferences and survives restarts.
+    const val LOG_PERSIST_ENABLED = "log_persist_enabled"
+    const val DEFAULT_LOG_PERSIST_ENABLED = false
+
     /**
      * Returns the persistent phone UUID, generating one on first call.
      */

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -59,6 +59,22 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         } catch (e: Exception) {
             CompanionLog.w(TAG, "MulticastLock failed: ${e.message}")
         }
+        // "Always log" mode: if the maintainer persisted logging on, start it as
+        // soon as the service exists — independent of any connection. Resumes on
+        // every service start (app open, BT/WiFi auto-start, OS sticky-restart);
+        // a cold reboot resumes it once one of those triggers first starts the
+        // service (there is no standalone BOOT_COMPLETED launcher).
+        maybeStartPersistentLogging()
+    }
+
+    /** Start file logging if the persisted "always log" pref is enabled. */
+    private fun maybeStartPersistentLogging() {
+        val persist = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+            .getBoolean(CompanionPrefs.LOG_PERSIST_ENABLED, CompanionPrefs.DEFAULT_LOG_PERSIST_ENABLED)
+        if (persist && fileLogger?.isActive?.value != true) {
+            CompanionLog.i(TAG, "Always-log mode on — starting file logging")
+            startFileLogging()
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -87,6 +103,9 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
                 startTcp()
                 if (intent.getBooleanExtra(EXTRA_START_LOGGING, false)) {
                     startFileLogging()
+                } else {
+                    // Always-log mode: resume logging on any service start.
+                    maybeStartPersistentLogging()
                 }
             }
 
@@ -120,6 +139,10 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
                     CompanionLog.i(TAG, "Service restarted by system, resuming")
                     startTcp()
                 }
+                // Resume always-log mode after an OS-initiated restart, even if
+                // the service wasn't "running" before the kill — onCreate also
+                // covers the fresh-process case, this covers sticky redelivery.
+                maybeStartPersistentLogging()
             }
         }
         return START_STICKY
@@ -307,8 +330,12 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             // 10-minute idle timeout: if the AA proxy never connects while
             // logging is active, auto-disable to avoid runaway log files when
             // the user forgets the toggle on. Cleared on first connection.
+            // SKIPPED entirely in "always log" mode — the maintainer wants
+            // continuous capture regardless of connection state.
             fileLogIdleTimeoutJob?.cancel()
-            if (!loggingSessionEverConnected) {
+            val persist = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+                .getBoolean(CompanionPrefs.LOG_PERSIST_ENABLED, CompanionPrefs.DEFAULT_LOG_PERSIST_ENABLED)
+            if (!persist && !loggingSessionEverConnected) {
                 fileLogIdleTimeoutJob = serviceScope.launch {
                     delay(LOG_IDLE_TIMEOUT_MS)
                     if (_fileLoggingActive.value && !loggingSessionEverConnected) {

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -1349,9 +1349,10 @@ private fun FileLoggingSection() {
 
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "Logs persist as long as this toggle is on, regardless of " +
-                    "connection state. If no connection is ever made within 10 minutes " +
-                    "of enabling, logging auto-disables to prevent runaway files.\n\n" +
+                text = "Logs persist as long as this toggle is on, while the " +
+                    "service is running. If no connection is ever made within 10 minutes " +
+                    "of enabling, logging auto-disables to prevent runaway files " +
+                    "(unless \"Always log\" below is on).\n\n" +
                     "Recommended only for troubleshooting — turn this back off " +
                     "when you're done. Continuous file logging adds I/O overhead " +
                     "and can affect proxy throughput.\n\n" +
@@ -1359,6 +1360,72 @@ private fun FileLoggingSection() {
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+
+            // ── Always log (maintainer) ────────────────────────────────
+            // Persisted opt-in: keep logging on continuously across drives,
+            // disconnects, service restarts, and reboots — no 10-min idle
+            // auto-off. The transient toggle above is service-scoped and not
+            // persisted; this flag is, and the service auto-starts logging
+            // whenever it comes up while this is set.
+            val logPrefs = remember {
+                context.getSharedPreferences(CompanionPrefs.NAME, Context.MODE_PRIVATE)
+            }
+            var alwaysLog by remember {
+                mutableStateOf(
+                    logPrefs.getBoolean(
+                        CompanionPrefs.LOG_PERSIST_ENABLED,
+                        CompanionPrefs.DEFAULT_LOG_PERSIST_ENABLED,
+                    )
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Always log (maintainer)",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Switch(
+                    checked = alwaysLog,
+                    onCheckedChange = { on ->
+                        alwaysLog = on
+                        logPrefs.edit().putBoolean(CompanionPrefs.LOG_PERSIST_ENABLED, on).apply()
+                        if (on) {
+                            // Start logging right now (covers the case where the
+                            // service is already running), and ensure the service
+                            // is up so logging persists. Reuses the same atomic
+                            // ACTION_START + EXTRA_START_LOGGING piggyback.
+                            val running = isServiceRunning
+                            val service = getCompanionService(context)
+                            if (running && service != null) {
+                                service.startFileLogging()
+                            } else {
+                                val intent = android.content.Intent(context, CompanionService::class.java).apply {
+                                    action = CompanionService.ACTION_START
+                                    putExtra(CompanionService.EXTRA_START_LOGGING, true)
+                                }
+                                androidx.core.content.ContextCompat.startForegroundService(context, intent)
+                            }
+                        }
+                        // Turning OFF does not stop the current session's logging
+                        // (use the toggle above for that) — it only stops auto-start
+                        // on future service starts and re-arms the idle timeout.
+                    },
+                )
+            }
+            if (alwaysLog) {
+                Text(
+                    text = "Logging stays on continuously across drives, disconnects, " +
+                        "and service restarts until you turn this off — no 10-minute " +
+                        "auto-off. After a phone reboot it resumes as soon as the " +
+                        "service next starts (you open the app, or BT/WiFi auto-start fires).",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = OalGreen,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
The companion File Logging toggle does not stay on the way a maintainer needs for capturing intermittent mid-drive issues. Today it is:
- **service-scoped + not persisted** — the on/off state lives in a service StateFlow, not prefs
- **connection-gated** — auto-disables after a 10-minute no-connection idle timeout
- **stopped on service teardown** — onDestroy (Stop tap / stop-on-disconnect / OS kill), with no resume on restart

So after a disconnect/restart the next drive often is not logged, silently.

## Fix
New persisted `LOG_PERSIST_ENABLED` pref (default off, maintainer opt-in):
- `onCreate` + `ACTION_START` + system-restart branch auto-start logging when set
- `startFileLogging()` skips the 10-minute idle timeout when set
- new **Always log (maintainer)** toggle in the File Logging card; enabling it starts logging immediately via the existing atomic `ACTION_START` + `EXTRA_START_LOGGING` piggyback

Once enabled, logging stays on continuously across drives, disconnects, and service restarts until explicitly turned off. After a device restart it resumes on the next service start (app open / BT / WiFi auto-start) — there is no standalone BOOT_COMPLETED launcher, and the comments + UI text say so rather than overpromising.

Turning the toggle off does **not** stop the current session (the transient toggle does that) — it only disables future auto-start and re-arms the idle timeout.

## Verified
- `:companion:compileDebugKotlin` BUILD SUCCESSFUL
- 3 files, +108/-4, no new deps

Motivation: needed to reliably capture an intermittent mid-drive AA freeze (frozen video / no audio / no reconnect) where the car log ended before the event and the phone was not logging.