### PR TITLE
fix(connect): reject stale phone IP on wake reconnect (#27)

### DIFF
--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -296,6 +296,17 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     @Volatile private var connectInFlight = false
     /** Throttle for the auto-reconnect collector (Car Hotspot mode). */
     @Volatile private var lastAutoReconnectAttemptMs: Long = 0L
+
+    // Discovery freshness floor (wall-clock ms). Set on a long-gap wake so the
+    // mDNS grace in [resolveCarHotspotPhone] REJECTS phone entries last seen
+    // before the wake — those carry the phone's pre-sleep IP, which the car's
+    // hotspot DHCP often re-leases to a new address across a sleep. Without
+    // this, the grace returns the stale cached IP and the connector dials a
+    // dead address for ~60s until the periodic sweep re-resolves (issue #27).
+    // 0 = no floor (accept any resolved entry). Cleared once a fresh resolve
+    // lands or a connect succeeds, so a phone that legitimately keeps its IP
+    // isn't rejected forever.
+    @Volatile private var discoveryFreshnessFloorMs: Long = 0L
     private val AUTO_RECONNECT_MIN_GAP_MS = 10_000L
     /**
      * mDNS-only grace window inside [resolveCarHotspotPhone]. mDNS is
@@ -303,6 +314,15 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      * before kicking the active /24 sweep.
      */
     private val MDNS_GRACE_MS = 3_000L
+    /**
+     * Margin subtracted when setting [discoveryFreshnessFloorMs] on wake.
+     * Tolerates small clock jitter and accepts discovery entries that were
+     * (re)seen in the instant around the wake event, while still rejecting
+     * entries that were last seen before the sleep (which carry the stale
+     * pre-sleep IP). 2s is comfortably below a realistic sleep gap and above
+     * any plausible same-tick re-announce skew.
+     */
+    private val DISCOVERY_FRESHNESS_MARGIN_MS = 2_000L
     /**
      * "Head-start" grace given to the default phone when it isn't the
      * first one to surface in discovery. If a non-default known phone
@@ -892,6 +912,22 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     )
                     _activePhoneId.value = null
                 }
+                // On any reconnect-worthy wake, raise the discovery freshness
+                // floor so the mDNS grace can't return a phone entry resolved
+                // BEFORE the sleep — that entry holds the pre-sleep IP, which
+                // the car hotspot often re-leases to a new address across a
+                // sleep. Forcing a re-resolve avoids dialing the stale IP for
+                // ~60s until the sweep catches up (issue #27). A small margin
+                // tolerates clock jitter and entries seen mid-wake.
+                if (event.gapMs >= WAKE_AUTO_RECONNECT_MIN_GAP_MS) {
+                    discoveryFreshnessFloorMs =
+                        System.currentTimeMillis() - DISCOVERY_FRESHNESS_MARGIN_MS
+                    OalLog.i(
+                        TAG,
+                        "Wake (gap=${event.gapMs}ms) — discovery freshness floor set; " +
+                            "stale pre-wake phone IPs will be re-resolved",
+                    )
+                }
                 // Force-kick auto-reconnect on wake. `phoneDiscovery.phones`
                 // edge-triggered collector only fires when isResolved flips
                 // false→true; after a short sleep the phone often stays
@@ -1419,35 +1455,46 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             preferences.defaultPhoneId.first().takeIf { it.isNotBlank() }
         } catch (_: Exception) { null }
 
-        // Phase 1: mDNS-only grace. Cheapest, fastest, no socket pressure.
-        OalLog.i(TAG, "Resolving phone — mDNS grace ${MDNS_GRACE_MS}ms")
-        val mdnsHit = kotlinx.coroutines.withTimeoutOrNull(MDNS_GRACE_MS) {
-            collectWithDefaultHeadStart(defaultId)
-        }
-        if (mdnsHit != null) {
-            OalLog.i(TAG, "Resolved via mDNS within ${MDNS_GRACE_MS}ms")
-            return mdnsHit
-        }
-
-        // Phase 2: UDP broadcast. ~50ms when the AP allows it. Sits
-        // between mDNS (often broken on AAOS 12/13) and the full /24
-        // sweep (always works, ~400ms wall time).
-        OalLog.i(TAG, "mDNS grace expired — trying UDP broadcast")
-        val broadcastHits = phoneDiscovery.udpBroadcastAllInterfaces(listenWindowMs = 600L)
-        if (broadcastHits > 0) {
-            val picked = pickBestPhone(phoneDiscovery.phones.value, defaultId)
-            if (picked != null) {
-                OalLog.i(TAG, "Resolved via UDP broadcast ($broadcastHits hit(s))")
-                return picked
+        // The discovery freshness floor (set on wake) governs exactly this one
+        // resolve pass: it makes the phases below reject stale pre-wake entries
+        // and wait for a re-resolve. Clear it on the way out (any path) so a
+        // phone that legitimately keeps the same IP — and thus won't re-announce
+        // with a newer lastSeenMs — isn't rejected on subsequent resolves.
+        try {
+            // Phase 1: mDNS-only grace. Cheapest, fastest, no socket pressure.
+            OalLog.i(TAG, "Resolving phone — mDNS grace ${MDNS_GRACE_MS}ms")
+            val mdnsHit = kotlinx.coroutines.withTimeoutOrNull(MDNS_GRACE_MS) {
+                collectWithDefaultHeadStart(defaultId)
             }
-        }
+            if (mdnsHit != null) {
+                OalLog.i(TAG, "Resolved via mDNS within ${MDNS_GRACE_MS}ms")
+                return mdnsHit
+            }
 
-        // Phase 3: full /24 TCP sweep. Always works on cooperative APs.
-        OalLog.i(TAG, "UDP broadcast empty — kicking /24 sweep")
-        kickSweep()
-        val remaining = (timeoutMs - MDNS_GRACE_MS - 600L).coerceAtLeast(2_000L)
-        return kotlinx.coroutines.withTimeoutOrNull(remaining) {
-            collectWithDefaultHeadStart(defaultId)
+            // Phase 2: UDP broadcast. ~50ms when the AP allows it. Sits
+            // between mDNS (often broken on AAOS 12/13) and the full /24
+            // sweep (always works, ~400ms wall time).
+            OalLog.i(TAG, "mDNS grace expired — trying UDP broadcast")
+            val broadcastHits = phoneDiscovery.udpBroadcastAllInterfaces(listenWindowMs = 600L)
+            if (broadcastHits > 0) {
+                val picked = pickBestPhone(phoneDiscovery.phones.value, defaultId)
+                if (picked != null) {
+                    OalLog.i(TAG, "Resolved via UDP broadcast ($broadcastHits hit(s))")
+                    return picked
+                }
+            }
+
+            // Phase 3: full /24 TCP sweep. Always works on cooperative APs.
+            OalLog.i(TAG, "UDP broadcast empty — kicking /24 sweep")
+            kickSweep()
+            val remaining = (timeoutMs - MDNS_GRACE_MS - 600L).coerceAtLeast(2_000L)
+            return kotlinx.coroutines.withTimeoutOrNull(remaining) {
+                collectWithDefaultHeadStart(defaultId)
+            }
+        } finally {
+            if (discoveryFreshnessFloorMs != 0L) {
+                discoveryFreshnessFloorMs = 0L
+            }
         }
     }
 
@@ -1480,7 +1527,13 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             // for first.
             val defaultJob = async {
                 phoneDiscovery.phones
-                    .map { list -> list.firstOrNull { it.isResolved && it.phoneId == defaultId } }
+                    .map { list ->
+                        val floor = discoveryFreshnessFloorMs
+                        list.firstOrNull {
+                            it.isResolved && it.phoneId == defaultId &&
+                                (floor == 0L || it.lastSeenMs >= floor)
+                        }
+                    }
                     .first { it != null }!!
             }
             val anyJob = async {
@@ -1525,8 +1578,12 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     ): com.openautolink.app.transport.PhoneDiscovery.DiscoveredPhone? {
         // Defensive: drop IPv6 link-local hosts that slipped through. They
         // aren't usable for TCP without a scope ID (e.g. %wlan0).
+        // Also drop entries last seen before the discovery freshness floor
+        // (set on wake) — those carry the phone's stale pre-sleep IP (issue #27).
+        val floor = discoveryFreshnessFloorMs
         val resolved = list.filter {
-            it.isResolved && !it.host.isNullOrBlank() && !isUnusableHost(it.host)
+            it.isResolved && !it.host.isNullOrBlank() && !isUnusableHost(it.host) &&
+                (floor == 0L || it.lastSeenMs >= floor)
         }
         if (resolved.isEmpty()) return null
         if (defaultId != null) {


### PR DESCRIPTION
Fixes #27.

## Problem
After a sleep, the car auto-reconnect dialed the phone's **pre-sleep IP** for ~60s before the periodic /24 sweep re-resolved it — frozen stream even though the correct new IP was already known via mDNS seconds in.

From the diagnosed incident (single phone, three DHCP IPs across the wake):
- 14:26:27 `connect()` → `Manual IP mode: 10.181.20.109` (stale), retried ~14x/60s
- **14:26:35 `PhoneDiscovery: Resolved → 10.181.20.69`** (correct new IP available)
- 14:27:32 sweep finally forces the switch → connects

## Root cause
`resolveCarHotspotPhone`'s 3s mDNS grace returns the first `isResolved` entry from `phoneDiscovery.phones`. On wake that cache still holds the pre-sleep entry (`isResolved=true`, old IP), so the grace returns the stale IP in <3s — before the phone re-announces at its new address. The car hotspot DHCP commonly re-leases a new phone IP across a sleep, so this fires often.

## Fix (direction A from the issue: discovery freshness floor)
- On any reconnect-worthy wake, set `discoveryFreshnessFloorMs = now - 2s`.
- `pickBestPhone` + the default-phone collector reject entries whose `lastSeenMs` predates the floor, so the mDNS grace can't return a stale pre-wake IP. It falls through to the UDP-broadcast / sweep phases, which actively re-probe and surface the phone's **current** IP (`addOrUpdate` always bumps `lastSeenMs` on re-discovery and overwrites `host` by `phone_id`).
- The floor governs exactly one resolve pass and is cleared in a `finally`, so a phone that legitimately keeps the same IP (and won't re-announce with a newer timestamp) is never rejected on later resolves.

Net: instead of dialing a dead IP for ~60s, the car waits out the 3s grace then re-resolves to the new IP within the UDP/sweep phase (~1s).

## Scope / safety
- One file, +85/-28, no new deps, no behavior change when `discoveryFreshnessFloorMs == 0` (the non-wake path is untouched).
- Verified: `:app:compileDebugKotlin` BUILD SUCCESSFUL.

Note: this is the wake/reconnect bug, distinct from the separate mid-session stream-stall (frozen video, no disconnect) that still needs a car-side stall watchdog.