### PR TITLE
feat(app): persisted Always Log mode for maintainer (car app)

### DIFF
--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -85,6 +85,13 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val FILE_LOGGING_ENABLED = booleanPreferencesKey("file_logging_enabled")
         val FILE_LOGGING_AUTOSTART_USB = booleanPreferencesKey("file_logging_autostart_usb")
         val LOGCAT_CAPTURE_ENABLED = booleanPreferencesKey("logcat_capture_enabled")
+        // Maintainer "always log" mode (car app). When enabled, file logging
+        // starts automatically whenever the projection screen comes up, so a
+        // drive is captured without the user remembering to toggle it on. The
+        // car app's logging is already connection-independent (it survives
+        // disconnects/reconnects; it's only torn down in onCleared at app exit),
+        // so this just removes the manual step. Persisted, default off.
+        val LOG_PERSIST_ENABLED = booleanPreferencesKey("log_persist_enabled")
 
         // Maintainer-only diagnostic log upload. OFF by default. When enabled,
         // the user supplies their own endpoint URL + bearer token + a device
@@ -223,6 +230,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_FILE_LOGGING_ENABLED = false
         const val DEFAULT_FILE_LOGGING_AUTOSTART_USB = false
         const val DEFAULT_LOGCAT_CAPTURE_ENABLED = false
+        const val DEFAULT_LOG_PERSIST_ENABLED = false
         const val DEFAULT_LOG_UPLOAD_ENABLED = false
         const val DEFAULT_LOG_UPLOAD_URL = ""
         const val DEFAULT_LOG_UPLOAD_TOKEN = ""
@@ -418,6 +426,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val logcatCaptureEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[LOGCAT_CAPTURE_ENABLED] ?: DEFAULT_LOGCAT_CAPTURE_ENABLED
+    }
+
+    val logPersistEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[LOG_PERSIST_ENABLED] ?: DEFAULT_LOG_PERSIST_ENABLED
     }
 
     val logUploadEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -620,6 +632,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setLogcatCaptureEnabled(enabled: Boolean) {
         dataStore.edit { it[LOGCAT_CAPTURE_ENABLED] = enabled }
+    }
+
+    suspend fun setLogPersistEnabled(enabled: Boolean) {
+        dataStore.edit { it[LOG_PERSIST_ENABLED] = enabled }
     }
 
     suspend fun setSafeAreaTop(value: Int) {

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -1171,6 +1171,24 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 evaluateAutoUsbLogging(enabled, "pref-change")
             }
         }
+        // Maintainer "always log" mode: when the persisted pref is on, start
+        // file logging as soon as the projection screen comes up so the whole
+        // drive is captured without a manual toggle. Observe the pref so
+        // enabling it mid-session starts logging immediately too. Idempotent —
+        // startFileLoggingLocked no-ops when already active (e.g. USB-autostart
+        // or a manual toggle already started it).
+        viewModelScope.launch {
+            preferences.logPersistEnabled.collect { persist ->
+                if (persist) {
+                    synchronized(fileLogToggleLock) {
+                        if (!_fileLoggingActive.value) {
+                            OalLog.i(TAG, "Always-log mode on — starting file logging")
+                            startFileLoggingLocked(requireRemovable = false)
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -2406,6 +2406,29 @@ private fun DiagnosticsSettingsTab(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
+                Text("Always Log (maintainer)", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Automatically start file logging whenever the projection " +
+                        "screen comes up, so a whole drive is captured without " +
+                        "remembering to toggle it on. Persisted — stays on across " +
+                        "drives and reconnects until turned off. Uses internal " +
+                        "storage (no USB required). Recommended only for the " +
+                        "maintainer capturing intermittent issues.",
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Switch(
+                checked = uiState.logPersistEnabled,
+                onCheckedChange = { viewModel.updateLogPersistEnabled(it) },
+                modifier = Modifier.testTag("logPersistToggle"),
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(0.7f).padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
                 Text("Always Log to USB", style = MaterialTheme.typography.bodyLarge)
                 Text(
                     "Automatically start file logging whenever the app is running, " +

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -44,6 +44,7 @@ data class SettingsUiState(
     val fileLoggingEnabled: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_ENABLED,
     val fileLoggingAutoStartUsb: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_AUTOSTART_USB,
     val logcatCaptureEnabled: Boolean = AppPreferences.DEFAULT_LOGCAT_CAPTURE_ENABLED,
+    val logPersistEnabled: Boolean = AppPreferences.DEFAULT_LOG_PERSIST_ENABLED,
     // Maintainer log upload (off by default)
     val logUploadEnabled: Boolean = AppPreferences.DEFAULT_LOG_UPLOAD_ENABLED,
     val logUploadUrl: String = AppPreferences.DEFAULT_LOG_UPLOAD_URL,
@@ -127,6 +128,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.logUploadUrl,
         preferences.logUploadToken,
         preferences.logUploadDeviceLabel,
+        preferences.logPersistEnabled,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -174,6 +176,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             logUploadUrl = values[42] as String,
             logUploadToken = values[43] as String,
             logUploadDeviceLabel = values[44] as String,
+            logPersistEnabled = values[45] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -396,6 +399,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateLogcatCaptureEnabled(enabled: Boolean) {
         viewModelScope.launch { preferences.setLogcatCaptureEnabled(enabled) }
+    }
+
+    fun updateLogPersistEnabled(enabled: Boolean) {
+        viewModelScope.launch { preferences.setLogPersistEnabled(enabled) }
     }
 
     fun updateLogUploadEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Why
The companion app got persisted always-log (PR #28), but the **car app** still has no equivalent. Every recent incident triage has had to work from a **stale car log** (the car uploads its newest on-disk file, which predates the drive) because nobody manually toggled the overlay record button. The phone side captures cleanly now; the car side is half-blind.

Most recent example: the 2026-06-23 ~08:30 mid-drive Wi-Fi drop (issue #31) was diagnosed entirely from the phone log because the car uploaded yesterday's session.

## What
Persisted `LOG_PERSIST_ENABLED` pref (DataStore, default off, maintainer opt-in):
- **AppPreferences**: key + default + `Flow` + setter (the 4-part DataStore pattern).
- **ProjectionViewModel** init block: observe the pref; when on, auto-start file logging as the projection screen comes up. Idempotent — `startFileLoggingLocked` no-ops if logging is already active (USB-autostart or a manual overlay toggle). Mirrors the existing `fileLoggingAutoStartUsb` collector right above it.
- **Settings → File Logging**: new "Always Log (maintainer)" toggle.

The car app's file logging is **already connection-independent** — it survives disconnects/reconnects and is only torn down in `onCleared()` at app exit (projection screen destroyed). So unlike the companion (which needed idle-timeout + service-restart handling), the car fix is just "auto-start it, persisted." Uses internal storage (no USB requirement, unlike the existing Always-Log-to-USB option).

## Behavior
- Toggle on → logging starts immediately and on every subsequent app launch, capturing whole drives without the manual step.
- Toggle off → future auto-start disabled; an explicit manual stop mid-session is honored until next launch (the pref-change collector won't re-fire while the pref stays true). Matches the companion semantics.

## Verified
- `:app:compileDebugKotlin` BUILD SUCCESSFUL
- 4 files, +64, no new deps, combine arity updated (`values[45]`)

Pairs with companion PR #28 — both apps now capture continuously, so the next incident is logged on **both** sides.
