### PR TITLE
fix(video): force-focus keyframe + freeze cap for post-call video freeze (#35)

### DIFF
--- a/app/src/main/cpp/aasdk_jni.cpp
+++ b/app/src/main/cpp/aasdk_jni.cpp
@@ -232,6 +232,20 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeRequestKeyframe(
     }
 }
 
+/*
+ * Class:     com_openautolink_app_transport_aasdk_AasdkNative
+ * Method:    nativeRequestKeyframeForceFocus
+ */
+JNIEXPORT void JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeRequestKeyframeForceFocus(
+    JNIEnv* /*env*/, jclass /*clazz*/)
+{
+    std::lock_guard<std::mutex> lock(gSessionMutex);
+    if (gSession) {
+        gSession->requestKeyframeForceFocus();
+    }
+}
+
 // Typed vehicle sensor JNI methods — each calls the corresponding C++ method
 // that builds the correct SensorBatch protobuf and sends via sensorChannel_.
 

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -1705,6 +1705,50 @@ void JniSession::requestKeyframe()
     });
 }
 
+// Force a fresh IDR by performing a real focus TRANSITION rather than
+// re-asserting the same PROJECTED state (issue #35). The plain requestKeyframe()
+// above re-sends VIDEO_FOCUS_PROJECTED, but if the head unit already holds
+// projected focus (e.g. after a phone-call / GM-UI takeover that backgrounded us
+// without ever dropping focus), the phone sees no state change and emits no
+// out-of-cycle IDR — leaving video frozen until the next natural GOP (~2 min).
+//
+// Bouncing NATIVE_TRANSIENT -> PROJECTED is a genuine yield-then-reacquire, which
+// is exactly what makes the phone send a fresh IDR (the same transition that
+// produces the IDR on initial projection). NATIVE_TRANSIENT (not plain NATIVE) is
+// deliberate: the phone treats it as a temporary handover, and our own
+// onVideoFocusRequest() only escalates plain NATIVE to a user-Exit teardown.
+// Both indications are posted on the strand in order so they serialize correctly.
+void JniSession::requestKeyframeForceFocus()
+{
+    if (!streaming_ || !videoChannel_) return;
+    ioService_->post([this]() {
+        LOGI("Requesting keyframe via focus bounce (NATIVE_TRANSIENT -> PROJECTED)");
+
+        // 1. Yield: announce transient native focus.
+        currentVideoFocus_.store(
+            aap_protobuf::service::media::video::message::VIDEO_FOCUS_NATIVE_TRANSIENT);
+        aap_protobuf::service::media::video::message::VideoFocusNotification yield;
+        yield.set_focus(
+            aap_protobuf::service::media::video::message::VIDEO_FOCUS_NATIVE_TRANSIENT);
+        yield.set_unsolicited(true);
+        auto yieldPromise = aasdk::channel::SendPromise::defer(*strand_);
+        yieldPromise->then([]() {}, [](const auto&) {});
+        videoChannel_->sendVideoFocusIndication(yield, std::move(yieldPromise));
+
+        // 2. Reacquire: announce projected focus again. The PROJECTED-after-yield
+        //    transition is what prompts the phone to emit a fresh IDR.
+        currentVideoFocus_.store(
+            aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
+        aap_protobuf::service::media::video::message::VideoFocusNotification reacquire;
+        reacquire.set_focus(
+            aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
+        reacquire.set_unsolicited(true);
+        auto reacquirePromise = aasdk::channel::SendPromise::defer(*strand_);
+        reacquirePromise->then([]() {}, [](const auto&) {});
+        videoChannel_->sendVideoFocusIndication(reacquire, std::move(reacquirePromise));
+    });
+}
+
 // ============================================================================
 // Typed vehicle sensor methods Ã¢â‚¬â€ each builds SensorBatch and sends
 // ============================================================================

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -118,6 +118,14 @@ public:
     /** Request a video keyframe (IDR). */
     void requestKeyframe();
 
+    /**
+     * Force a fresh IDR via a real focus transition (NATIVE_TRANSIENT ->
+     * PROJECTED) instead of re-asserting PROJECTED. Use when the phone may
+     * already think we hold projected focus and would ignore a same-state
+     * keyframe request (issue #35).
+     */
+    void requestKeyframeForceFocus();
+
     // Typed vehicle sensor methods — each builds a SensorBatch and sends
     void sendSpeedSensor(int speedMmPerS);
     void sendGearSensor(int gear);

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -1598,6 +1598,10 @@ class SessionManager(
         aasdkSession?.requestKeyframe()
     }
 
+    suspend fun requestKeyframeForceFocus() {
+        aasdkSession?.requestKeyframeForceFocus()
+    }
+
     private suspend fun syncLocalPreferences() {
         val ctx = context ?: return
         try {
@@ -1693,13 +1697,26 @@ class SessionManager(
                 var attempt = 0
                 while (decoder.needsKeyframe.value) {
                     attempt++
-                    requestKeyframe()
-                    if (attempt == 1) {
-                        OalLog.i(TAG, "Keyframe re-request #$attempt")
+                    // Issue #35: a plain keyframe re-request re-asserts PROJECTED
+                    // focus, which the phone ignores when it already thinks we hold
+                    // it (post phone-call / GM-UI takeover) — so it emits no IDR and
+                    // video stays frozen until the next natural GOP (~2 min). Use the
+                    // focus-bounce variant (NATIVE_TRANSIENT -> PROJECTED, a real
+                    // transition) on the first attempt and periodically thereafter to
+                    // actually pull a fresh IDR forward; plain re-requests in between.
+                    val useForceFocus = attempt == 1 || attempt % 4 == 0
+                    if (useForceFocus) {
+                        requestKeyframeForceFocus()
                     } else {
-                        OalLog.w(TAG, "Keyframe re-request #$attempt (still waiting)")
+                        requestKeyframe()
+                    }
+                    if (attempt == 1) {
+                        OalLog.i(TAG, "Keyframe re-request #$attempt (focus bounce)")
+                    } else {
+                        val mode = if (useForceFocus) " (focus bounce)" else ""
+                        OalLog.w(TAG, "Keyframe re-request #$attempt (still waiting)$mode")
                         _remoteDiagnostics?.log(DiagnosticLevel.WARN, "video",
-                            "Keyframe re-request #$attempt")
+                            "Keyframe re-request #$attempt$mode")
                     }
                     delay(2000)
                 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
@@ -124,5 +124,8 @@ object AasdkNative {
     external fun nativeRequestKeyframe()
 
     @JvmStatic
+    external fun nativeRequestKeyframeForceFocus()
+
+    @JvmStatic
     external fun nativeIsStreaming(): Boolean
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -303,6 +303,15 @@ class AasdkSession(
         AasdkNative.nativeRequestKeyframe()
     }
 
+    /**
+     * Force a fresh IDR via a real video-focus transition (issue #35). Use when a
+     * plain [requestKeyframe] may be ignored because the phone already believes we
+     * hold projected focus (e.g. after a phone-call / GM-UI takeover).
+     */
+    fun requestKeyframeForceFocus() {
+        AasdkNative.nativeRequestKeyframeForceFocus()
+    }
+
     // -- AasdkSessionCallback (called from native thread → dispatch to flows) --
 
     override fun onSessionStarted() {

--- a/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
+++ b/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
@@ -43,6 +43,15 @@ class MediaCodecDecoder(
         // rendering. Gives the decoder time to accumulate picture content from P-frames
         // so the first visible frame is mostly complete rather than green.
         private const val SEED_WARMUP_MS = 2500L
+        // Freeze cap (issue #35): after a cached-IDR replay we set awaitingFreshIdr
+        // and drop P-frames until a FRESH real IDR arrives. If the keyframe
+        // re-request doesn't pull one forward (e.g. the phone ignores a same-state
+        // VideoFocusIndication after a phone-call/GM-UI takeover), that wait can be
+        // up to the phone's natural GOP (~2 min) — a 2-minute frozen screen. Cap it:
+        // once awaitingFreshIdr has held this long, stop dropping and feed P-frames
+        // anyway. The P-chain references content we missed, so expect a few hundred
+        // ms of blockiness as it rebuilds — far better than a multi-minute freeze.
+        private const val AWAITING_FRESH_IDR_CAP_MS = 3000L
     }
 
     private val _decoderState = MutableStateFlow(DecoderState.IDLE)
@@ -143,6 +152,9 @@ class MediaCodecDecoder(
     // Instead, drop all P-frames until a fresh real IDR arrives from the
     // phone, showing a frozen-but-clean cached frame in the meantime.
     @Volatile private var awaitingFreshIdr = false
+    // Wall-clock (elapsedRealtime) when awaitingFreshIdr was last raised, so
+    // handleRegularFrame can cap the P-frame-drop window (issue #35). 0 = not set.
+    @Volatile private var awaitingFreshIdrSinceMs = 0L
     // Skip first few frames after codec init to avoid green hue from resolution
     // transition. When codec is configured at 1920x1080 but video is 2560x1440,
     // the first frames decode with wrong color plane alignment until the codec
@@ -178,6 +190,7 @@ class MediaCodecDecoder(
                     // arrives — shows a frozen-but-clean cached frame
                     // instead of progressively-corrupting blocky garbage.
                     awaitingFreshIdr = true
+                    awaitingFreshIdrSinceMs = System.currentTimeMillis()
                     _needsKeyframe = false
                     _needsKeyframeFlow.value = true
                 } else {
@@ -261,6 +274,7 @@ class MediaCodecDecoder(
         _decoderState.value = DecoderState.IDLE
         receivedIdr = false
         awaitingFreshIdr = false
+        awaitingFreshIdrSinceMs = 0L
         _needsKeyframe = true
         _needsKeyframeFlow.value = true
         codecConfigData?.let { config ->
@@ -313,6 +327,7 @@ class MediaCodecDecoder(
         codecConfigData = frame.data.copyOf()
         receivedIdr = false
         awaitingFreshIdr = false
+        awaitingFreshIdrSinceMs = 0L
         _needsKeyframe = true  // Request IDR after codec reconfigure
         _needsKeyframeFlow.value = true
 
@@ -406,6 +421,7 @@ class MediaCodecDecoder(
             Log.i(TAG, "Fresh IDR arrived — clearing awaitingFreshIdr, P-frames will flow")
             DiagnosticLog.i("video", "Fresh IDR cleared awaitingFreshIdr")
             awaitingFreshIdr = false
+            awaitingFreshIdrSinceMs = 0L
         }
         // Always keep the latest IDR cached — if the surface is destroyed (user
         // navigates away), we can replay it instantly when the surface returns
@@ -435,9 +451,27 @@ class MediaCodecDecoder(
             // we never decoded (missed during backgrounding). Feeding them
             // would produce progressively-worse blockiness. Drop until a
             // fresh real IDR from the phone re-anchors the reference chain.
-            framesDropped.incrementAndGet()
-            updateDropStats()
-            return
+            //
+            // BUT cap the wait (issue #35): if the fresh IDR never comes (e.g.
+            // the phone ignores our same-state keyframe re-request after a
+            // phone-call / GM-UI takeover), dropping forever leaves the screen
+            // frozen until the phone's next natural GOP IDR (~2 min). Once the
+            // gate has held longer than AWAITING_FRESH_IDR_CAP_MS, give up
+            // waiting and feed P-frames anyway — accept a few hundred ms of
+            // blockiness as the reference chain rebuilds over a multi-minute freeze.
+            val heldMs = if (awaitingFreshIdrSinceMs > 0)
+                System.currentTimeMillis() - awaitingFreshIdrSinceMs else 0L
+            if (heldMs >= AWAITING_FRESH_IDR_CAP_MS) {
+                Log.w(TAG, "awaitingFreshIdr held ${heldMs}ms (cap ${AWAITING_FRESH_IDR_CAP_MS}ms) — no fresh IDR arrived, feeding P-frames anyway")
+                DiagnosticLog.w("video", "Fresh-IDR wait capped at ${heldMs}ms — resuming P-frames (expect brief blockiness)")
+                awaitingFreshIdr = false
+                awaitingFreshIdrSinceMs = 0L
+                // fall through to normal P-frame handling below
+            } else {
+                framesDropped.incrementAndGet()
+                updateDropStats()
+                return
+            }
         }
         if (codec == null) {
             framesDropped.incrementAndGet()
@@ -857,6 +891,7 @@ class MediaCodecDecoder(
             receivedIdr = false
             renderingEnabled = false
             awaitingFreshIdr = false
+            awaitingFreshIdrSinceMs = 0L
             seedIdrTimeMs = 0
             lastQueuedPtsMs = -1
             consecutiveDrops = 0


### PR DESCRIPTION
## What

Fixes the post-call (GM-UI takeover) video freeze in #35. A phone call backgrounds the projection Activity; on hang-up the projection returns but video is frozen on one stale frame for up to ~2 min before self-recovering. Root cause (full evidence in #35): on resume OAL drops P-frames until a *fresh* IDR arrives, but its keyframe re-request only re-asserts `VIDEO_FOCUS_PROJECTED` — a no-op state the phone ignores, so no out-of-cycle IDR is sent and recovery waits for the phone's next natural ~2-min GOP IDR.

This is a **draft**: fix A changes on-wire AA focus behavior and needs a real bench/drive confirm that the GM phone honors the mid-session focus transition with an IDR. Fix C is the pure-defensive safety net and is independently correct.

## Two changes

**A — focus-bounce keyframe request (addresses root cause).** New native path `requestKeyframeForceFocus()` that sends a real focus transition `VIDEO_FOCUS_NATIVE_TRANSIENT` -> `VIDEO_FOCUS_PROJECTED` instead of re-asserting PROJECTED. A genuine yield-then-reacquire is what makes the phone emit a fresh IDR (same transition that produces the IDR on initial projection). `NATIVE_TRANSIENT` (not plain `NATIVE`) is deliberate — `onVideoFocusRequest()` only escalates plain `NATIVE` to a user-Exit teardown. `watchKeyframeNeeds()` now uses the bounce on the first re-request of each episode and every 4th attempt after, plain re-requests in between.

Wiring: `jni_session.cpp` / `jni_session.h` / `aasdk_jni.cpp` (new JNI) -> `AasdkNative.kt` -> `AasdkSession.kt` -> `SessionManager.kt`.

**C — car-side freeze cap (defensive self-heal).** `MediaCodecDecoder` now timestamps when `awaitingFreshIdr` is raised; if the gate holds longer than `AWAITING_FRESH_IDR_CAP_MS` (3s) with no fresh IDR, it stops dropping P-frames and feeds them anyway. Trades a few hundred ms of blockiness as the reference chain rebuilds for capping the freeze at ~3s instead of ~2min. Guarantees recovery even if a given phone ignores the focus transition from A.

## Why both

A fixes the cause (most drives recover near-instantly). C is the backstop so a phone that ignores the transition still never produces a multi-minute freeze. They are independent and additive.

## Test

- `./gradlew :app:assembleDebug` BUILD SUCCESSFUL (native + Kotlin; only pre-existing protobuf deprecation warnings).
- Field validation pending: place/receive a call while projecting + navigating, hang up after ~30s, confirm the projection unfreezes within a few seconds (look for `Keyframe re-request #1 (focus bounce)`, then `IDR received` / `Fresh IDR cleared awaitingFreshIdr`; or the C fallback `Fresh-IDR wait capped at <N>ms`).

## Notes

- Does not touch the transport layer or #34's mid-session stall (a distinct mode in the same logging session).
- Tunables: `AWAITING_FRESH_IDR_CAP_MS` (3000) and the bounce cadence (`attempt % 4`) are conservative starting points.
