### PR TITLE
feat(session): video-stall watchdog forces reconnect on wedged AA stream (#34)

### DIFF
--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -67,6 +67,18 @@ class SessionManager(
     companion object {
         private const val TAG = "SessionManager"
 
+        /**
+         * Video-stall watchdog (issue #34). If no inbound AA video frame arrives
+         * for this long while we're STREAMING and foreground, the AA video
+         * channel has wedged (native layer blocked on a dead flow, never fires
+         * onSessionStopped) — force a reconnect. Generous enough not to trip on
+         * brief network hiccups or the phone's periodic-IDR gap (~2-2.5 min
+         * between keyframes, but P-frames flow continuously in between, so a
+         * healthy stream never goes this long without ANY frame).
+         */
+        private const val VIDEO_STALL_THRESHOLD_MS = 8_000L
+        private const val VIDEO_STALL_POLL_MS = 1_000L
+
         // Activity-sourced UI-mode snapshot that can be published before
         // SessionManager exists (ViewModel lazy creation path).
         @Volatile
@@ -363,6 +375,15 @@ class SessionManager(
     private var decoderWatchJob: Job? = null
     private var keyframeWatchJob: Job? = null
     private var callStateJob: Job? = null
+    private var videoStallWatchJob: Job? = null
+
+    /**
+     * True while the app is intentionally idle (Activity paused / screen off /
+     * backgrounded to AAOS home). The video-stall watchdog must NOT fire a
+     * reconnect during these windows — video legitimately stops when we're not
+     * foreground. Set in [markGoingIdle], cleared on the next wake/start.
+     */
+    @Volatile private var isGoingIdle = false
 
     // Track last known active time for sleep/wake detection.
     // Single source of truth, updated on:
@@ -687,6 +708,10 @@ class SessionManager(
             // Watch call state for mic purpose routing
             callStateJob?.cancel()
             callStateJob = launch { watchCallState() }
+
+            // Watch for a wedged AA video channel (issue #34)
+            videoStallWatchJob?.cancel()
+            videoStallWatchJob = launch { watchVideoStall() }
 
             // Start direct mode session
             startSession(directTransport, hotspotSsid, hotspotPassword,
@@ -1095,6 +1120,8 @@ class SessionManager(
         keyframeWatchJob = null
         callStateJob?.cancel()
         callStateJob = null
+        videoStallWatchJob?.cancel()
+        videoStallWatchJob = null
         aasdkSession?.stop()
         aasdkSession = null
         stopDirectLocationForwarding()
@@ -1220,6 +1247,7 @@ class SessionManager(
                     decoderWatchJob?.cancelAndJoin()
                     keyframeWatchJob?.cancelAndJoin()
                     callStateJob?.cancelAndJoin()
+                    videoStallWatchJob?.cancelAndJoin()
                 } catch (_: Exception) {}
                 doReconnectAfterCancel(
                     codecPreference, micSourcePreference, scalingMode, directTransport,
@@ -1296,6 +1324,7 @@ class SessionManager(
             decoderWatchJob = launch { watchDecoderState() }
             keyframeWatchJob = launch { watchKeyframeNeeds() }
             callStateJob = launch { watchCallState() }
+            videoStallWatchJob = launch { watchVideoStall() }
 
             startSession(directTransport, hotspotSsid, hotspotPassword,
                 videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
@@ -1379,6 +1408,7 @@ class SessionManager(
             OalLog.d(TAG, "Wake dedup (reason=$reason within ${WAKE_DEDUPE_MS}ms)")
             return
         }
+        isGoingIdle = false
         val gap = now - lastActiveTimestamp
         lastWakeHandledAtMs = now
         lastActiveTimestamp = now
@@ -1415,6 +1445,7 @@ class SessionManager(
      * during steady streaming).
      */
     fun markGoingIdle(reason: String) {
+        isGoingIdle = true
         lastActiveTimestamp = SystemClock.elapsedRealtime()
         OalLog.i(TAG, "Going idle: $reason")
         DiagnosticLog.i("transport", "Going idle: $reason")
@@ -1703,6 +1734,51 @@ class SessionManager(
                     }
                     delay(2000)
                 }
+            }
+        }
+    }
+
+    /**
+     * Video-stall watchdog (issue #34). The AA video channel can wedge mid-drive
+     * — frames stop arriving while the TCP socket stays alive and other channels
+     * (nav) keep flowing. The native aasdk layer stays blocked on the dead flow
+     * and never calls onSessionStopped, so the existing auto-reconnect (which is
+     * wired only to onSessionStopped) never triggers and the screen stays frozen
+     * indefinitely while the app UI remains responsive.
+     *
+     * This polls the last-video-frame timestamp and, if it goes stale while we're
+     * actively STREAMING and foreground, forces a reconnect via
+     * AasdkSession.forceReconnect() — which routes through the normal teardown +
+     * restart. The phone is left advertising on a stalled link, so the restart
+     * reconnects within ~1s.
+     *
+     * Guards against false trips:
+     *  - only while sessionState == STREAMING (not during connect/handshake)
+     *  - only when not intentionally idle (backgrounded / screen-off / paused),
+     *    where video legitimately stops
+     *  - only after at least one frame has been seen (lastVideoFrameMs != 0)
+     *  - re-arms the baseline after each forced reconnect so we don't loop
+     */
+    private suspend fun watchVideoStall() {
+        // Wait for a session to exist.
+        while (aasdkSession == null) { delay(VIDEO_STALL_POLL_MS) }
+        val session = aasdkSession ?: return
+        while (true) {
+            delay(VIDEO_STALL_POLL_MS)
+            if (_sessionState.value != SessionState.STREAMING) continue
+            if (isGoingIdle) continue
+            val last = session.lastVideoFrameMs
+            if (last == 0L) continue // no frame yet this session
+            val staleFor = SystemClock.elapsedRealtime() - last
+            if (staleFor >= VIDEO_STALL_THRESHOLD_MS) {
+                OalLog.w(TAG, "Video stall detected: no frame for ${staleFor}ms while STREAMING — forcing reconnect")
+                DiagnosticLog.w("video", "Video stall ${staleFor}ms — forcing reconnect")
+                _remoteDiagnostics?.log(DiagnosticLevel.WARN, "video",
+                    "Video stall ${staleFor}ms — forcing reconnect")
+                aasdkSession?.forceReconnect("video stall (${staleFor}ms no frame)")
+                // Back off a full threshold so the freshly-restarted session has
+                // time to deliver its first frame before we evaluate again.
+                delay(VIDEO_STALL_THRESHOLD_MS)
             }
         }
     }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -68,6 +68,17 @@ class AasdkSession(
     private val _connectionState = MutableStateFlow(ConnectionState.DISCONNECTED)
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
+    /**
+     * Wall-clock ([SystemClock.elapsedRealtime]) of the most recent inbound
+     * video frame. The stall watchdog in SessionManager reads this to detect a
+     * wedged AA video channel — frames stop arriving while the TCP socket stays
+     * alive and other channels (nav) keep flowing, so the native layer never
+     * fires onSessionStopped and nothing recovers (issue #34). 0 = no frame yet.
+     */
+    @Volatile
+    var lastVideoFrameMs: Long = 0L
+        private set
+
     private val _videoFrames = MutableSharedFlow<VideoFrame>(extraBufferCapacity = 30)
     val videoFrames: SharedFlow<VideoFrame> = _videoFrames.asSharedFlow()
 
@@ -364,6 +375,7 @@ class AasdkSession(
     }
 
     override fun onVideoFrame(data: ByteArray, timestampUs: Long, width: Int, height: Int, flags: Int) {
+        lastVideoFrameMs = android.os.SystemClock.elapsedRealtime()
         val frame = VideoFrame(
             width = width,
             height = height,


### PR DESCRIPTION
Fixes #34.

## Problem
The AA video channel can wedge mid-drive: video frames stop arriving while the TCP socket stays alive and other channels (nav) keep flowing. The native aasdk layer stays blocked on the dead flow and **never calls `onSessionStopped`** — and the existing auto-reconnect is wired *only* to `onSessionStopped` (`AasdkSession.kt:577-578`). So nothing recovers: the screen stays frozen indefinitely while the app UI stays fully responsive.

Captured live 2026-06-23 (both sides, always-log):
- 17:00:43 last video IDR; nav keeps flowing until 17:02:29.
- Car log shows **zero `onError`, zero `onSessionStopped`** across the entire freeze — session state still `CONNECTED`.
- Maintainer confirmed: OpenAutoLink UI responsive (upload/settings work), only the AA stream frozen; phone sat in "Advertising" (healthy, waiting); car never reconnected.

Already-documented blind spot (`TcpConnector.kt:36`): *"when the phone is unreachable at the TCP layer we never get an onSessionStopped to count from."* Same gap applies to a data stall on a live socket.

## Fix — session-level video-stall watchdog
- `AasdkSession.onVideoFrame` bumps `lastVideoFrameMs` (elapsedRealtime).
- `SessionManager.watchVideoStall()` polls every 1s; if no video frame for `VIDEO_STALL_THRESHOLD_MS` (8s) while `STREAMING` and foreground, calls `AasdkSession.forceReconnect()` — which routes through the normal teardown + restart. The phone is left advertising on the stalled link, so it reconnects in ~1s.

## Guards against false trips
- only while `sessionState == STREAMING` (not during connect/handshake)
- only when **not** intentionally idle — new `isGoingIdle` flag, set in `markGoingIdle` (Activity pause / screen-off / background) and cleared on wake, where video legitimately stops
- only after at least one frame has been seen this session
- backs off a full threshold after each forced reconnect so it can't loop
- watcher launched at both the session-start and reconnect sites; cancelled in both teardown paths

Why 8s: healthy streams deliver P-frames continuously (keyframes every ~2-2.5 min, but frames never stop for 8s), so the threshold is comfortably clear of normal cadence while still recovering fast.

## Scope / safety
- 2 files, +88/-0, no new deps. Reuses the existing `forceReconnect` lever (same one sleep/wake uses).
- Verified: `:app:compileDebugKotlin` BUILD SUCCESSFUL.

## Honest caveat
This recovers from the stall; it does not address *why the phone's video flow stalls upstream* (the car can't see that). The watchdog is correct regardless of the upstream trigger — it turns an indefinite frozen screen into a ~9-10s auto-recovery.
