### PR TITLE
fix(session,video): Error-30 backoff escalation + codec-release race (#30, #38)

### DIFF
--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -46,6 +46,19 @@ class AasdkSession(
     companion object {
         private const val TAG = "AasdkSession"
 
+        /** Minimum dwell a native session must stay up to count as a genuine
+         *  connection (vs. an Error-30 flap). A session that dies sooner does
+         *  NOT reset consecutiveReconnectFailures, so backoff keeps escalating
+         *  (issue #30). 20s comfortably exceeds the few-seconds flap window seen
+         *  in the storm logs while staying well under any normal drive segment. */
+        private const val STABLE_DWELL_MS = 20_000L
+
+        /** Backoff floor for protocol/handshake errors (AASDK Error 30 — phone
+         *  still holds the old SSL session). Higher than the generic 3s base
+         *  because a 5s re-dial frequently beat the phone's own teardown and
+         *  re-provoked the rejection, sustaining the storm (issue #30). */
+        private const val PROTOCOL_ERROR_BASE_MS = 8_000L
+
         /** Process-wide native onError coalescer.
          *
          *  Lives in the companion object (not on instances) so it survives
@@ -123,6 +136,16 @@ class AasdkSession(
     /** True when the last failure was an AA protocol/handshake error (Error 30). */
     @Volatile
     private var lastFailureWasProtocolError = false
+
+    /** [SystemClock.elapsedRealtime] when the current native session last
+     *  started, or 0 when no session is up. Used to measure session dwell so a
+     *  *flapping* session (dies seconds after start) does NOT reset the
+     *  reconnect-failure counter — only a session that stayed up past
+     *  [STABLE_DWELL_MS] is treated as a genuine recovery (issue #30). Without
+     *  this gate every flap re-entered backoff as "retry #1" at the 5s floor and
+     *  the exponential ramp never engaged, re-provoking Error 30 in a storm. */
+    @Volatile
+    private var sessionStartedAtMs: Long = 0L
 
     private var transportPipe: AasdkTransportPipe? = null
 
@@ -327,8 +350,12 @@ class AasdkSession(
 
     override fun onSessionStarted() {
         OalLog.i(TAG, "AA session started (native)")
-        consecutiveReconnectFailures = 0
-        _reconnectAttempt.value = 0
+        // NOTE: do NOT reset consecutiveReconnectFailures here. A session that
+        // dies seconds after starting (Error-30 flap) would otherwise re-enter
+        // backoff as "retry #1" forever and never escalate (issue #30). The
+        // counter is reset in onSessionStopped() only if THIS session stayed up
+        // past STABLE_DWELL_MS, i.e. it was a genuine recovery, not a flap.
+        sessionStartedAtMs = android.os.SystemClock.elapsedRealtime()
         lastFailureWasProtocolError = false
         scope.launch {
             _connectionState.value = ConnectionState.CONNECTED
@@ -359,12 +386,28 @@ class AasdkSession(
             // phone disconnect). Restart the transport connector after a delay so it
             // retries connecting once WiFi comes back.
             if (!explicitStop) {
+                // Dwell gate (issue #30): if the session that just died had been up
+                // longer than STABLE_DWELL_MS it was a genuine connection, so this
+                // is a FRESH failure series — reset the counter. If it died fast
+                // (flap), keep accumulating so backoff escalates toward the 30s cap
+                // instead of pinning at "retry #1" and re-provoking Error 30.
+                val dwellMs = if (sessionStartedAtMs > 0L)
+                    android.os.SystemClock.elapsedRealtime() - sessionStartedAtMs
+                else
+                    Long.MAX_VALUE
+                if (dwellMs >= STABLE_DWELL_MS) {
+                    consecutiveReconnectFailures = 0
+                }
+                sessionStartedAtMs = 0L
+
                 consecutiveReconnectFailures++
                 _reconnectAttempt.value = consecutiveReconnectFailures
 
                 // Exponential backoff: 3s base, longer if protocol error (phone
-                // needs time to tear down old SSL session). Cap at 30s.
-                val baseDelayMs = if (lastFailureWasProtocolError) 5000L else 3000L
+                // needs time to tear down old SSL session). Cap at 30s. Error 30
+                // (stale SSL session) gets a higher floor — a 5s re-dial often
+                // beat the phone's own teardown and re-provoked the rejection.
+                val baseDelayMs = if (lastFailureWasProtocolError) PROTOCOL_ERROR_BASE_MS else 3000L
                 val backoffMs = (baseDelayMs * (1L shl (consecutiveReconnectFailures - 1).coerceAtMost(3)))
                     .coerceAtMost(30_000L)
                 OalLog.i(TAG, "Session died unexpectedly — retry #$consecutiveReconnectFailures in ${backoffMs}ms" +

--- a/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
+++ b/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
@@ -742,7 +742,7 @@ class MediaCodecDecoder(
      * - Stale P-frames (PTS not advancing) are dropped immediately
      */
     private fun queueFrame(frame: VideoFrame) {
-        val mc = codec ?: return
+        if (codec == null) return
 
         // Drop stale P-frames (PTS went backwards — reordered or duplicate)
         if (!frame.isKeyframe && lastQueuedPtsMs >= 0 && frame.ptsMs > 0 && frame.ptsMs < lastQueuedPtsMs) {
@@ -761,41 +761,50 @@ class MediaCodecDecoder(
             INPUT_TIMEOUT_US
         }
 
-        try {
-            val inputIndex = mc.dequeueInputBuffer(timeout)
-            if (inputIndex < 0) {
-                framesDropped.incrementAndGet()
-                consecutiveDrops++
-                if (consecutiveDrops == 5 || (consecutiveDrops > 5 && consecutiveDrops % 30 == 0)) {
-                    Log.w(TAG, "Decoder behind: $consecutiveDrops consecutive frame drops")
+        // Hold codecReleaseLock across the native input calls. queueFrame runs on
+        // the frame-input thread while releaseCodec() (surface detach / teardown)
+        // can release the same MediaCodec instance concurrently — a check-then-act
+        // race that threw IllegalStateException from native_dequeueInputBuffer and
+        // left the surface abandoned (~72s black until re-attach, issue #38).
+        // Re-read codec under the lock and bail if release won.
+        synchronized(codecReleaseLock) {
+            val mc = codec ?: return
+            try {
+                val inputIndex = mc.dequeueInputBuffer(timeout)
+                if (inputIndex < 0) {
+                    framesDropped.incrementAndGet()
+                    consecutiveDrops++
+                    if (consecutiveDrops == 5 || (consecutiveDrops > 5 && consecutiveDrops % 30 == 0)) {
+                        Log.w(TAG, "Decoder behind: $consecutiveDrops consecutive frame drops")
+                    }
+                    return
                 }
-                return
-            }
 
-            val inputBuffer = mc.getInputBuffer(inputIndex) ?: return
-            if (frame.data.size > inputBuffer.capacity()) {
-                Log.w(TAG, "Frame too large: ${frame.data.size} > ${inputBuffer.capacity()}")
-                mc.queueInputBuffer(inputIndex, 0, 0, 0, 0)
-                framesDropped.incrementAndGet()
-                return
-            }
+                val inputBuffer = mc.getInputBuffer(inputIndex) ?: return
+                if (frame.data.size > inputBuffer.capacity()) {
+                    Log.w(TAG, "Frame too large: ${frame.data.size} > ${inputBuffer.capacity()}")
+                    mc.queueInputBuffer(inputIndex, 0, 0, 0, 0)
+                    framesDropped.incrementAndGet()
+                    return
+                }
 
-            inputBuffer.clear()
-            inputBuffer.put(frame.data)
+                inputBuffer.clear()
+                inputBuffer.put(frame.data)
 
-            val flags = if (frame.isKeyframe) MediaCodec.BUFFER_FLAG_KEY_FRAME else 0
-            mc.queueInputBuffer(inputIndex, 0, frame.data.size, frame.ptsMs * 1000, flags)
-            lastQueuedPtsMs = frame.ptsMs
-            consecutiveDrops = 0
-        } catch (e: MediaCodec.CodecException) {
-            Log.e(TAG, "Codec error queuing frame", e)
-            DiagnosticLog.e("video", "Codec error queuing frame: ${e.message}, recoverable=${e.isRecoverable}")
-            if (!e.isRecoverable) {
-                _decoderState.value = DecoderState.ERROR
-                _needsKeyframe = true
+                val flags = if (frame.isKeyframe) MediaCodec.BUFFER_FLAG_KEY_FRAME else 0
+                mc.queueInputBuffer(inputIndex, 0, frame.data.size, frame.ptsMs * 1000, flags)
+                lastQueuedPtsMs = frame.ptsMs
+                consecutiveDrops = 0
+            } catch (e: MediaCodec.CodecException) {
+                Log.e(TAG, "Codec error queuing frame", e)
+                DiagnosticLog.e("video", "Codec error queuing frame: ${e.message}, recoverable=${e.isRecoverable}")
+                if (!e.isRecoverable) {
+                    _decoderState.value = DecoderState.ERROR
+                    _needsKeyframe = true
+                }
+            } catch (e: IllegalStateException) {
+                Log.w(TAG, "Codec in bad state", e)
             }
-        } catch (e: IllegalStateException) {
-            Log.w(TAG, "Codec in bad state", e)
         }
     }
 


### PR DESCRIPTION
## Two car-side reliability fixes (batched)

### Fixes #30 — AASDK Error 30 reconnect-storm self-escalation
`onSessionStarted()` reset `consecutiveReconnectFailures = 0` on **every** native
start, so a session that died seconds later (Error-30 flap) always re-entered
backoff as "retry #1" at the floor and the exponential ramp never engaged —
re-dialling while the phone still held the stale SSL session, sustaining the storm.

**Fix:** dwell-gate the reset. Stamp `sessionStartedAtMs` on start; in
`onSessionStopped()` only reset the counter if the just-ended session was up
longer than `STABLE_DWELL_MS` (20s). A flap keeps accumulating so backoff
escalates toward the 30s cap; a genuine long session still starts a fresh series.
Also raised the protocol-error (Error 30) backoff floor 5s -> 8s
(`PROTOCOL_ERROR_BASE_MS`) so the re-dial doesn't beat the phone's own SSL teardown.
`_reconnectAttempt` still tracks the real count, so picker escalation is unaffected.

### Fixes #38 — codec-release race -> ~72s black screen on activity_pause
`queueFrame()` read `codec` and issued native `dequeueInputBuffer`/`queueInputBuffer`
calls **outside** `codecReleaseLock`, while `releaseCodec()` (surface detach /
teardown) released the same instance under the lock — a check-then-act race that
threw `IllegalStateException` from `native_dequeueInputBuffer` and abandoned the
surface (~72s black until re-attach).

**Fix:** run the native input block inside `synchronized(codecReleaseLock)`,
re-reading `codec` under the lock and bailing if release won. The PTS pre-check
stays outside the lock (doesn't touch the codec); lock-hold is bounded by the
16ms `INPUT_TIMEOUT_US`.

### Validation
- `:app:compileReleaseKotlin` BUILD SUCCESSFUL (temurin-17).
- Both fixes are localization-HIGH (code-anchored to the exact race / reset site).
- On-device confirm still pending: a real Error-30 drive (escalating backoff in the
  log instead of looping "retry #1") and an activity_pause backgrounding (no
  IllegalStateException, no 72s gap).
