### PR TITLE
fix(companion): CancellationException not ERROR on teardown (#39)

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -124,6 +124,12 @@ class AaProxy(
                 val job1 = launch { pump(aaIn, carOut, "AA->Car") }
                 val job2 = launch { pump(carIn, aaOut, "Car->AA") }
                 joinAll(job1, job2)
+            } catch (e: CancellationException) {
+                // Intentional teardown (stop() -> scope.cancel()). Cancellation is
+                // normal control flow, not an application error — rethrow so
+                // structured concurrency propagates it and it stays out of the
+                // ERROR stream (which the triage pipeline treats as actionable).
+                throw e
             } catch (e: Exception) {
                 CompanionLog.e(TAG, "Bridge error: ${e.message}")
             } finally {
@@ -169,6 +175,8 @@ class AaProxy(
                     output.write(buffer, 0, read)
                     output.flush()
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 CompanionLog.d(TAG, "$name error: ${e.message}")
             }


### PR DESCRIPTION
## Fixes #39 — CancellationException logged as ERROR on every intentional teardown

`AaProxy.launchBridge()` caught the `CancellationException` thrown by `joinAll`
when `stop()` -> `scope.cancel()` ran, via a broad `catch (e: Exception)`, and
logged it at ERROR (`Bridge error: Job was cancelled`). Every intentional teardown
therefore emitted a false-positive ERROR that the triage pipeline flags as
actionable, and swallowing `CancellationException` is a structured-concurrency
anti-pattern (cancellation must propagate).

**Fix:** special-case `catch (e: CancellationException) { throw e }` before the
generic catch in both `launchBridge()` and `pump()`. Intentional teardown stops
emitting ERROR noise; only genuine bridge failures reach the ERROR stream.
Cosmetic + correctness, no functional change to the bridge.

### Validation
- `:companion:compileReleaseKotlin` BUILD SUCCESSFUL (temurin-17).
- `CancellationException` already imported (`kotlinx.coroutines.CancellationException`).
