### PR TITLE
fix: launch-crash NPE (#44) + watchdog false-fire (#43) + roundabout cluster drop (#42)

### DIFF
--- a/app/src/main/java/com/openautolink/app/cluster/OalClusterSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/OalClusterSession.kt
@@ -289,10 +289,32 @@ internal fun buildManeuver(maneuver: ManeuverState, carContext: CarContext): Man
     // Path 2: VectorDrawable fallback
     val type = mapManeuverTypeToCarApp(maneuver.type)
     val builder = Maneuver.Builder(type)
+    // Roundabout maneuver types REQUIRE an exit number — androidx
+    // Maneuver.Builder.build() throws IllegalArgumentException
+    // ("Maneuver missing roundaboutExitNumber") for any TYPE_ROUNDABOUT_*
+    // without one, which dropped the whole cluster Trip on every roundabout
+    // and stopped nav guidance updating (issue #42). The exit number is
+    // already carried on ManeuverState; default to 1 if the phone didn't
+    // supply it (better a slightly-wrong exit count than a dropped Trip).
+    if (isRoundaboutManeuverType(type)) {
+        builder.setRoundaboutExitNumber(
+            (maneuver.roundaboutExitNumber ?: 1).coerceAtLeast(1)
+        )
+    }
     val resId = ManeuverIconRenderer.drawableForManeuver(maneuver.type)
     builder.setIcon(CarIcon.Builder(IconCompat.createWithResource(carContext, resId)).build())
     return builder.build()
 }
+
+/** True for the androidx Maneuver.TYPE_ROUNDABOUT_* constants that mandate an
+ *  exit number on build(). Kept in sync with the roundabout cases in
+ *  [mapManeuverTypeToCarApp]. */
+internal fun isRoundaboutManeuverType(type: Int): Boolean = type == Maneuver.TYPE_ROUNDABOUT_ENTER_CCW ||
+    type == Maneuver.TYPE_ROUNDABOUT_EXIT_CCW ||
+    type == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CW ||
+    type == Maneuver.TYPE_ROUNDABOUT_ENTER_AND_EXIT_CCW ||
+    type == Maneuver.TYPE_ROUNDABOUT_ENTER_CW ||
+    type == Maneuver.TYPE_ROUNDABOUT_EXIT_CW
 
 internal fun mapManeuverTypeToCarApp(type: ManeuverType): Int = when (type) {
     ManeuverType.DEPART -> Maneuver.TYPE_DEPART

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -83,10 +83,15 @@ class AasdkSession(
 
     /**
      * Wall-clock ([SystemClock.elapsedRealtime]) of the most recent inbound
-     * video frame. The stall watchdog in SessionManager reads this to detect a
-     * wedged AA video channel — frames stop arriving while the TCP socket stays
-     * alive and other channels (nav) keep flowing, so the native layer never
-     * fires onSessionStopped and nothing recovers (issue #34). 0 = no frame yet.
+     * video frame, or 0 when no frame has arrived in the CURRENT session. The
+     * stall watchdog in SessionManager reads this to detect a wedged AA video
+     * channel — frames stop arriving while the TCP socket stays alive and other
+     * channels (nav) keep flowing, so the native layer never fires
+     * onSessionStopped and nothing recovers (issue #34). Reset to 0 in
+     * [onSessionStarted] so a freshly-(re)started session is never measured
+     * against the PREVIOUS session's last-frame time — that stale baseline made
+     * the watchdog false-fire ~instantly on resume and tear down a healthy
+     * session before its first frame (issue #43).
      */
     @Volatile
     var lastVideoFrameMs: Long = 0L
@@ -357,6 +362,11 @@ class AasdkSession(
         // past STABLE_DWELL_MS, i.e. it was a genuine recovery, not a flap.
         sessionStartedAtMs = android.os.SystemClock.elapsedRealtime()
         lastFailureWasProtocolError = false
+        // Re-baseline the video-stall watchdog for the new session (issue #43).
+        // AasdkSession persists across reconnects, so without this reset the
+        // watchdog would compare the fresh session against the PREVIOUS
+        // session's last-frame time and force-reconnect before frame #1.
+        lastVideoFrameMs = 0L
         scope.launch {
             _connectionState.value = ConnectionState.CONNECTED
             _controlMessages.emit(ControlMessage.PhoneConnected(phoneName = "", phoneType = "wireless"))

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -255,6 +255,14 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         ProjectionUiState()
     )
 
+    // Guards file-logging start/stop. Declared HERE (before the init blocks) and
+    // eagerly initialized — NOT `by lazy` — because the always-log collector in
+    // init { } can touch it synchronously during construction (DataStore emits
+    // its cached value immediately), which raced the lazy delegate's own
+    // initialization and NPE'd in the ViewModel constructor on the main thread
+    // (launch-time crash). Eager + early declaration removes the race.
+    private val fileLogToggleLock = Any()
+
     init {
         registerTransportNetworkCallback()
 
@@ -1714,8 +1722,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     fun toggleStats() {
         _showStats.value = !_showStats.value
     }
-
-    private val fileLogToggleLock: Any by lazy { Any() }
 
     /** True while the auto-start-on-USB pref owns the current file-logger session.
      *  When the user manually stops via the overlay record button we clear this


### PR DESCRIPTION
Fixes #44, fixes #43, fixes #42.

Three car-app fixes from a single slow+crash drive capture (build 0.1.351, maintainer's 06-26 drive).

## #44 — Launch-time crash (main thread): ProjectionViewModel init-order NPE
**The big one — froze the whole UI until relaunch.** The car "Always Log" feature (#32) added an `init {}` collector that calls `synchronized(fileLogToggleLock)`, but `fileLogToggleLock` was declared `by lazy` *below* that init block. DataStore emits `logPersistEnabled` synchronously during construction, so the collector touched the lazy delegate **before it was initialized** → NPE in the ViewModel constructor, on the main thread (deobfuscated against the 0.1.351 mapping to the exact line). Because it's a race on DataStore cache timing, it's intermittent — matching "sometimes slow, eventually crashes."

**Fix:** declare the lock eagerly (`private val fileLogToggleLock = Any()`) above the init blocks. Race removed.

## #43 — Video-stall watchdog (#34) false-fires on session resume
`AasdkSession` persists across reconnects, so `lastVideoFrameMs` survived teardown; a fresh session was measured against the *previous* session's minutes-old timestamp and force-reconnected ~250ms after start, before frame #1 (e.g. watchdog claiming "1,755,793 ms stale" mapping exactly to the prior session's death). Regression in my own #34 watchdog.

**Fix:** reset `lastVideoFrameMs = 0L` in `onSessionStarted()`. The watchdog's existing `last == 0L` guard then correctly waits for the new session's first frame before arming.

## #42 — Cluster Trip dropped on every roundabout
`buildManeuver()` mapped to androidx `Maneuver.TYPE_ROUNDABOUT_*` but never called `setRoundaboutExitNumber()`, so `build()` threw `IllegalArgumentException` (~1/s during navigation, 251× in one drive) and cluster nav guidance stopped updating. The exit number was already carried on `ManeuverState` (populated by `AasdkSession`) but unused.

**Fix:** set the exit number before `build()` for roundabout types (default 1 if the phone didn't supply one — better a slightly-wrong exit count than a dropped Trip).

## Scope / verification
- 3 files, +44/-6, no new deps.
- `:app:compileDebugKotlin` BUILD SUCCESSFUL (also confirms the androidx `setRoundaboutExitNumber` / `TYPE_ROUNDABOUT_*` API names).
- #44 and #43 are regressions from my own recently-shipped features (#32 always-log, #34 watchdog); #42 is pre-existing.
