### PR TITLE
fix(connect): reject IPv6 hosts on IPv4-only hotspot link (#47)

### DIFF
--- a/app/src/main/java/com/openautolink/app/transport/HostUsability.kt
+++ b/app/src/main/java/com/openautolink/app/transport/HostUsability.kt
@@ -1,0 +1,60 @@
+package com.openautolink.app.transport
+
+/**
+ * Pure predicate for "can the hotspot/TCP connect path actually dial this host?"
+ *
+ * Extracted as a dependency-free helper (no Android, no ViewModel) so it can be
+ * unit-tested and reused at every phone-selection site instead of each call
+ * re-deriving its own ad-hoc check.
+ *
+ * ## Why reject ALL IPv6, not just link-local (issue #48)
+ *
+ * OpenAutoLink's local-link model is IPv4-only on every path the *companion*
+ * actually serves on:
+ *
+ *  - the companion's TCP server, identity probe, and UDP discovery all bind
+ *    IPv4 sockets ([com.openautolink.companion] `TcpAdvertiser`),
+ *  - the car-side gateway fallback ([com.openautolink.app.transport.hotspot.TcpConnector.getGatewayIp])
+ *    derives an IPv4 address from DHCP,
+ *  - the /24 subnet sweep ([PhoneDiscovery]) is IPv4-only.
+ *
+ * On a phone-hotspot link the phone's *global* IPv6 address (e.g. a cellular
+ * `2607:…` GUA) is advertised over mDNS but is **not routable over the SoftAP
+ * bridge**, so a `connect()` to it never completes. Worse, in Car-Hotspot mode
+ * the resolved host is fed straight to [TcpConnector.manualIp], which forces the
+ * direct-dial branch and *skips* the IPv4 gateway/sweep fallback — so a single
+ * IPv6 mDNS answer would pin the connector to an unreachable address and retry
+ * it forever (issue #48: 54 dead dials to `2607:…` while the working IPv4
+ * `10.218.15.62` sat unused in the sweep plan, escalating into an AASDK-30
+ * reconnect storm).
+ *
+ * Since the companion never serves on IPv6 on the local link, any IPv6 literal
+ * is unusable for our connect path — link-local (needs a scope id NSD doesn't
+ * surface) *and* global (not bridged on the hotspot). Rejecting all IPv6 makes
+ * selection fall through to the IPv4 address that discovery already surfaces.
+ *
+ * If OAL ever gains a genuinely IPv6-reachable transport, narrow this predicate
+ * rather than re-introducing per-site checks.
+ */
+object HostUsability {
+
+    /**
+     * True when [host] must NOT be handed to the connect path.
+     *
+     * Treats a host as unusable when it is blank or any IPv6 literal. IPv6 is
+     * detected structurally (a literal containing more than one ':' — which an
+     * IPv4 `a.b.c.d` or `a.b.c.d:port` never does) so it needs no InetAddress
+     * allocation and is safe on a raw mDNS-resolved address string. A trailing
+     * `:port` on an IPv4 host (one colon) is preserved as usable.
+     */
+    fun isUnusable(host: String?): Boolean {
+        if (host.isNullOrBlank()) return true
+        // IPv6 literals contain at least two ':' (e.g. "fe80::1", "2607:fb91::9c").
+        // IPv4 "10.0.0.5" has none; "10.0.0.5:5277" has exactly one. A bracketed
+        // "[2607:..]" form also trips the >1 colon test.
+        return host.count { it == ':' } > 1
+    }
+
+    /** Convenience inverse — readable at filter sites. */
+    fun isUsable(host: String?): Boolean = !isUnusable(host)
+}

--- a/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
+++ b/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
@@ -83,18 +83,32 @@ class TcpConnector(
                 manualHost = raw
                 manualPort = COMPANION_PORT
             }
-            OalLog.i(TAG, "Manual IP mode: $manualHost:$manualPort")
         } else {
             manualHost = null
             manualPort = COMPANION_PORT
             startNsdDiscovery()
         }
 
+        // Guard (issue #48): a manual host that is an IPv6 literal is unusable on
+        // OAL's IPv4-only local link. If one is somehow handed in, do NOT pin the
+        // direct-dial branch to it (which would skip the gateway/mDNS fallback and
+        // retry a dead address forever). Drop to discovery instead so the IPv4
+        // path can recover.
+        val effectiveManualHost: String? =
+            if (manualHost != null && com.openautolink.app.transport.HostUsability.isUnusable(manualHost)) {
+                OalLog.w(TAG, "Manual host $manualHost is IPv6/unusable — ignoring, falling back to discovery")
+                if (discoveryListener == null) startNsdDiscovery()
+                null
+            } else {
+                if (manualHost != null) OalLog.i(TAG, "Manual IP mode: $manualHost:$manualPort")
+                manualHost
+            }
+
         connectJob = scope.launch(Dispatchers.IO) {
             while (isActive && isRunning) {
                 // Manual IP — skip all discovery, connect directly
-                if (manualHost != null) {
-                    if (tryConnect(manualHost, manualPort, "manual")) return@launch
+                if (effectiveManualHost != null) {
+                    if (tryConnect(effectiveManualHost, manualPort, "manual")) return@launch
                     onConnectFailure?.invoke()
                     delay(RETRY_DELAY_MS)
                     continue
@@ -124,6 +138,14 @@ class TcpConnector(
     }
 
     private fun tryConnect(host: String, port: Int, source: String): Boolean {
+        // Issue #48: never attempt an IPv6 literal — the companion serves IPv4
+        // only on the local link, and on a hotspot a global IPv6 (2607:…) isn't
+        // bridged. Reject here so every caller (manual / mDNS / gateway) is
+        // covered by one guard and we move on to the next IPv4 candidate.
+        if (com.openautolink.app.transport.HostUsability.isUnusable(host)) {
+            OalLog.d(TAG, "Skipping unusable (IPv6) host from $source: $host")
+            return false
+        }
         OalLog.i(TAG, "Connecting to $host:$port ($source)")
         return try {
             val socket = Socket()

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -1557,6 +1557,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                         val floor = discoveryFreshnessFloorMs
                         list.firstOrNull {
                             it.isResolved && it.phoneId == defaultId &&
+                                !isUnusableHost(it.host.orEmpty()) &&
                                 (floor == 0L || it.lastSeenMs >= floor)
                         }
                     }
@@ -1619,9 +1620,14 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     }
 
     private fun isUnusableHost(host: String): Boolean {
-        // Cheap textual check — `fe80:` prefix covers IPv6 link-local. Avoids
-        // creating an InetAddress just for filtering.
-        return host.startsWith("fe80:", ignoreCase = true)
+        // Delegates to the shared pure predicate so every selection site applies
+        // the same rule. Rejects all IPv6 literals (link-local AND global): the
+        // companion only ever serves IPv4 on the local link, and on a phone
+        // hotspot a global IPv6 (e.g. cellular 2607:…) is advertised over mDNS
+        // but not routable over the SoftAP bridge — dialing it pins the
+        // connector to a dead address and never falls back to the IPv4 the
+        // sweep already knows (issue #48).
+        return com.openautolink.app.transport.HostUsability.isUnusable(host)
     }
 
     /**

--- a/app/src/test/java/com/openautolink/app/transport/HostUsabilityTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/HostUsabilityTest.kt
@@ -1,0 +1,75 @@
+package com.openautolink.app.transport
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for [HostUsability] — the connect-path host filter.
+ *
+ * Regression anchor: issue #48, where the car dialed the phone's global IPv6
+ * (`2607:fb91:1ecb:cdb3::9c`) over the hotspot and retried it ~54 times while
+ * the reachable IPv4 sat unused, escalating into an AASDK-30 reconnect storm.
+ */
+class HostUsabilityTest {
+
+    // ── IPv4: usable ────────────────────────────────────────────────────
+
+    @Test
+    fun `plain ipv4 is usable`() {
+        assertTrue(HostUsability.isUsable("10.218.15.62"))
+        assertFalse(HostUsability.isUnusable("10.218.15.62"))
+    }
+
+    @Test
+    fun `ipv4 with port is usable`() {
+        // One colon — must be preserved (ProjectionViewModel appends :port).
+        assertTrue(HostUsability.isUsable("10.218.15.109:5277"))
+    }
+
+    @Test
+    fun `ipv4 hotspot and gateway ranges are usable`() {
+        assertTrue(HostUsability.isUsable("192.168.43.1"))
+        assertTrue(HostUsability.isUsable("172.23.178.230"))
+    }
+
+    // ── IPv6: unusable ──────────────────────────────────────────────────
+
+    @Test
+    fun `global ipv6 from issue 48 is unusable`() {
+        // The exact address the car dead-dialed 54 times on 2026-06-29.
+        assertTrue(HostUsability.isUnusable("2607:fb91:1ecb:cdb3::9c"))
+        assertFalse(HostUsability.isUsable("2607:fb91:1ecb:cdb3::9c"))
+    }
+
+    @Test
+    fun `link-local ipv6 is unusable`() {
+        assertTrue(HostUsability.isUnusable("fe80::1"))
+        assertTrue(HostUsability.isUnusable("fe80::a00:27ff:fe4e:66a1"))
+    }
+
+    @Test
+    fun `ipv6 with zone id is unusable`() {
+        assertTrue(HostUsability.isUnusable("fe80::1%wlan0"))
+    }
+
+    @Test
+    fun `bracketed ipv6 with port is unusable`() {
+        assertTrue(HostUsability.isUnusable("[2607:fb91::9c]:5277"))
+    }
+
+    @Test
+    fun `ipv6 loopback and unspecified are unusable`() {
+        assertTrue(HostUsability.isUnusable("::1"))
+        assertTrue(HostUsability.isUnusable("::"))
+    }
+
+    // ── Blank / null ────────────────────────────────────────────────────
+
+    @Test
+    fun `null and blank are unusable`() {
+        assertTrue(HostUsability.isUnusable(null))
+        assertTrue(HostUsability.isUnusable(""))
+        assertTrue(HostUsability.isUnusable("   "))
+    }
+}


### PR DESCRIPTION
Closes #47.

## Problem
On a phone hotspot, mDNS resolves the companion to the phone's **global IPv6**
address (cellular GUA, e.g. `2607:fb91:...`). That address is advertised but is
**not routable over the SoftAP bridge**, while the reachable IPv4 sits unused in
the sweep plan. In Car-Hotspot mode the resolved host is fed straight to
`TcpConnector.manualIp`, which forces the direct-dial branch and **skips the IPv4
gateway/sweep fallback** - so the connector pins to the dead IPv6 and retries it
forever, escalating into an AASDK-30 reconnect storm.

Captured 2026-06-29 (car `oal_2026-06-29_16-00-24.log`): 54 dead dials to
`2607:fb91:1ecb:cdb3::9c` with the working IPv4 `10.218.15.62` ignored each
sweep; reached "Reconnect attempt 47" before mDNS happened to return IPv4, which
then connected instantly.

## Root cause
- `ProjectionViewModel.isUnusableHost()` only rejected `fe80:` link-local, so a
  **global** IPv6 passed through.
- The default-phone selector in `collectWithDefaultHeadStart` filtered by
  `phone_id` only, never by host.
- The companion serves **IPv4 only** on every path it advertises (TCP server,
  identity probe, UDP discovery, gateway), so any IPv6 literal is unusable for
  our connect path.

## Fix
1. New pure `HostUsability` predicate - any IPv6 literal is unusable on OAL's
   IPv4-only local link. IPv6 detected structurally (`:` count > 1) so an IPv4
   `host:port` is preserved.
2. `isUnusableHost` delegates to it; the default-phone selector applies it too.
3. Defense-in-depth: `TcpConnector.tryConnect` rejects IPv6 from every source
   (manual / mDNS / gateway); the manual-IP branch falls back to discovery
   instead of pinning to an unusable host.
4. Unit test `HostUsabilityTest` covering the `2607:...` address + IPv4/port/blank/
   link-local/zone-id cases.

4 files, +169/-6.

## Verification
- `:app:compileDebugKotlin` + `:app:testDebugUnitTest --tests HostUsabilityTest`
  **pass** on host (JDK 17).
- Shipped in the **0.1.355 draft** on `automotive:internal`.
- **NOT road-tested yet** - needs a hotspot drive to confirm the car prefers IPv4
  and reconnects cleanly. Do not treat as verified until then.
