### PR TITLE
fix(session): hold video-stall watchdog through keyframe warmup (#30/#34)

### DIFF
--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -95,6 +95,21 @@ class SessionManager(
          */
         private const val VIDEO_STALL_WARMUP_MS = 16_000L
 
+        /**
+         * Sustained-low-bitrate recovery (issue: black/frozen map on a starved
+         * link, build 0.1.356 drive 2026-06-30). When video bitrate stays below
+         * [LOW_BITRATE_FLOOR_KBPS] for [LOW_BITRATE_RECOVER_SECONDS] consecutive
+         * 1s samples while STREAMING (past warmup), the link is starving video
+         * even though a frame trickles in often enough that the no-frame stall
+         * watchdog never trips. Force one recovery reconnect.
+         *
+         * The floor is set FAR below a static-but-healthy map (which still runs
+         * hundreds of kbps) so a legitimately quiet map never trips it; only a
+         * genuinely starved link (the capture sat at 12-13 kbps) sustains this.
+         */
+        private const val LOW_BITRATE_FLOOR_KBPS = 60f
+        private const val LOW_BITRATE_RECOVER_SECONDS = 12
+
         // Activity-sourced UI-mode snapshot that can be published before
         // SessionManager exists (ViewModel lazy creation path).
         @Volatile
@@ -1807,6 +1822,7 @@ class SessionManager(
         // Wait for a session to exist.
         while (aasdkSession == null) { delay(VIDEO_STALL_POLL_MS) }
         val session = aasdkSession ?: return
+        var consecutiveLowBitrateSec = 0
         while (true) {
             delay(VIDEO_STALL_POLL_MS)
             val last = session.lastVideoFrameMs
@@ -1832,8 +1848,41 @@ class SessionManager(
                 _remoteDiagnostics?.log(DiagnosticLevel.WARN, "video",
                     "Video stall ${staleFor}ms — forcing reconnect")
                 aasdkSession?.forceReconnect("video stall (${staleFor}ms no frame)")
+                consecutiveLowBitrateSec = 0
                 // Back off a full threshold so the freshly-restarted session has
                 // time to deliver its first frame before we evaluate again.
+                delay(VIDEO_STALL_THRESHOLD_MS)
+                continue
+            }
+
+            // Sustained-low-bitrate recovery: frames trickle in (so the no-frame
+            // stall never trips) but the link is starving video — a black/frozen
+            // map while audio still plays. Advance a consecutive-low counter and
+            // force one recovery reconnect if it persists past the warmup window.
+            val stats = _videoDecoder?.stats?.value
+            val starved = stats != null && VideoStallPolicy.isStarvedSample(
+                bitrateKbps = stats.bitrateKbps,
+                hasRendered = stats.framesDecoded > 0,
+                floorKbps = LOW_BITRATE_FLOOR_KBPS,
+            )
+            consecutiveLowBitrateSec = if (starved) consecutiveLowBitrateSec + 1 else 0
+            val recoverLowBitrate = VideoStallPolicy.shouldRecoverLowBitrate(
+                streaming = _sessionState.value == SessionState.STREAMING,
+                goingIdle = isGoingIdle,
+                streamingSinceMs = streamingSinceMs,
+                nowMs = now,
+                warmupMs = VIDEO_STALL_WARMUP_MS,
+                consecutiveLowSeconds = consecutiveLowBitrateSec,
+                requiredLowSeconds = LOW_BITRATE_RECOVER_SECONDS,
+            )
+            if (recoverLowBitrate) {
+                val kbps = stats?.bitrateKbps?.toInt() ?: 0
+                OalLog.w(TAG, "Video starved: ${kbps}kbps for ${consecutiveLowBitrateSec}s while STREAMING — forcing reconnect")
+                DiagnosticLog.w("video", "Video starved ${kbps}kbps ${consecutiveLowBitrateSec}s — forcing reconnect")
+                _remoteDiagnostics?.log(DiagnosticLevel.WARN, "video",
+                    "Video starved ${kbps}kbps ${consecutiveLowBitrateSec}s — forcing reconnect")
+                aasdkSession?.forceReconnect("video starved (${kbps}kbps ${consecutiveLowBitrateSec}s)")
+                consecutiveLowBitrateSec = 0
                 delay(VIDEO_STALL_THRESHOLD_MS)
             }
         }

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -79,6 +79,22 @@ class SessionManager(
         private const val VIDEO_STALL_THRESHOLD_MS = 8_000L
         private const val VIDEO_STALL_POLL_MS = 1_000L
 
+        /**
+         * Grace period after a session reaches STREAMING before the video-stall
+         * watchdog is allowed to force a reconnect (issue #30/#34 interaction).
+         *
+         * On connect the phone sends a tiny "seed" IDR almost immediately, then
+         * a multi-second gap before the first REAL keyframe while its encoder
+         * warms up. `lastVideoFrameMs` is bumped by that seed IDR, so the
+         * watchdog would arm and — when the warmup gap exceeds the 8s threshold —
+         * force a reconnect that lands straight in an AASDK Error-30 flap,
+         * turning a normal warmup into ~25s of reconnect churn before the stream
+         * settles (observed 2026-06-30, build 0.1.355). Holding the watchdog off
+         * for this window lets the initial keyframe warmup complete; a genuine
+         * mid-drive wedge still trips it once the grace has elapsed.
+         */
+        private const val VIDEO_STALL_WARMUP_MS = 16_000L
+
         // Activity-sourced UI-mode snapshot that can be published before
         // SessionManager exists (ViewModel lazy creation path).
         @Volatile
@@ -376,6 +392,14 @@ class SessionManager(
     private var keyframeWatchJob: Job? = null
     private var callStateJob: Job? = null
     private var videoStallWatchJob: Job? = null
+
+    /**
+     * [SystemClock.elapsedRealtime] when the current session last transitioned
+     * to STREAMING, or 0 when not streaming. The video-stall watchdog uses this
+     * to skip the initial keyframe-warmup window (issue #30/#34): it won't force
+     * a reconnect until [VIDEO_STALL_WARMUP_MS] after streaming began.
+     */
+    @Volatile private var streamingSinceMs: Long = 0L
 
     /**
      * True while the app is intentionally idle (Activity paused / screen off /
@@ -1769,10 +1793,13 @@ class SessionManager(
      * restart. The phone is left advertising on a stalled link, so the restart
      * reconnects within ~1s.
      *
-     * Guards against false trips:
+     * Guards against false trips (see [VideoStallPolicy]):
      *  - only while sessionState == STREAMING (not during connect/handshake)
      *  - only when not intentionally idle (backgrounded / screen-off / paused),
      *    where video legitimately stops
+     *  - only after the initial keyframe-warmup window ([VIDEO_STALL_WARMUP_MS])
+     *    has elapsed since STREAMING began — the seed-IDR→first-real-keyframe gap
+     *    would otherwise force a reconnect that flaps into Error-30 (issue #30/#34)
      *  - only after at least one frame has been seen (lastVideoFrameMs != 0)
      *  - re-arms the baseline after each forced reconnect so we don't loop
      */
@@ -1782,12 +1809,24 @@ class SessionManager(
         val session = aasdkSession ?: return
         while (true) {
             delay(VIDEO_STALL_POLL_MS)
-            if (_sessionState.value != SessionState.STREAMING) continue
-            if (isGoingIdle) continue
             val last = session.lastVideoFrameMs
-            if (last == 0L) continue // no frame yet this session
-            val staleFor = SystemClock.elapsedRealtime() - last
-            if (staleFor >= VIDEO_STALL_THRESHOLD_MS) {
+            val now = SystemClock.elapsedRealtime()
+            // Decision (incl. the keyframe-warmup grace, issue #30/#34) lives in
+            // the pure VideoStallPolicy so it can be unit tested. The phone sends
+            // a tiny seed IDR right after connect, then a multi-second gap before
+            // the first real keyframe; without the warmup grace that gap trips the
+            // 8s threshold and forces a reconnect that flaps into Error-30.
+            val shouldReconnect = VideoStallPolicy.shouldForceReconnect(
+                streaming = _sessionState.value == SessionState.STREAMING,
+                goingIdle = isGoingIdle,
+                streamingSinceMs = streamingSinceMs,
+                lastVideoFrameMs = last,
+                nowMs = now,
+                warmupMs = VIDEO_STALL_WARMUP_MS,
+                thresholdMs = VIDEO_STALL_THRESHOLD_MS,
+            )
+            if (shouldReconnect) {
+                val staleFor = now - last
                 OalLog.w(TAG, "Video stall detected: no frame for ${staleFor}ms while STREAMING — forcing reconnect")
                 DiagnosticLog.w("video", "Video stall ${staleFor}ms — forcing reconnect")
                 _remoteDiagnostics?.log(DiagnosticLevel.WARN, "video",
@@ -1819,6 +1858,7 @@ class SessionManager(
                 resetLatchedVehicleSensorState("phone_connected")
                 seedCurrentUiNightMode("phone_connected")
                 _sessionState.value = SessionState.STREAMING
+                streamingSinceMs = SystemClock.elapsedRealtime()
                 _statusMessage.value = "Streaming"
                 aasdkSession?.let { startLocationForwarding(it) }
                 _vehicleDataForwarder?.start()

--- a/app/src/main/java/com/openautolink/app/session/VideoStallPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/session/VideoStallPolicy.kt
@@ -1,0 +1,44 @@
+package com.openautolink.app.session
+
+/**
+ * Pure decision logic for the video-stall watchdog, extracted so it can be unit
+ * tested without an Android runtime / live SessionManager.
+ *
+ * The watchdog forces a reconnect when the AA video channel wedges mid-drive
+ * (frames stop while the socket stays alive). But it must NOT fire during the
+ * initial keyframe-warmup window after a session reaches STREAMING — the phone
+ * sends a tiny seed IDR immediately, then a multi-second gap before the first
+ * real keyframe, and tripping there forces a reconnect that flaps into AASDK
+ * Error-30 (issue #30/#34 interaction, observed in build 0.1.355).
+ */
+object VideoStallPolicy {
+
+    /**
+     * @param streaming        true only while sessionState == STREAMING
+     * @param goingIdle        true while intentionally idle (paused/screen-off)
+     * @param streamingSinceMs elapsedRealtime when STREAMING began, 0 if not streaming
+     * @param lastVideoFrameMs elapsedRealtime of the most recent inbound frame, 0 if none yet
+     * @param nowMs            current elapsedRealtime
+     * @param warmupMs         grace window after streaming start before arming
+     * @param thresholdMs      max tolerated gap with no frame once armed
+     * @return true iff the watchdog should force a reconnect right now
+     */
+    fun shouldForceReconnect(
+        streaming: Boolean,
+        goingIdle: Boolean,
+        streamingSinceMs: Long,
+        lastVideoFrameMs: Long,
+        nowMs: Long,
+        warmupMs: Long,
+        thresholdMs: Long,
+    ): Boolean {
+        if (!streaming) return false
+        if (goingIdle) return false
+        // Initial keyframe-warmup grace.
+        if (streamingSinceMs == 0L) return false
+        if (nowMs - streamingSinceMs < warmupMs) return false
+        // Need at least one frame this session before measuring staleness.
+        if (lastVideoFrameMs == 0L) return false
+        return (nowMs - lastVideoFrameMs) >= thresholdMs
+    }
+}

--- a/app/src/main/java/com/openautolink/app/session/VideoStallPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/session/VideoStallPolicy.kt
@@ -41,4 +41,50 @@ object VideoStallPolicy {
         if (lastVideoFrameMs == 0L) return false
         return (nowMs - lastVideoFrameMs) >= thresholdMs
     }
+
+    /**
+     * Decide whether a SUSTAINED ultra-low video bitrate warrants a recovery
+     * reconnect, even though frames are technically still trickling in (so the
+     * no-frame [shouldForceReconnect] never trips).
+     *
+     * Motivating capture (build 0.1.356 drive, 2026-06-30): a flaky car-AP link
+     * starved the video stream to ~12-13 kbps for 2+ minutes — a black/frozen map
+     * — while audio (a separate, tiny channel) kept playing and a frame dribbled
+     * in often enough to keep [lastVideoFrameMs] fresh. The user sees a dead map
+     * with no automatic recovery.
+     *
+     * False-positive guards (a static map legitimately dips low but recovers):
+     *  - only past the streaming warmup window,
+     *  - the floor is set far below a static-but-healthy map (which still runs
+     *    hundreds of kbps); only a genuinely starved link sits this low,
+     *  - requires [requiredLowSeconds] CONSECUTIVE low-bitrate samples, so a
+     *    momentary dip never trips it — the caller tracks the run length.
+     *
+     * @param consecutiveLowSeconds how many consecutive ~1s samples have been
+     *        below [floorKbps] while streaming (caller-maintained counter)
+     */
+    fun shouldRecoverLowBitrate(
+        streaming: Boolean,
+        goingIdle: Boolean,
+        streamingSinceMs: Long,
+        nowMs: Long,
+        warmupMs: Long,
+        consecutiveLowSeconds: Int,
+        requiredLowSeconds: Int,
+    ): Boolean {
+        if (!streaming) return false
+        if (goingIdle) return false
+        if (streamingSinceMs == 0L) return false
+        if (nowMs - streamingSinceMs < warmupMs) return false
+        return consecutiveLowSeconds >= requiredLowSeconds
+    }
+
+    /**
+     * Whether a single bitrate sample counts as "ultra-low" (starved link), used
+     * by the caller to advance/reset its consecutive-low counter. A sample only
+     * counts once at least one keyframe has rendered ([hasRendered]) — before
+     * that, 0 kbps is just "no video yet", not starvation.
+     */
+    fun isStarvedSample(bitrateKbps: Float, hasRendered: Boolean, floorKbps: Float): Boolean =
+        hasRendered && bitrateKbps < floorKbps
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -130,6 +130,18 @@ class AasdkSession(
     @Volatile
     private var explicitStop = false
 
+    /**
+     * True from the moment [forceReconnect] begins tearing down the native
+     * session until the replacement session starts. nativeStopSession() aborts
+     * whatever native read/operation was in flight, which surfaces ASYNCHRONOUSLY
+     * as `onError("AASDK Error: 30")` — that 30 is `OPERATION_ABORTED` (we caused
+     * it), NOT a protocol/handshake rejection. [explicitStop] is cleared
+     * synchronously inside forceReconnect() (before that async onError lands), so
+     * it can't be used to recognise the self-abort. This longer-lived flag can.
+     */
+    @Volatile
+    private var forcedStopInFlight = false
+
     /** Consecutive reconnect failures — drives exponential backoff. Also
      *  exposed as a StateFlow so the UI controller can escalate (e.g., open
      *  the phone picker) after a threshold of repeated failures. */
@@ -270,6 +282,11 @@ class AasdkSession(
         // later — we're doing the restart ourselves immediately. Without this
         // both reconnects race and one fails with "Native session start failed".
         explicitStop = true
+        // Mark the self-abort window: nativeStopSession() will abort the in-flight
+        // native read, surfacing async as onError(Error 30 = OPERATION_ABORTED).
+        // Stays set until the new session starts so onError can tell our own abort
+        // apart from a real protocol failure (issue: self-inflicted Error-30 storm).
+        forcedStopInFlight = true
         _tcpConnector?.stop()
         _tcpConnector = null
         _usbConnectionManager?.stop()
@@ -362,6 +379,9 @@ class AasdkSession(
         // past STABLE_DWELL_MS, i.e. it was a genuine recovery, not a flap.
         sessionStartedAtMs = android.os.SystemClock.elapsedRealtime()
         lastFailureWasProtocolError = false
+        // The replacement session is up — any self-abort window from a forced
+        // reconnect is over. Subsequent Error-30s are real, not our own teardown.
+        forcedStopInFlight = false
         // Re-baseline the video-stall watchdog for the new session (issue #43).
         // AasdkSession persists across reconnects, so without this reset the
         // watchdog would compare the fresh session against the PREVIOUS
@@ -634,9 +654,14 @@ class AasdkSession(
             else OalLog.e(TAG, "Native error: $message")
             shouldEmit = true
         }
-        // Flag protocol/handshake errors so reconnect uses extended backoff.
-        // AASDK Error 30 = SSL handshake rejected (phone still holds old session).
-        if ("AASDK Error: 30" in message) {
+        // AASDK Error 30 = OPERATION_ABORTED. It means an in-flight native
+        // operation was cancelled — which is EXACTLY what our own forceReconnect()
+        // -> nativeStopSession() does. Only treat it as a real protocol failure
+        // (extended backoff + chooser escalation) when it did NOT come from our
+        // own forced teardown; otherwise it's self-inflicted and recovers on the
+        // restart we already kicked off. Misclassifying the self-abort turned a
+        // single watchdog reconnect into an Error-30 "storm" + chooser pop.
+        if ("AASDK Error: 30" in message && !forcedStopInFlight) {
             lastFailureWasProtocolError = true
         }
         // Only emit at most once per second (matches the log coalescing). Auto-reconnect

--- a/app/src/test/java/com/openautolink/app/session/VideoStallPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/VideoStallPolicyTest.kt
@@ -1,0 +1,92 @@
+package com.openautolink.app.session
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit coverage for [VideoStallPolicy] — the video-stall watchdog decision,
+ * including the keyframe-warmup grace added for issue #30/#34.
+ *
+ * Regression anchor: build 0.1.355 drive (2026-06-30). The phone sent a seed IDR
+ * ~1s after STREAMING, then no frame for ~9s while its encoder warmed up; the
+ * watchdog fired at the 8s mark and force-reconnected straight into AASDK
+ * Error-30, churning for ~25s before the stream settled.
+ *
+ * Timeline convention: STREAMING began at elapsedRealtime = 100_000 ("since").
+ */
+class VideoStallPolicyTest {
+
+    private val WARMUP = 16_000L
+    private val THRESHOLD = 8_000L
+    private val SINCE = 100_000L  // when STREAMING began
+
+    private fun decide(
+        streaming: Boolean = true,
+        goingIdle: Boolean = false,
+        streamingSinceMs: Long = SINCE,
+        lastVideoFrameMs: Long,
+        nowMs: Long,
+    ) = VideoStallPolicy.shouldForceReconnect(
+        streaming, goingIdle, streamingSinceMs, lastVideoFrameMs, nowMs, WARMUP, THRESHOLD,
+    )
+
+    // ── The #30/#34 regression: warmup gap must NOT fire ────────────────
+
+    @Test
+    fun `seed-IDR warmup gap does NOT force reconnect`() {
+        // STREAMING at 100_000; seed IDR at 101_000; now 110_000 -> 9s stale
+        // (> 8s threshold) BUT only 10s into the 16s warmup -> hold off.
+        assertFalse(decide(lastVideoFrameMs = 101_000L, nowMs = 110_000L))
+    }
+
+    @Test
+    fun `still suppressed right up to the warmup boundary`() {
+        // 15.9s in, frame ~9s stale — still inside warmup -> suppressed.
+        assertFalse(decide(lastVideoFrameMs = 106_900L, nowMs = 115_900L))
+    }
+
+    // ── Genuine mid-drive wedge AFTER warmup: must fire ─────────────────
+
+    @Test
+    fun `real stall after warmup forces reconnect`() {
+        // 60s into a healthy stream, frames stop for 9s -> wedge -> reconnect.
+        assertTrue(decide(lastVideoFrameMs = 151_000L, nowMs = 160_000L))
+    }
+
+    @Test
+    fun `healthy stream after warmup does NOT fire`() {
+        // 60s in, last frame 2s ago — normal, no reconnect.
+        assertFalse(decide(lastVideoFrameMs = 158_000L, nowMs = 160_000L))
+    }
+
+    @Test
+    fun `exactly at threshold just past warmup fires`() {
+        // 17s in (past 16s warmup), stale == threshold (8s) -> fire.
+        assertTrue(decide(lastVideoFrameMs = 109_000L, nowMs = 117_000L))
+    }
+
+    // ── Standing guards still hold ──────────────────────────────────────
+
+    @Test
+    fun `not streaming never fires`() {
+        assertFalse(decide(streaming = false, lastVideoFrameMs = 101_000L, nowMs = 160_000L))
+    }
+
+    @Test
+    fun `intentionally idle never fires`() {
+        assertFalse(decide(goingIdle = true, lastVideoFrameMs = 101_000L, nowMs = 160_000L))
+    }
+
+    @Test
+    fun `zero streaming baseline never fires`() {
+        // streamingSinceMs == 0 means "not streaming yet" — must not fire.
+        assertFalse(decide(streamingSinceMs = 0L, lastVideoFrameMs = 0L, nowMs = 160_000L))
+    }
+
+    @Test
+    fun `no frame yet after warmup does NOT fire`() {
+        // Past warmup but zero frames this session -> wait, don't reconnect-loop.
+        assertFalse(decide(lastVideoFrameMs = 0L, nowMs = 160_000L))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/session/VideoStallPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/VideoStallPolicyTest.kt
@@ -89,4 +89,50 @@ class VideoStallPolicyTest {
         // Past warmup but zero frames this session -> wait, don't reconnect-loop.
         assertFalse(decide(lastVideoFrameMs = 0L, nowMs = 160_000L))
     }
+
+    // ── Sustained-low-bitrate recovery (0.1.356 starved-link drive) ─────
+
+    private fun recover(
+        streaming: Boolean = true,
+        goingIdle: Boolean = false,
+        streamingSinceMs: Long = SINCE,
+        nowMs: Long = SINCE + 60_000L,           // well past warmup by default
+        consecutiveLowSeconds: Int,
+        requiredLowSeconds: Int = 12,
+    ) = VideoStallPolicy.shouldRecoverLowBitrate(
+        streaming, goingIdle, streamingSinceMs, nowMs, WARMUP, consecutiveLowSeconds, requiredLowSeconds,
+    )
+
+    @Test
+    fun `12s of starvation past warmup forces recovery`() {
+        assertTrue(recover(consecutiveLowSeconds = 12))
+    }
+
+    @Test
+    fun `brief low-bitrate dip does NOT force recovery`() {
+        // A static map dipping low for a few seconds must not trip it.
+        assertFalse(recover(consecutiveLowSeconds = 4))
+    }
+
+    @Test
+    fun `starvation during warmup is held off`() {
+        // 10s into streaming, already 10 low samples — still inside 16s warmup.
+        assertFalse(recover(nowMs = SINCE + 10_000L, consecutiveLowSeconds = 10))
+    }
+
+    @Test
+    fun `starvation while idle or not streaming never fires`() {
+        assertFalse(recover(goingIdle = true, consecutiveLowSeconds = 30))
+        assertFalse(recover(streaming = false, consecutiveLowSeconds = 30))
+    }
+
+    @Test
+    fun `isStarvedSample requires a rendered frame and sub-floor bitrate`() {
+        // The 0.1.356 capture: 13 kbps with frames rendered -> starved.
+        assertTrue(VideoStallPolicy.isStarvedSample(13f, hasRendered = true, floorKbps = 60f))
+        // 0 kbps before any keyframe is just "no video yet", not starvation.
+        assertFalse(VideoStallPolicy.isStarvedSample(0f, hasRendered = false, floorKbps = 60f))
+        // A healthy-but-quiet static map well above the floor -> not starved.
+        assertFalse(VideoStallPolicy.isStarvedSample(450f, hasRendered = true, floorKbps = 60f))
+    }
 }


### PR DESCRIPTION
Addresses the startup reconnect churn in #30 (and refines the #34 watchdog).

## Problem
On the 0.1.355 hotspot drive (2026-06-30) the car connected fine over IPv4, but
the video-stall watchdog (#34) force-reconnected ~9s after the first frame and
flapped into AASDK Error-30, churning for ~25s before the stream settled:

```
15:09:01  IDR received: 8176B (seed)  ->  First frame rendered in 45ms
15:09:33  Video stall detected: no frame for 8994ms  ->  forcing reconnect
15:09:33  AASDK Error: 30  ->  retry storm  ->  "Reconnect attempt 2 - opening chooser"
15:09:58  AA session started -> STREAMING (stable from here)
```

## Root cause
On connect the phone sends a tiny **seed IDR** (8176 bytes) almost immediately,
then a multi-second gap before its first **real** keyframe while the encoder
warms up. `lastVideoFrameMs` is bumped by the seed IDR, so the watchdog arms and
the warmup gap (>8s) trips `VIDEO_STALL_THRESHOLD_MS`, forcing a reconnect that
lands in an Error-30 flap. The watchdog is firing into normal startup, not a real
wedge.

## Fix
Add a `VIDEO_STALL_WARMUP_MS` (16s) grace measured from the STREAMING transition
(new `streamingSinceMs` baseline). The watchdog won't force a reconnect until the
warmup elapses, so the seed-IDR -> first-real-keyframe warmup completes
undisturbed. A genuine mid-drive wedge is still caught once the grace passes.

Decision logic extracted to a pure `VideoStallPolicy` object so it is unit
testable: `VideoStallPolicyTest` (9 cases) covers warmup suppression of the
0.1.355 gap, a post-warmup wedge still firing, and the standing guards
(not-streaming / idle / no-frame-yet).

## Verification
- `:app:testDebugUnitTest --tests VideoStallPolicyTest` **passes** (host, JDK 17).
- **Not road-tested yet** - going into a new internal build for a same-route retest.
- Does not close #30: the broader Error-30 reconnect-storm hardening is separate;
  this removes the watchdog as a *trigger* of it during startup.
