### PR TITLE
fix(reconnect): deep-sleep reconnect-storm fix + video diagnostics

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -215,6 +215,7 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     cbMethods_.onVoiceSession = env->GetMethodID(cbClass, "onVoiceSession", "(Z)V");
     cbMethods_.onAudioFocusRequest = env->GetMethodID(cbClass, "onAudioFocusRequest", "(I)V");
     cbMethods_.onError = env->GetMethodID(cbClass, "onError", "(Ljava/lang/String;)V");
+    cbMethods_.onNativeLog = env->GetMethodID(cbClass, "onNativeLog", "(ILjava/lang/String;Ljava/lang/String;)V");
     env->DeleteLocalRef(cbClass);
 
     // Read SDR config from Kotlin
@@ -416,6 +417,11 @@ void JniSession::stop()
 {
     if (stopped_.exchange(true)) return;
     LOGI("Stopping session");
+    // (D) Deep-sleep black-video investigation: we tear down by closing the
+    // TCP socket WITHOUT sending a ByeBye to the phone (despite the header
+    // comment). The phone only discovers the drop as an I/O error. Log it so
+    // the diagnostic trace marks the exact teardown moment and its reason.
+    nativeDiag(2, "session", "stop() closing transport WITHOUT ByeBye reason=" + stopReason_);
     streaming_ = false;
 
     if (transport_) transport_->stop();
@@ -443,8 +449,24 @@ void JniSession::stop()
     transport_.reset();
 }
 
+void JniSession::nativeDiag(int level, const char* tag, const std::string& msg)
+{
+    if (!cbMethods_.onNativeLog || !callbackRef_) return;
+    bool attached;
+    JNIEnv* env = getEnv(attached);
+    if (env) {
+        jstring jtag = env->NewStringUTF(tag);
+        jstring jmsg = env->NewStringUTF(msg.c_str());
+        env->CallVoidMethod(callbackRef_, cbMethods_.onNativeLog,
+                            static_cast<jint>(level), jtag, jmsg);
+        env->DeleteLocalRef(jtag);
+        env->DeleteLocalRef(jmsg);
+    }
+    releaseEnv(attached);
+}
+
 // ============================================================================
-// IControlServiceChannelEventHandler Ã¢â‚¬â€ AA handshake + session control
+// IControlServiceChannelEventHandler Ã¢â‚¬â€ AA handshake + session control
 // ============================================================================
 
 void JniSession::onVersionResponse(uint16_t majorCode, uint16_t minorCode,
@@ -864,6 +886,7 @@ void JniSession::onMediaChannelSetupRequest(
     currentVideoFocus_.store(
         aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
     LOGI("Sending VIDEO_FOCUS_PROJECTED after setup (unsolicited)");
+    nativeDiag(1, "vfocus", "us->phone VideoFocusIndication PROJECTED unsolicited=true (post-setup)");
     aap_protobuf::service::media::video::message::VideoFocusNotification focus;
     focus.set_focus(aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
     focus.set_unsolicited(true);
@@ -880,6 +903,10 @@ void JniSession::onMediaChannelStartIndication(
     LOGI("Video stream starting: session=%d config_idx=%d",
          indication.session_id(), indication.configuration_index());
     logProtoRaw("VideoStart", indication);
+    nativeDiag(1, "video", "phone->us VideoStart session=" +
+               std::to_string(indication.session_id()) + " config_idx=" +
+               std::to_string(indication.configuration_index()) +
+               " -> replying VideoFocusIndication PROJECTED");
 
     currentVideoFocus_.store(
         aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
@@ -897,6 +924,7 @@ void JniSession::onMediaChannelStopIndication(
     const aap_protobuf::service::media::shared::message::Stop& /*indication*/)
 {
     LOGI("Video stream stopping");
+    nativeDiag(2, "video", "phone->us VideoStop (stream stopping)");
     videoChannel_->receive(shared_from_this());
 }
 
@@ -1002,6 +1030,9 @@ void JniSession::onVideoFocusRequest(
     LOGI("Video focus request from phone: mode=%d reason=%d "
          "(focus 1=PROJECTED 2=NATIVE 3=NATIVE_TRANSIENT; "
          "reason 1=PHONE_SCREEN_OFF 2=LAUNCH_NATIVE)", mode, reason);
+    nativeDiag(2, "vfocus", "phone->us VideoFocusRequest mode=" + std::to_string(mode) +
+               " reason=" + std::to_string(reason) +
+               " (mode 1=PROJECTED 2=NATIVE 3=NATIVE_TRANSIENT; reason 1=PHONE_SCREEN_OFF 2=LAUNCH_NATIVE)");
 
     // VIDEO_FOCUS_NATIVE = user tapped "Exit" in the AA app launcher on the
     // phone (the phone never sends ByeBye for this; it just asks us to show
@@ -1040,6 +1071,8 @@ void JniSession::onVideoFocusRequest(
     // screen off) — keep projecting. Reply with our current focus state.
     int reply = currentVideoFocus_.load();
     LOGI("Replying with current focus=%d", reply);
+    nativeDiag(1, "vfocus", "us->phone VideoFocusIndication (reply) focus=" +
+               std::to_string(reply) + " unsolicited=false");
     aap_protobuf::service::media::video::message::VideoFocusNotification focus;
     focus.set_focus(
         static_cast<aap_protobuf::service::media::video::message::VideoFocusMode>(reply));
@@ -1696,6 +1729,13 @@ void JniSession::requestKeyframe()
     if (!streaming_ || !videoChannel_) return;
     ioService_->post([this]() {
         LOGI("Requesting keyframe (VideoFocusIndication)");
+        // NOTE: there is no keyframe-request message in the AA protocol. This
+        // only re-asserts PROJECTED focus (unsolicited=false); if the phone
+        // already holds PROJECTED this is a NO-OP and will NOT force a fresh
+        // IDR. Logged so the diagnostic trace shows exactly how many of these
+        // went out during a black-video gap (they are effectively inert).
+        nativeDiag(2, "vfocus", "us->phone requestKeyframe = re-assert VideoFocusIndication(PROJECTED) "
+                   "[protocol no-op; does NOT force IDR]");
         aap_protobuf::service::media::video::message::VideoFocusNotification focus;
         focus.set_focus(aap_protobuf::service::media::video::message::VIDEO_FOCUS_PROJECTED);
         focus.set_unsolicited(false);

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -213,6 +213,11 @@ private:
     void releaseEnv(bool attached);
     void callVoidCallback(jmethodID method);
 
+    // Route a native diagnostic line into the Kotlin DiagnosticLog (the triaged
+    // log that gets uploaded). level: 0=d 1=i 2=w 3=e. Safe to call from the io
+    // thread; no-op if the callback isn't wired yet.
+    void nativeDiag(int level, const char* tag, const std::string& msg);
+
     JavaVM* jvm_;
     jobject callbackRef_ = nullptr;
 
@@ -366,6 +371,7 @@ private:
         jmethodID onVoiceSession = nullptr;
         jmethodID onAudioFocusRequest = nullptr;
         jmethodID onError = nullptr;
+        jmethodID onNativeLog = nullptr;
     };
     CallbackMethods cbMethods_;
 };

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -88,6 +88,18 @@ class AasdkSession(
     // TCP connector — used in "hotspot" transport mode (Car Hotspot / Phone Hotspot)
     private var _tcpConnector: TcpConnector? = null
 
+    // -- (A) Video frame-flow diagnostic counters --
+    // Periodically summarize inbound frame flow into the triaged DiagnosticLog
+    // so a black-video gap definitively shows whether bytes are still arriving
+    // (P-frames flowing but no IDR to anchor) vs the encoder being silent.
+    // All touched only from onVideoFrame (native io thread) + reset on start.
+    private var vfWindowStartMs: Long = 0L
+    private var vfFrameCount: Int = 0
+    private var vfKeyframeCount: Int = 0
+    private var vfByteCount: Long = 0L
+    private var vfLastFrameMs: Long = 0L
+    private val vfLogIntervalMs = 2000L
+
     // USB connection manager — only used in "usb" transport mode
     private var _usbConnectionManager: UsbConnectionManager? = null
 
@@ -310,6 +322,12 @@ class AasdkSession(
         consecutiveReconnectFailures = 0
         _reconnectAttempt.value = 0
         lastFailureWasProtocolError = false
+        // (A) Reset frame-flow counters so each session's video trace is clean.
+        vfWindowStartMs = 0L
+        vfFrameCount = 0
+        vfKeyframeCount = 0
+        vfByteCount = 0L
+        vfLastFrameMs = 0L
         scope.launch {
             _connectionState.value = ConnectionState.CONNECTED
             _controlMessages.emit(ControlMessage.PhoneConnected(phoneName = "", phoneType = "wireless"))
@@ -364,6 +382,7 @@ class AasdkSession(
     }
 
     override fun onVideoFrame(data: ByteArray, timestampUs: Long, width: Int, height: Int, flags: Int) {
+        recordVideoFrameFlow(data.size, flags)
         val frame = VideoFrame(
             width = width,
             height = height,
@@ -372,6 +391,39 @@ class AasdkSession(
             data = data
         )
         _videoFrames.tryEmit(frame)
+    }
+
+    /**
+     * (A) Frame-flow diagnostic. Accumulates inbound frames and emits a
+     * DiagnosticLog summary at most every [vfLogIntervalMs]. The gap-since-last
+     * frame is the key signal: during a black-video gap this shows whether the
+     * phone's encoder is still sending bytes (P-frames, no IDR) or is silent.
+     * Called on the native io thread; cheap and lock-free (single producer).
+     */
+    private fun recordVideoFrameFlow(size: Int, flags: Int) {
+        val now = android.os.SystemClock.elapsedRealtime()
+        val isKeyframe = (flags and 0x0001) != 0
+        val gap = if (vfLastFrameMs == 0L) 0L else now - vfLastFrameMs
+        vfLastFrameMs = now
+        if (vfWindowStartMs == 0L) vfWindowStartMs = now
+        vfFrameCount++
+        if (isKeyframe) vfKeyframeCount++
+        vfByteCount += size
+        val elapsed = now - vfWindowStartMs
+        // Flush a summary every interval, or immediately after a >1s starvation
+        // gap between frames (so a stall is captured even at low frame rates).
+        if (elapsed >= vfLogIntervalMs || gap > 1000L) {
+            val kbps = if (elapsed > 0) (vfByteCount * 8 / elapsed) else 0
+            com.openautolink.app.diagnostics.DiagnosticLog.i(
+                "vflow",
+                "frames=$vfFrameCount idr=$vfKeyframeCount bytes=$vfByteCount " +
+                    "~${kbps}kbps window=${elapsed}ms maxGap=${gap}ms"
+            )
+            vfWindowStartMs = now
+            vfFrameCount = 0
+            vfKeyframeCount = 0
+            vfByteCount = 0L
+        }
     }
 
     override fun onVideoCodecConfigured(codecType: Int) {
@@ -572,6 +624,15 @@ class AasdkSession(
             scope.launch {
                 _controlMessages.emit(ControlMessage.Error(code = -1, message = message))
             }
+        }
+    }
+
+    override fun onNativeLog(level: Int, tag: String, message: String) {
+        when (level) {
+            0 -> com.openautolink.app.diagnostics.DiagnosticLog.d(tag, message)
+            2 -> com.openautolink.app.diagnostics.DiagnosticLog.w(tag, message)
+            3 -> com.openautolink.app.diagnostics.DiagnosticLog.e(tag, message)
+            else -> com.openautolink.app.diagnostics.DiagnosticLog.i(tag, message)
         }
     }
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -127,7 +127,35 @@ class AasdkSession(
 
     private var transportPipe: AasdkTransportPipe? = null
 
-    // -- Lifecycle --
+    /**
+     * Handle to the single pending auto-reconnect coroutine (the backoff delay +
+     * transport restart scheduled from [onSessionStopped]). Tracked so that (a)
+     * a new teardown cancels an already-pending retry instead of stacking a
+     * second timer, and (b) a successful [onSessionStarted] cancels any pending
+     * retry so a STALE timer can't tear down the healthy session it raced with.
+     *
+     * Root cause of the deep-sleep reconnect storm (0.1.363 log 2026-07-19):
+     * several rapid teardowns during the wake window each armed their own
+     * fire-and-forget `scope.launch { delay(); startTcp() }` with no handle, so
+     * a leftover timer restarted the transport on top of an already-connected
+     * session — killing it and scheduling yet another retry (self-perpetuating).
+     * Guarded by [reconnectLock]; assignments and cancels are serialized.
+     */
+    @Volatile
+    private var reconnectJob: kotlinx.coroutines.Job? = null
+    private val reconnectLock = Any()
+
+    private fun cancelPendingReconnect(why: String) {
+        synchronized(reconnectLock) {
+            reconnectJob?.let {
+                if (it.isActive) {
+                    it.cancel()
+                    OalLog.i(TAG, "Cancelled pending reconnect ($why)")
+                }
+            }
+            reconnectJob = null
+        }
+    }
 
     fun start() {
         explicitStop = false
@@ -220,6 +248,7 @@ class AasdkSession(
     fun stop() {
         explicitStop = true
         OalLog.i(TAG, "Stopping aasdk session")
+        cancelPendingReconnect("explicit stop")
         _tcpConnector?.stop()
         _tcpConnector = null
         _usbConnectionManager?.stop()
@@ -243,6 +272,7 @@ class AasdkSession(
         // later — we're doing the restart ourselves immediately. Without this
         // both reconnects race and one fails with "Native session start failed".
         explicitStop = true
+        cancelPendingReconnect("force reconnect")
         _tcpConnector?.stop()
         _tcpConnector = null
         _usbConnectionManager?.stop()
@@ -319,6 +349,10 @@ class AasdkSession(
 
     override fun onSessionStarted() {
         OalLog.i(TAG, "AA session started (native)")
+        // Cancel any pending auto-reconnect timer: this session is now healthy,
+        // so a leftover retry from an earlier teardown must NOT fire and restart
+        // the transport underneath us (the deep-sleep reconnect-storm root cause).
+        cancelPendingReconnect("session started")
         consecutiveReconnectFailures = 0
         _reconnectAttempt.value = 0
         lastFailureWasProtocolError = false
@@ -349,34 +383,55 @@ class AasdkSession(
             explicitStop = true
         }
 
-        scope.launch {
-            _connectionState.value = ConnectionState.DISCONNECTED
-            _controlMessages.emit(ControlMessage.PhoneDisconnected(reason = reason))
+        // Auto-reconnect if this wasn't an explicit stop (e.g., car sleep/wake,
+        // phone disconnect). Restart the transport connector after a delay so it
+        // retries connecting once WiFi comes back.
+        //
+        // Single-flight: cancel any already-pending retry before arming a new
+        // one, and track this coroutine in [reconnectJob] so a later
+        // onSessionStarted() can cancel it. Without this, several rapid
+        // teardowns during a deep-sleep wake each armed an independent timer;
+        // leftover timers then restarted the transport on top of a healthy
+        // session → reconnect storm (0.1.363 log 2026-07-19).
+        if (!explicitStop) {
+            consecutiveReconnectFailures++
+            _reconnectAttempt.value = consecutiveReconnectFailures
 
-            // Auto-reconnect if this wasn't an explicit stop (e.g., car sleep/wake,
-            // phone disconnect). Restart the transport connector after a delay so it
-            // retries connecting once WiFi comes back.
-            if (!explicitStop) {
-                consecutiveReconnectFailures++
-                _reconnectAttempt.value = consecutiveReconnectFailures
+            // Exponential backoff: 3s base, longer if protocol error (phone
+            // needs time to tear down old SSL session). Cap at 30s.
+            val baseDelayMs = if (lastFailureWasProtocolError) 5000L else 3000L
+            val backoffMs = (baseDelayMs * (1L shl (consecutiveReconnectFailures - 1).coerceAtMost(3)))
+                .coerceAtMost(30_000L)
+            OalLog.i(TAG, "Session died unexpectedly — retry #$consecutiveReconnectFailures in ${backoffMs}ms" +
+                if (lastFailureWasProtocolError) " (protocol error, extended backoff)" else "")
+            lastFailureWasProtocolError = false
 
-                // Exponential backoff: 3s base, longer if protocol error (phone
-                // needs time to tear down old SSL session). Cap at 30s.
-                val baseDelayMs = if (lastFailureWasProtocolError) 5000L else 3000L
-                val backoffMs = (baseDelayMs * (1L shl (consecutiveReconnectFailures - 1).coerceAtMost(3)))
-                    .coerceAtMost(30_000L)
-                OalLog.i(TAG, "Session died unexpectedly — retry #$consecutiveReconnectFailures in ${backoffMs}ms" +
-                    if (lastFailureWasProtocolError) " (protocol error, extended backoff)" else "")
-                lastFailureWasProtocolError = false
+            cancelPendingReconnect("superseded by newer teardown")
+            val job = scope.launch {
+                _connectionState.value = ConnectionState.DISCONNECTED
+                _controlMessages.emit(ControlMessage.PhoneDisconnected(reason = reason))
 
                 kotlinx.coroutines.delay(backoffMs)
-                if (!explicitStop) {
+                // Guard: if a session already reconnected while we waited (the
+                // CONNECTED guard) or an explicit stop landed, do NOT restart —
+                // restarting would tear down a working session.
+                if (explicitStop) {
+                    OalLog.i(TAG, "Pending reconnect aborted (explicit stop)")
+                } else if (_connectionState.value == ConnectionState.CONNECTED) {
+                    OalLog.i(TAG, "Pending reconnect skipped (already CONNECTED)")
+                } else {
                     OalLog.i(TAG, "Restarting transport connector")
                     when (transportMode) {
                         "usb" -> startUsb()
                         else -> startTcp()
                     }
                 }
+            }
+            synchronized(reconnectLock) { reconnectJob = job }
+        } else {
+            scope.launch {
+                _connectionState.value = ConnectionState.DISCONNECTED
+                _controlMessages.emit(ControlMessage.PhoneDisconnected(reason = reason))
             }
         }
     }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
@@ -109,4 +109,13 @@ interface AasdkSessionCallback {
 
     /** Error from the native session. */
     fun onError(message: String)
+
+    /**
+     * Diagnostic log line emitted by the native session, routed into the
+     * triaged DiagnosticLog (uploaded via the maintainer log-upload feature).
+     * @param level 0=debug 1=info 2=warn 3=error
+     * @param tag DiagnosticLog tag (e.g. "vfocus", "video", "session")
+     * @param message the log message
+     */
+    fun onNativeLog(level: Int, tag: String, message: String)
 }


### PR DESCRIPTION
## Summary
Two car-side commits addressing the deep-sleep reconnect issues, verified with real drive logs.

### 1. Diagnostics (commit b4d52a02, shipped 0.1.363)
Logging-only, no behavior change. Closes three blind spots that made the deep-sleep black-video root cause unfalsifiable:
- **(A) frame-flow counter** — `AasdkSession.onVideoFrame` emits a `vflow` DiagnosticLog line every ~2s (or after a >1s starvation gap): `frames/idr/bytes/kbps + maxGap`. Distinguishes P-frames-flowing-but-no-IDR from encoder-silent.
- **(B) focus-protocol trace** — new native to Kotlin `onNativeLog` JNI bridge routes AA video-focus events (`vfocus`), VideoStart/Stop (`video`), teardown (`session`) into the triaged log.
- **(C)** `requestKeyframe()` logs that it is a protocol no-op.
- **(D)** `JniSession::stop()` logs that teardown closes the socket WITHOUT a ByeBye.

### 2. Reconnect-storm fix (commit f204f5af, shipped 0.1.364)
The diagnostics caught a self-inflicted reconnect storm after a 10-min deep-sleep gap: `vflow` proved the app streamed 10-16 Mbps flawlessly, yet a fully-connected session (real IDR, "First frame rendered 181ms") was torn down 2s later by a stale retry timer from an earlier dead session. Companion log showed a matching 4s cadence with NO "Blazing lost" -> not RF.

**Root cause:** `onSessionStopped` scheduled auto-reconnect in a fire-and-forget `scope.launch { delay(); startTcp() }` with no handle, so overlapping teardowns during the wake window each armed an independent timer; leftover timers restarted the transport on top of a healthy session.

**Fix:** single cancellable `reconnectJob` (single-flight); `onSessionStarted()` cancels any pending retry (a healthy session must not be killed by a stale timer); retry skips restart if already CONNECTED or explicit stop; `stop()`/`forceReconnect()` cancel pending retries too.

## Verification
- `:app:compileDebugKotlin` + `:app:externalNativeBuildDebug` BUILD SUCCESSFUL.
- Both builds shipped to Play `automotive:internal` (0.1.363, 0.1.364).
- Deep-sleep road-test still pending: expect one clean `AA session started` that stays up + `Cancelled pending reconnect` lines + `vflow` climbing to multi-Mbps.
