### PR TITLE
fix(companion): recover from mid-drive half-open freeze on unexpected bridge break

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -29,7 +29,17 @@ class AaProxy(
 ) {
     interface Listener {
         fun onConnected()
-        fun onDisconnected()
+        /**
+         * The bridge ended. [unexpected] is true when a live AA<->Car bridge
+         * broke on its own (gearhead closed its localhost socket, or a
+         * read/write failed) while the proxy was still running — i.e. NOT an
+         * intentional [stop]. The car TCP socket is then left half-open (no
+         * FIN/RST reaches the car because the WiFi L2 link is still up), so the
+         * car sits frozen until its ~9s ping-timeout. The handler should treat
+         * an unexpected break as a recovery trigger (close the car socket so the
+         * car gets a clean reset + reconnects, and relaunch AA).
+         */
+        fun onDisconnected(unexpected: Boolean)
     }
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -127,12 +137,18 @@ class AaProxy(
             } catch (e: Exception) {
                 CompanionLog.e(TAG, "Bridge error: ${e.message}")
             } finally {
-                CompanionLog.i(TAG, "Bridge closed")
+                // "Unexpected" = the bridge ended while we were still running
+                // (gearhead dropped its socket / a pump read or write failed),
+                // as opposed to an intentional stop() which flips isRunning
+                // false first. Only an unexpected break should trigger the
+                // car-socket-reset + AA relaunch recovery on the handler side.
+                val unexpected = isRunning
+                CompanionLog.i(TAG, "Bridge closed (unexpected=$unexpected)")
                 activeCarSocket = null
                 runCatching { aaSocket.close() }
                 // Don't close carSocket here — let the TcpAdvertiser manage it via cleanup()
                 if (activeBridges.decrementAndGet() <= 0) {
-                    listener?.onDisconnected()
+                    listener?.onDisconnected(unexpected)
                 }
             }
         }

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -176,8 +176,8 @@ class TcpAdvertiser(
                             aaLaunchAttempts = 0
                             stateListener.onProxyConnected()
                         }
-                        override fun onDisconnected() {
-                            CompanionLog.i(TAG, "Warm proxy disconnected")
+                        override fun onDisconnected(unexpected: Boolean) {
+                            CompanionLog.i(TAG, "Warm proxy disconnected (unexpected=$unexpected)")
                             stateListener.onProxyDisconnected()
                             isLaunching = false
                         }
@@ -378,11 +378,29 @@ class TcpAdvertiser(
                             stateListener.onProxyConnected()
                         }
 
-                        override fun onDisconnected() {
-                            CompanionLog.i(TAG, "AA TCP proxy disconnected")
+                        override fun onDisconnected(unexpected: Boolean) {
+                            CompanionLog.i(TAG, "AA TCP proxy disconnected (unexpected=$unexpected)")
                             stateListener.onProxyDisconnected()
                             // Re-accept next connection
                             isLaunching = false
+                            // Root-cause recovery for the mid-drive freeze: when
+                            // gearhead drops its localhost socket mid-session the
+                            // car TCP socket is left half-open and the car sits
+                            // frozen until its ~9s ping-timeout. Proactively (a)
+                            // close the car socket so the car gets a clean reset
+                            // and its single-flight reconnect fires immediately,
+                            // and (b) re-fire the AA launch so the phone rebuilds
+                            // the bridge as soon as the car reconnects. Only on an
+                            // UNEXPECTED break (not an intentional stop / user exit
+                            // / car-driven reconnect, which manage the socket
+                            // themselves).
+                            if (unexpected && isRunning) {
+                                CompanionLog.i(TAG,
+                                    "Unexpected bridge break — resetting car socket + relaunching AA")
+                                activeCarSocket?.let { runCatching { it.close() } }
+                                activeCarSocket = null
+                                activeProxy?.localPort?.takeIf { it > 0 }?.let { fireAaLaunchIntent(it) }
+                            }
                         }
                     },
                 )


### PR DESCRIPTION
## Summary
Phone-side root-cause fix for the mid-drive freeze. Recovers from an unexpected AA bridge break instead of leaving the car TCP socket half-open. Companion module only; compiles clean.

## Root cause (0.1.364/365 investigation, log 2026-07-20)
A flawless 15.5-min bridge (08:15:43→08:31:21) ended with the phone proxy logging `Car->AA error: Broken pipe`. That error is from `AaProxy.pump(carIn, aaOut, "Car->AA")` — the write to **aaOut, the LOCAL gearhead socket**, failed. So **Google's Android Auto app closed its own localhost socket** (the upstream trigger — not our code; gearhead's reason isn't in our filtered logcat).

The bug is what we did next: **nothing.** `AaProxy.launchBridge`'s finally deliberately leaves the car socket open (comment: "let the TcpAdvertiser manage it via cleanup()"), and `TcpAdvertiser.onDisconnected` only logged + set `isLaunching=false`. **There is no `cleanup()`.** So the car TCP socket was left **half-open** — still ESTABLISHED, no FIN/RST because the Wi-Fi L2 link stays up — and the car sat frozen until its ~9s native ping-timeout, with the phone app showing disconnected. Exactly the reported symptom.

## Fix
- `AaProxy.Listener.onDisconnected` now carries `unexpected: Boolean` (= `isRunning` at break time: true when the bridge broke on its own, false during an intentional `stop()`).
- On an **unexpected** break, `TcpAdvertiser.onDisconnected` now:
  1. closes `activeCarSocket` → the car gets a clean reset and its 0.1.364 single-flight reconnect fires immediately (no 9s wait), and
  2. re-fires the AA launch intent so the phone actively rebuilds the bridge.
- Intentional stop / user-exit / car-driven reconnect paths are unaffected (`unexpected=false`, or they already manage the socket).

## Relationship to 0.1.365
The car-side frame-arrival watchdog (#53, 0.1.365) recovers from the **car** end; this removes the cause on the **phone** end. Together: phone actively re-bridges AND the car self-heals if anything is still missed.

## Verification
- `:companion:compileDebugKotlin` BUILD SUCCESSFUL.
- Phone app ships via the GitHub release workflow (not the Play aab flow).
- Road-test pending: on the next gearhead mid-session drop, expect companion `Bridge closed (unexpected=true)` → `Unexpected bridge break — resetting car socket + relaunching AA`, and a fast car reconnect instead of a frozen screen.
