### PR TITLE
feat(companion): maintainer verbose-logcat toggle to capture gearhead logs

### DIFF
--- a/companion/src/main/AndroidManifest.xml
+++ b/companion/src/main/AndroidManifest.xml
@@ -30,6 +30,14 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+    <!-- Maintainer verbose logcat capture: READ_LOGS is a signature/privileged
+         permission a normal app cannot be granted at runtime. Declared here so a
+         maintainer can grant it once via ADB
+         (`adb shell pm grant com.openautolink.companion android.permission.READ_LOGS`)
+         to let the "Verbose logcat" toggle capture other apps' logs (gearhead).
+         Without the grant, capture still works but only sees our own process. -->
+    <uses-permission android:name="android.permission.READ_LOGS"
+        tools:ignore="ProtectedPermissions" />
 
     <application
         android:allowBackup="true"

--- a/companion/src/main/java/com/openautolink/companion/MainActivity.kt
+++ b/companion/src/main/java/com/openautolink/companion/MainActivity.kt
@@ -167,6 +167,15 @@ object CompanionPrefs {
     const val LOG_PERSIST_ENABLED = "log_persist_enabled"
     const val DEFAULT_LOG_PERSIST_ENABLED = false
 
+    // Maintainer-only "verbose logcat capture" mode. OFF by default. When OFF,
+    // logcat capture is filtered to OAL/WiFi tags (`*:S`), which is compact but
+    // CANNOT see why Google's AA app (gearhead) drops a session. When ON, the
+    // capture is UNFILTERED (all tags, all processes) so gearhead's own teardown
+    // reason is recorded — used to diagnose the mid-drive freeze root cause. The
+    // log is larger, so this is a deliberate maintainer opt-in, not a default.
+    const val LOG_VERBOSE_CAPTURE = "log_verbose_capture"
+    const val DEFAULT_LOG_VERBOSE_CAPTURE = false
+
     /**
      * Returns the persistent phone UUID, generating one on first call.
      */

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/CompanionFileLogger.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/CompanionFileLogger.kt
@@ -152,21 +152,43 @@ class CompanionFileLogger(private val context: Context) {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         logcatScope = scope
 
+        // Maintainer verbose-capture toggle: when ON, capture ALL logcat
+        // (every tag, every process) so Google's AA app (gearhead) teardown
+        // reason is recorded — needed to diagnose why it drops mid-session.
+        // When OFF (default), filter to OAL/WiFi tags for a compact log.
+        val verbose = try {
+            context.getSharedPreferences(
+                com.openautolink.companion.CompanionPrefs.NAME, Context.MODE_PRIVATE
+            ).getBoolean(
+                com.openautolink.companion.CompanionPrefs.LOG_VERBOSE_CAPTURE,
+                com.openautolink.companion.CompanionPrefs.DEFAULT_LOG_VERBOSE_CAPTURE
+            )
+        } catch (_: Exception) { false }
+
+        val logcatCmd = if (verbose) {
+            // Unfiltered: all tags at debug+ across the whole device. Larger,
+            // but the only way to see gearhead's own logs.
+            arrayOf("logcat", "-v", "threadtime", "*:D")
+        } else {
+            arrayOf(
+                "logcat", "-v", "threadtime",
+                // Filter to our tags + system WiFi/connectivity
+                "OAL_Service:V", "OAL_TcpAdv:V",
+                "OAL_Proxy:V", "OAL_BtAutoStart:V", "OAL_WifiJob:V",
+                "OAL_WifiRx:V", "OAL_Trigger:V", "OAL_FileLog:V",
+                "WifiStateMachine:I", "ConnectivityService:I",
+                "NetworkAgent:I", "WifiManager:I",
+                "*:S" // silence everything else
+            )
+        }
+
         scope.launch {
             try {
                 // Clear logcat buffer first, then stream new lines
                 Runtime.getRuntime().exec(arrayOf("logcat", "-c")).waitFor()
+                Log.i(TAG, "Logcat capture starting (verbose=$verbose)")
 
-                val process = Runtime.getRuntime().exec(arrayOf(
-                    "logcat", "-v", "threadtime",
-                    // Filter to our tags + system WiFi/connectivity
-                    "OAL_Service:V", "OAL_TcpAdv:V",
-                    "OAL_Proxy:V", "OAL_BtAutoStart:V", "OAL_WifiJob:V",
-                    "OAL_WifiRx:V", "OAL_Trigger:V", "OAL_FileLog:V",
-                    "WifiStateMachine:I", "ConnectivityService:I",
-                    "NetworkAgent:I", "WifiManager:I",
-                    "*:S" // silence everything else
-                ))
+                val process = Runtime.getRuntime().exec(logcatCmd)
                 logcatProcess = process
 
                 val lcWriter = BufferedWriter(

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -1426,6 +1426,54 @@ private fun FileLoggingSection() {
                     color = OalGreen,
                 )
             }
+
+            // ── Verbose logcat capture (maintainer) ─────────────────────
+            // Default capture is filtered to OAL/WiFi tags, which can't show
+            // WHY Google's AA app (gearhead) drops a session. This opt-in
+            // captures ALL logcat so gearhead's own teardown reason is
+            // recorded. Takes effect on the NEXT logging session (toggle
+            // file logging off/on, or reconnect, to apply).
+            var verboseCapture by remember {
+                mutableStateOf(
+                    logPrefs.getBoolean(
+                        CompanionPrefs.LOG_VERBOSE_CAPTURE,
+                        CompanionPrefs.DEFAULT_LOG_VERBOSE_CAPTURE,
+                    )
+                )
+            }
+            Spacer(Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Verbose logcat (maintainer)",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Switch(
+                    checked = verboseCapture,
+                    onCheckedChange = { on ->
+                        verboseCapture = on
+                        logPrefs.edit().putBoolean(CompanionPrefs.LOG_VERBOSE_CAPTURE, on).apply()
+                    },
+                )
+            }
+            if (verboseCapture) {
+                Text(
+                    text = "Captures ALL device logcat (including Google's Android Auto " +
+                        "app) so we can see why it drops mid-session. Larger logs. " +
+                        "Applies to the next logging session — toggle file logging " +
+                        "off then on, or reconnect, to start a fresh verbose capture.\n\n" +
+                        "One-time setup (to see OTHER apps' logs, not just ours): grant " +
+                        "READ_LOGS via ADB —\n" +
+                        "adb shell pm grant com.openautolink.companion android.permission.READ_LOGS\n" +
+                        "then reboot the phone. Without it, capture still runs but only " +
+                        "records this app's own process.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = OalGreen,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Adds a maintainer-only **Verbose logcat** toggle to the companion (phone) app so we can finally capture *why* Google's Android Auto app (gearhead) drops a session mid-drive.

## Why
The mid-drive freeze is triggered by gearhead closing its own localhost socket (confirmed in the 0.1.364/365 investigation). We can now *recover* from it (v0.1.366 phone fix + 0.1.365 car watchdog — both confirmed working in the 2026-07-20 16:xx logs), but we still don't know the upstream cause, because the companion's logcat capture is filtered to OAL/WiFi tags (`*:S`) and can't see gearhead's own logs.

## Change
- New pref `CompanionPrefs.LOG_VERBOSE_CAPTURE` (off by default).
- `CompanionFileLogger.startLogcatCapture` reads it: **ON** → unfiltered `logcat -v threadtime *:D` (all tags/processes incl. gearhead); **OFF** → the existing tag-filtered command.
- UI toggle "Verbose logcat (maintainer)" in MainScreen, right beside "Always log", with help text. Applies to the next logging session.
- Manifest declares `READ_LOGS` (with `tools:ignore="ProtectedPermissions"`).

## Important: READ_LOGS is a privileged permission
A normal app can't be granted `READ_LOGS` at runtime, so capturing *other apps'* logs needs a one-time ADB grant:
```
adb shell pm grant com.openautolink.companion android.permission.READ_LOGS
```
then reboot the phone. Without it, verbose capture still runs but only records our own process (graceful degradation). The toggle's help text spells this out.

## Verification
- `:companion:compileDebugKotlin` BUILD SUCCESSFUL (manifest merge clean).
- Fully gated behind the maintainer toggle — no effect on normal users.
- Ships via the GitHub release workflow (companion APK).
