### PR TITLE
fix(companion): stop tearing down the warm proxy AA is already reading

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -48,19 +48,49 @@ class AaProxy(
     private val activeBridges = AtomicInteger(0)
     private var bridgeUsed = false
 
-    /** Returns true if at least one AA bridge is active (AA connected and streaming). */
-    fun hasActiveBridge(): Boolean = activeBridges.get() > 0
+    /**
+     * Bridges that are actually PUMPING (car socket acquired, both pipes wired up).
+     *
+     * Distinct from [activeBridges] on purpose. `activeBridges` is incremented the
+     * instant the bridge coroutine starts — which, on the pre-warm path, happens
+     * while we are still *waiting* for the car to show up (see
+     * [awaitPendingCarSocket]). Treating that window as "active" made
+     * [hasActiveBridge] return true before any data could possibly flow, which sent
+     * TcpAdvertiser.handleCarConnection() down its destructive branch: stop() the
+     * proxy and re-listen on a NEW port, tearing the socket out from under the AA
+     * reader that was already attached. gearhead then logged
+     * `ReaderThread: end of stream received, dataReceived=false` ->
+     * FRAMER_READ_END_OF_STREAM_NO_DATA -> PROTOCOL_IO_ERROR(3)/READER_CLOSE(52),
+     * and OAL relaunched AA on the new port, producing the reconnect storm
+     * (confirmed by live adb capture 2026-07-25 13:56).
+     */
+    private val pumpingBridges = AtomicInteger(0)
+
+    /**
+     * True only when a bridge is genuinely pumping bytes.
+     *
+     * Callers use this to decide whether a newly-arrived car socket can be swapped
+     * into the existing (still-warm) proxy instead of destroying it. During the
+     * pre-warm wait this MUST report false so the car socket is handed to the
+     * waiting bridge via [updateCarSocket] rather than triggering a rebind.
+     */
+    fun hasActiveBridge(): Boolean = pumpingBridges.get() > 0
+
+    /** True if a bridge coroutine exists at all, including one still awaiting a car socket. */
+    fun hasPendingBridge(): Boolean = activeBridges.get() > 0
 
     @Volatile private var pendingCarSocket: Socket? = null
 
     /**
      * Replace the car-side socket used for the next bridge session.
-     * Safe to call while waiting for AA to connect (no active bridge).
-     * If a bridge is already active this is a no-op — the active session
-     * owns its socket until it completes.
+     * Safe to call while waiting for AA to connect (no active bridge), and also
+     * while a pre-warm bridge is parked in [awaitPendingCarSocket] — that is
+     * exactly how the car socket reaches a bridge that AA attached to first.
+     * If a bridge is already PUMPING this is a no-op — the live session owns its
+     * socket until it completes.
      */
     fun updateCarSocket(newCarSocket: Socket) {
-        if (activeBridges.get() > 0) return  // active bridge owns its socket
+        if (pumpingBridges.get() > 0) return  // live bridge owns its socket
         pendingCarSocket = newCarSocket
         CompanionLog.d(TAG, "Car socket updated (pending AA connect)")
     }
@@ -95,6 +125,7 @@ class AaProxy(
     private fun launchBridge(aaSocket: Socket) {
         scope.launch {
             var carSocket: Socket? = null
+            var counted = false
             try {
                 activeBridges.incrementAndGet()
                 listener?.onConnected()
@@ -106,6 +137,13 @@ class AaProxy(
                 // came up before the car ignition's WiFi finished), no socket
                 // exists yet — wait briefly for one to arrive via
                 // updateCarSocket() rather than failing immediately.
+                //
+                // NOTE: pumpingBridges is deliberately NOT incremented until the
+                // car socket is in hand. While parked in awaitPendingCarSocket()
+                // this proxy must still look "not active" so an arriving car
+                // socket is swapped in here instead of causing TcpAdvertiser to
+                // stop() us and rebind on a fresh port (which would EOF the AA
+                // reader already attached above).
                 carSocket = pendingCarSocket?.also { pendingCarSocket = null }
                     ?: preConnectedSocket
                     ?: awaitPendingCarSocket(PREWARM_CAR_WAIT_MS)
@@ -113,6 +151,8 @@ class AaProxy(
                         "No car socket within ${PREWARM_CAR_WAIT_MS}ms — AA connected but no car ready"
                     )
                 activeCarSocket = carSocket
+                pumpingBridges.incrementAndGet()
+                counted = true
 
                 CompanionLog.i(TAG, "Bridge established: AA <-> Car")
 
@@ -129,6 +169,7 @@ class AaProxy(
             } finally {
                 CompanionLog.i(TAG, "Bridge closed")
                 activeCarSocket = null
+                if (counted) pumpingBridges.decrementAndGet()
                 runCatching { aaSocket.close() }
                 // Don't close carSocket here — let the TcpAdvertiser manage it via cleanup()
                 if (activeBridges.decrementAndGet() <= 0) {

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -339,12 +339,24 @@ class TcpAdvertiser(
         // point for the pre-warm path: a proxy created by preWarmAaPipeline()
         // has no car socket yet, and lands here when the car finally arrives.
         if (proxy != null && !proxy.hasActiveBridge()) {
-            CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
+            // hasActiveBridge() is false both when AA hasn't connected yet AND
+            // when a pre-warm bridge is parked waiting for exactly this socket.
+            // Distinguish them in the log so the pre-warm race is visible.
+            if (proxy.hasPendingBridge()) {
+                CompanionLog.i(TAG, "Car connection handed to pre-warmed AA bridge on port ${proxy.localPort}")
+            } else {
+                CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
+            }
             activeCarSocket?.let { runCatching { it.close() } }
             activeCarSocket = carSocket
             proxy.updateCarSocket(carSocket)
-            // Re-fire the trigger in case AA missed the previous one
-            fireAaLaunchIntent(proxy.localPort)
+            // Re-fire the trigger only if AA has NOT already attached. Re-firing
+            // at a bridge that is mid-handshake makes gearhead obsolete its own
+            // session (SESSION_OBSOLETE_DUE_TO_NEW_CONNECTION) and starts the
+            // relaunch storm.
+            if (!proxy.hasPendingBridge()) {
+                fireAaLaunchIntent(proxy.localPort)
+            }
             // Reset the watchdog with the full budget
             startAaConnectWatchdog(carSocket)
             return


### PR DESCRIPTION
## Summary

Projection could fail to start at all — the AA↔Car bridge came up and was torn down repeatedly, never yielding a video keyframe. Root-caused with a live `adb` capture that put OAL's logs and Google's gearhead logs on **one timeline**.

**OAL was closing the socket Android Auto was already reading.**

## Root cause

`launchBridge()` incremented `activeBridges` the instant the bridge coroutine started — including while parked in `awaitPendingCarSocket()` waiting for the car to arrive. `hasActiveBridge()` therefore returned `true` before a single byte could flow.

So when the car finally connected, `TcpAdvertiser.handleCarConnection()` saw "bridge already active", skipped its socket-swap path, and took the destructive branch: `activeProxy.stop()` + re-listen on a **new port** — destroying the socket gearhead had already attached to.

The swap path already existed. It was just unreachable in this ordering.

## Evidence

Unified capture, 2026-07-25 13:56 (`622,557` lines):

```
13:56:33.092  OAL_Proxy: Android Auto connected to proxy
13:56:33.095  OAL_Proxy: AA connected first (pre-warm) — waiting up to 30000ms for car
13:56:35.737  OAL_TcpAdv: Car connected from 10.129.186.188
13:56:35.742  OAL_Proxy: Proxy server stopped: Socket closed      <-- OAL kills the warm proxy
13:56:35.743  OAL_Proxy: Proxy listening on localhost:40923       <-- rebinds, NEW port
13:56:35.744  OAL_Proxy: Bridge closed (unexpected=false)         <-- deliberate
```
```
13:56:35.745  CAR.GAL: ReaderThread: end of stream received, dataReceived=false
13:56:35.749  GH.ConnLoggerV2: FRAMER_READ_END_OF_STREAM_NO_DATA
              -> ProjectionErrorCode = PROTOCOL_IO_ERROR(3) / READER_CLOSE(52)
```

`120x` `FRAMER_READ_END_OF_STREAM_NO_DATA` vs only `16` successful GAL negotiations in one 60s capture.

Car side agrees (`AASDK Error: 30`, `channel-error escalation (5 errors in 2s)`).

## Why it was intermittent

It's a **race**. It only bites when AA attaches to the warm proxy *before* the car connects (`"AA connected first (pre-warm)"`). Car-first ordering builds the bridge once on a stable port and works — which is why 2026-07-20 was healthy on the *same* gearhead 17.3.662814 build (installed 2026-07-16).

## Changes

**`AaProxy.kt`**
- New `pumpingBridges` counter, incremented **only after** a car socket is in hand
- `hasActiveBridge()` now reflects genuinely-pumping bridges
- `updateCarSocket()` gates on `pumpingBridges`, so a car socket arriving mid-pre-warm is handed to the waiting bridge instead of refused
- New `hasPendingBridge()`

**`TcpAdvertiser.kt`**
- Suppress the redundant `fireAaLaunchIntent()` when AA is already attached — re-firing mid-handshake is what produced `SESSION_OBSOLETE_DUE_TO_NEW_CONNECTION(1001)`
- Distinct log line for the pre-warm path so this race stays visible

## Ruled out

- ❌ AA 17.3 gating flags — all still default `false` (`startup_proxy_signature_check_enabled`, `car_display_binder_assert_first_party`, `tls_auth_bypass_fix`)
- ❌ TLS / first-party rejection — `SSL_SUCCESS`, `CarInfo authorization: ALLOWED`, GAL `jaf[1,7] STATUS_SUCCESS`
- ❌ Car AP / IPv6 (#48) — reproduced on phone-hotspot at `10.129.186.31`
- ❌ `CAR.AUTH uid 10123 not allowed` — benign soft probe for optional `pctsverifier`/`galmonitor` components; the fatal check uses a different allowlist that *does* contain gearhead

## Test plan

- [x] `./gradlew :companion:compileDebugKotlin --rerun-tasks` → BUILD SUCCESSFUL
- [x] Car-first path unchanged (`preConnectedSocket` taken before any wait)
- [ ] **Road test**: expect `"Car connection handed to pre-warmed AA bridge on port N"`, port stays constant, no `Proxy server stopped`, no `FRAMER_READ_END_OF_STREAM_NO_DATA`

## Residual risk

`PREWARM_CAR_WAIT_MS` (30s) unchanged — if the car never arrives the bridge still fails after 30s, but now without destroying the listener. Bridge-break retry cadence untouched; should be far less reachable, but not fixed on its own merits.