### PR TITLE
Revert "fix(companion): stop tearing down the warm proxy AA is already reading" (#57)

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -58,49 +58,19 @@ class AaProxy(
     private val activeBridges = AtomicInteger(0)
     private var bridgeUsed = false
 
-    /**
-     * Bridges that are actually PUMPING (car socket acquired, both pipes wired up).
-     *
-     * Distinct from [activeBridges] on purpose. `activeBridges` is incremented the
-     * instant the bridge coroutine starts — which, on the pre-warm path, happens
-     * while we are still *waiting* for the car to show up (see
-     * [awaitPendingCarSocket]). Treating that window as "active" made
-     * [hasActiveBridge] return true before any data could possibly flow, which sent
-     * TcpAdvertiser.handleCarConnection() down its destructive branch: stop() the
-     * proxy and re-listen on a NEW port, tearing the socket out from under the AA
-     * reader that was already attached. gearhead then logged
-     * `ReaderThread: end of stream received, dataReceived=false` ->
-     * FRAMER_READ_END_OF_STREAM_NO_DATA -> PROTOCOL_IO_ERROR(3)/READER_CLOSE(52),
-     * and OAL relaunched AA on the new port, producing the reconnect storm
-     * (confirmed by live adb capture 2026-07-25 13:56).
-     */
-    private val pumpingBridges = AtomicInteger(0)
-
-    /**
-     * True only when a bridge is genuinely pumping bytes.
-     *
-     * Callers use this to decide whether a newly-arrived car socket can be swapped
-     * into the existing (still-warm) proxy instead of destroying it. During the
-     * pre-warm wait this MUST report false so the car socket is handed to the
-     * waiting bridge via [updateCarSocket] rather than triggering a rebind.
-     */
-    fun hasActiveBridge(): Boolean = pumpingBridges.get() > 0
-
-    /** True if a bridge coroutine exists at all, including one still awaiting a car socket. */
-    fun hasPendingBridge(): Boolean = activeBridges.get() > 0
+    /** Returns true if at least one AA bridge is active (AA connected and streaming). */
+    fun hasActiveBridge(): Boolean = activeBridges.get() > 0
 
     @Volatile private var pendingCarSocket: Socket? = null
 
     /**
      * Replace the car-side socket used for the next bridge session.
-     * Safe to call while waiting for AA to connect (no active bridge), and also
-     * while a pre-warm bridge is parked in [awaitPendingCarSocket] — that is
-     * exactly how the car socket reaches a bridge that AA attached to first.
-     * If a bridge is already PUMPING this is a no-op — the live session owns its
-     * socket until it completes.
+     * Safe to call while waiting for AA to connect (no active bridge).
+     * If a bridge is already active this is a no-op — the active session
+     * owns its socket until it completes.
      */
     fun updateCarSocket(newCarSocket: Socket) {
-        if (pumpingBridges.get() > 0) return  // live bridge owns its socket
+        if (activeBridges.get() > 0) return  // active bridge owns its socket
         pendingCarSocket = newCarSocket
         CompanionLog.d(TAG, "Car socket updated (pending AA connect)")
     }
@@ -135,7 +105,6 @@ class AaProxy(
     private fun launchBridge(aaSocket: Socket) {
         scope.launch {
             var carSocket: Socket? = null
-            var counted = false
             try {
                 activeBridges.incrementAndGet()
                 listener?.onConnected()
@@ -147,13 +116,6 @@ class AaProxy(
                 // came up before the car ignition's WiFi finished), no socket
                 // exists yet — wait briefly for one to arrive via
                 // updateCarSocket() rather than failing immediately.
-                //
-                // NOTE: pumpingBridges is deliberately NOT incremented until the
-                // car socket is in hand. While parked in awaitPendingCarSocket()
-                // this proxy must still look "not active" so an arriving car
-                // socket is swapped in here instead of causing TcpAdvertiser to
-                // stop() us and rebind on a fresh port (which would EOF the AA
-                // reader already attached above).
                 carSocket = pendingCarSocket?.also { pendingCarSocket = null }
                     ?: preConnectedSocket
                     ?: awaitPendingCarSocket(PREWARM_CAR_WAIT_MS)
@@ -161,8 +123,6 @@ class AaProxy(
                         "No car socket within ${PREWARM_CAR_WAIT_MS}ms — AA connected but no car ready"
                     )
                 activeCarSocket = carSocket
-                pumpingBridges.incrementAndGet()
-                counted = true
 
                 CompanionLog.i(TAG, "Bridge established: AA <-> Car")
 
@@ -185,7 +145,6 @@ class AaProxy(
                 val unexpected = isRunning
                 CompanionLog.i(TAG, "Bridge closed (unexpected=$unexpected)")
                 activeCarSocket = null
-                if (counted) pumpingBridges.decrementAndGet()
                 runCatching { aaSocket.close() }
                 // Don't close carSocket here — let the TcpAdvertiser manage it via cleanup()
                 if (activeBridges.decrementAndGet() <= 0) {

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -339,24 +339,12 @@ class TcpAdvertiser(
         // point for the pre-warm path: a proxy created by preWarmAaPipeline()
         // has no car socket yet, and lands here when the car finally arrives.
         if (proxy != null && !proxy.hasActiveBridge()) {
-            // hasActiveBridge() is false both when AA hasn't connected yet AND
-            // when a pre-warm bridge is parked waiting for exactly this socket.
-            // Distinguish them in the log so the pre-warm race is visible.
-            if (proxy.hasPendingBridge()) {
-                CompanionLog.i(TAG, "Car connection handed to pre-warmed AA bridge on port ${proxy.localPort}")
-            } else {
-                CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
-            }
+            CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
             activeCarSocket?.let { runCatching { it.close() } }
             activeCarSocket = carSocket
             proxy.updateCarSocket(carSocket)
-            // Re-fire the trigger only if AA has NOT already attached. Re-firing
-            // at a bridge that is mid-handshake makes gearhead obsolete its own
-            // session (SESSION_OBSOLETE_DUE_TO_NEW_CONNECTION) and starts the
-            // relaunch storm.
-            if (!proxy.hasPendingBridge()) {
-                fireAaLaunchIntent(proxy.localPort)
-            }
+            // Re-fire the trigger in case AA missed the previous one
+            fireAaLaunchIntent(proxy.localPort)
             // Reset the watchdog with the full budget
             startAaConnectWatchdog(carSocket)
             return


### PR DESCRIPTION
## Reverts #57 (v0.1.368)

**Reason: the fix in #57 traded one failure mode for a worse one.** Runtime testing on the real car showed projection went from "reconnect storm that sometimes produced a picture" to **no stream at all**.

### What #57 got right

The diagnosis was correct and the regression it targeted is genuinely fixed:
- `Proxy server stopped: Socket closed` — **0 occurrences**
- Proxy port stayed **constant** (35509) instead of rebinding
- `AASDK Error: 30` — **0** in that session (pre-fix session had 4)
- New path confirmed running: `Car connection handed to pre-warmed AA bridge on port 35509`

### What it broke

Making the listener persistent (the right goal) exposed a socket-lifecycle bug. `pendingCarSocket` is consumed destructively — bridge #1 takes it and nulls it. Any **later** AA connection to the now-surviving proxy finds no car socket, parks for 30s, fails, and repeats forever:

```
14:28:47.088  Car connection handed to pre-warmed AA bridge on port 35509
14:28:47.126  Bridge established: AA <-> Car
14:28:51.468  AA flowing through warm proxy          <-- a SECOND AA attaches
14:29:21.492  Bridge error: No car socket within 30000ms - AA connected but no car ready
14:29:51.783  Bridge error: No car socket within 30000ms
14:30:22.091  Bridge error: No car socket within 30000ms
              ...repeating every 30s
```

Car side, same window — TCP connects but the phone never answers the handshake:
```
14:29:03.669  Connected to companion at 10.129.186.31:5277
14:29:03.697  Sending version request (v1.7)...
14:29:18.683  Session abort: handshake timeout (15s, no SSL/version response)
```
Zero IDR, zero frames.

Frequency comparison, same day, same phone:

| Session | `No car socket within 30000ms` | Bridges established |
|---|---|---|
| 13:56 (pre-fix) | **0** | 416 |
| 14:26 (post-fix) | **5** | 2 |

Before #57 the proxy was destroyed and rebuilt on every car connection, which **accidentally** avoided this — each AA connection got a fresh proxy with a fresh socket. #57 kept one proxy alive across multiple AA attach attempts, but each car socket can only ever satisfy one bridge.

### Why revert rather than patch forward

The car app (`0.1.365`) independently has:
1. a **no-video / ping-timeout** problem, and
2. a **teardown deadlock** in `JniSession::stop()` (join on the io_service thread from a concurrent abort) that produces an ANR/tombstone

Debugging three interacting defects at once is not viable. Reverting restores a known baseline.

### Follow-up

The warm-proxy race is real and still worth fixing. The correct version must handle car-socket lifecycle across multiple AA attaches — e.g. return the still-open car socket to `pendingCarSocket` when a bridge ends, and stop AA re-attaching in a loop when no socket is available. That work should land with runtime verification that a session actually **streams**, not merely that the old error strings disappeared.

### Note on shipping

Android will not downgrade over an installed higher `versionCode`, so this ships as a **new** release (v0.1.369) containing the reverted code — reinstalling v0.1.367 will not work on a device already on v0.1.368.