### PR TITLE
fix(companion): keep the warm proxy AA is reading, with socket recycling

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -58,19 +58,38 @@ class AaProxy(
     private val activeBridges = AtomicInteger(0)
     private var bridgeUsed = false
 
-    /** Returns true if at least one AA bridge is active (AA connected and streaming). */
-    fun hasActiveBridge(): Boolean = activeBridges.get() > 0
+    /**
+     * Bridges that are actually PUMPING (car socket acquired, both pipes wired up).
+     *
+     * Deliberately distinct from [activeBridges], which is incremented the instant the
+     * bridge coroutine starts — including while it is parked in [awaitPendingCarSocket]
+     * waiting for the car. Reporting "active" during that wait made
+     * TcpAdvertiser.handleCarConnection() skip its socket-swap path and instead
+     * stop() the proxy and re-listen on a NEW port, tearing the socket out from under
+     * the AA reader that was already attached (gearhead: "ReaderThread: end of stream
+     * received, dataReceived=false" -> FRAMER_READ_END_OF_STREAM_NO_DATA ->
+     * PROTOCOL_IO_ERROR(3)/READER_CLOSE(52)). Observed 2026-07-25.
+     */
+    private val pumpingBridges = AtomicInteger(0)
+
+    /** True only when a bridge is genuinely relaying bytes. */
+    fun hasActiveBridge(): Boolean = pumpingBridges.get() > 0
+
+    /** True if a bridge coroutine exists at all, including one awaiting a car socket. */
+    fun hasPendingBridge(): Boolean = activeBridges.get() > 0
 
     @Volatile private var pendingCarSocket: Socket? = null
 
     /**
      * Replace the car-side socket used for the next bridge session.
-     * Safe to call while waiting for AA to connect (no active bridge).
-     * If a bridge is already active this is a no-op — the active session
-     * owns its socket until it completes.
+     *
+     * Safe while waiting for AA to connect, and also while a pre-warm bridge is parked
+     * in [awaitPendingCarSocket] — that is how the car socket reaches a bridge AA
+     * attached to first. A no-op while a bridge is actively PUMPING, since the live
+     * session owns its socket until it completes.
      */
     fun updateCarSocket(newCarSocket: Socket) {
-        if (activeBridges.get() > 0) return  // active bridge owns its socket
+        if (pumpingBridges.get() > 0) return  // live bridge owns its socket
         pendingCarSocket = newCarSocket
         CompanionLog.d(TAG, "Car socket updated (pending AA connect)")
     }
@@ -105,6 +124,7 @@ class AaProxy(
     private fun launchBridge(aaSocket: Socket) {
         scope.launch {
             var carSocket: Socket? = null
+            var counted = false
             try {
                 activeBridges.incrementAndGet()
                 listener?.onConnected()
@@ -116,6 +136,12 @@ class AaProxy(
                 // came up before the car ignition's WiFi finished), no socket
                 // exists yet — wait briefly for one to arrive via
                 // updateCarSocket() rather than failing immediately.
+                //
+                // pumpingBridges is deliberately NOT incremented until the car
+                // socket is in hand: while parked below this proxy must still
+                // report "not active" so an arriving car socket is swapped in
+                // here instead of causing TcpAdvertiser to stop() us and rebind
+                // on a fresh port (which would EOF the AA reader attached above).
                 carSocket = pendingCarSocket?.also { pendingCarSocket = null }
                     ?: preConnectedSocket
                     ?: awaitPendingCarSocket(PREWARM_CAR_WAIT_MS)
@@ -123,6 +149,8 @@ class AaProxy(
                         "No car socket within ${PREWARM_CAR_WAIT_MS}ms — AA connected but no car ready"
                     )
                 activeCarSocket = carSocket
+                pumpingBridges.incrementAndGet()
+                counted = true
 
                 CompanionLog.i(TAG, "Bridge established: AA <-> Car")
 
@@ -145,8 +173,27 @@ class AaProxy(
                 val unexpected = isRunning
                 CompanionLog.i(TAG, "Bridge closed (unexpected=$unexpected)")
                 activeCarSocket = null
+                if (counted) pumpingBridges.decrementAndGet()
                 runCatching { aaSocket.close() }
                 // Don't close carSocket here — let the TcpAdvertiser manage it via cleanup()
+                //
+                // CRITICAL (this is what broke v0.1.368): the car socket is taken out of
+                // pendingCarSocket destructively above. If this bridge never actually
+                // pumped — AA attached, took the socket, then went away before/while the
+                // bridge was set up — the socket must go BACK into the pool. Otherwise the
+                // proxy survives (correctly) but every LATER AA attach finds no car socket,
+                // parks for PREWARM_CAR_WAIT_MS and dies with "No car socket within 30000ms",
+                // repeating forever. That livelock is why v0.1.368 shipped a phone that
+                // never streamed and had to be reverted in v0.1.369.
+                //
+                // Only recycle a socket that is still usable, and only when no other bridge
+                // is pumping (which would own it).
+                if (isRunning && pumpingBridges.get() == 0) {
+                    carSocket?.takeIf { !it.isClosed && it.isConnected }?.let {
+                        pendingCarSocket = it
+                        CompanionLog.i(TAG, "Car socket still live — returned to pool for next AA attach")
+                    }
+                }
                 if (activeBridges.decrementAndGet() <= 0) {
                     listener?.onDisconnected(unexpected)
                 }

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -364,12 +364,24 @@ class TcpAdvertiser(
         // point for the pre-warm path: a proxy created by preWarmAaPipeline()
         // has no car socket yet, and lands here when the car finally arrives.
         if (proxy != null && !proxy.hasActiveBridge()) {
-            CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
+            // hasActiveBridge() is false BOTH when AA hasn't connected yet AND when a
+            // pre-warm bridge is parked waiting for exactly this socket. Distinguish
+            // them so the pre-warm race stays visible in logs.
+            val prewarmWaiting = proxy.hasPendingBridge()
+            if (prewarmWaiting) {
+                CompanionLog.i(TAG, "Car connection handed to pre-warmed AA bridge on port ${proxy.localPort}")
+            } else {
+                CompanionLog.i(TAG, "Car connection landing on warm proxy on port ${proxy.localPort}")
+            }
             activeCarSocket?.let { runCatching { it.close() } }
             activeCarSocket = carSocket
             proxy.updateCarSocket(carSocket)
-            // Re-fire the trigger in case AA missed the previous one
-            fireAaLaunchIntent(proxy.localPort)
+            // Re-fire the launch intent ONLY if AA has not already attached. Re-firing at
+            // a bridge that is mid-handshake makes gearhead obsolete its own session
+            // (SESSION_OBSOLETE_DUE_TO_NEW_CONNECTION) and starts the relaunch storm.
+            if (!prewarmWaiting) {
+                fireAaLaunchIntent(proxy.localPort)
+            }
             // Reset the watchdog with the full budget
             startAaConnectWatchdog(carSocket)
             return


### PR DESCRIPTION
## Second attempt at the warm-proxy pre-warm race

The first attempt (#57 / v0.1.368) fixed the race but introduced a **livelock** and was reverted in v0.1.369. This version adds the car-socket lifecycle handling that attempt was missing.

## The race (diagnosis unchanged)

`launchBridge()` incremented `activeBridges` the instant the coroutine started — including while parked in `awaitPendingCarSocket()` waiting for the car. So `hasActiveBridge()` returned `true` before a byte could flow, and when the car connected, `handleCarConnection()` skipped its socket-swap path and took the destructive branch: `stop()` + re-listen on a **new port**, destroying the socket gearhead was already reading.

```
13:56:33.092  OAL_Proxy: Android Auto connected to proxy
13:56:33.095  OAL_Proxy: AA connected first (pre-warm) — waiting up to 30000ms
13:56:35.737  OAL_TcpAdv: Car connected from 10.129.186.188
13:56:35.742  OAL_Proxy: Proxy server stopped: Socket closed      <-- the bug
13:56:35.743  OAL_Proxy: Proxy listening on localhost:40923       <-- NEW port
13:56:35.745  CAR.GAL:  ReaderThread: end of stream, dataReceived=false
13:56:35.749  GH.ConnLoggerV2: FRAMER_READ_END_OF_STREAM_NO_DATA
```

## Why v0.1.368 failed

`pendingCarSocket` is consumed **destructively**. Making the listener persistent (the correct goal) meant the first bridge took the socket and every *later* AA attach found none — parking for 30s, dying with `No car socket within 30000ms`, forever.

| Session | `No car socket` | `Bridge established` |
|---|---|---|
| 13:56 (pre-fix) | 0 | 416 |
| 14:26 (v0.1.368) | **5** | **2** |

TCP connected, no handshake, no video. Worse than the storm it replaced.

## Fix

- Track `pumpingBridges` separately from `activeBridges`; `hasActiveBridge()` now reflects only bridges actually relaying bytes.
- `updateCarSocket()` gates on `pumpingBridges`, so a socket arriving during the pre-warm wait is accepted.
- Add `hasPendingBridge()`; `handleCarConnection()` uses it to suppress the redundant AA launch intent when AA is already attached (re-firing mid-handshake is what produced `SESSION_OBSOLETE_DUE_TO_NEW_CONNECTION`).
- **NEW — the part v0.1.368 lacked:** when a bridge ends, return a still-live car socket to `pendingCarSocket` so subsequent AA attaches can use it. Guarded by `isRunning && pumpingBridges == 0` (never steal a live session's socket) and `!isClosed && isConnected` (never re-pool a dead one).

## Interaction with #59

If the car socket is genuinely dead it is **not** recycled — the waiting bridge times out once and the liveness check from #59 stops the relaunch loop rather than hot-looping.

## Test plan

- [x] `:companion:compileDebugKotlin --rerun-tasks` → BUILD SUCCESSFUL
- [x] Traced the exact v0.1.368 livelock sequence against the new code paths
- [ ] **Runtime** — required before merge: proxy port stays **constant**, no `Proxy server stopped` mid-attempt, no `No car socket within 30000ms` loop, and a real **~100KB+ IDR** with `codecActive=true`

This exact change regressed once already. Not merging until a capture shows video, not just quieter logs.