### PR TITLE
fix(sensors): answer SensorStartRequest with current state (#61)

### DIFF
--- a/app/src/main/cpp/jni_channel_handlers.cpp
+++ b/app/src/main/cpp/jni_channel_handlers.cpp
@@ -257,6 +257,13 @@ void JniSensorHandler::onSensorStartRequest(
     promise->then([]() {}, [this](const auto& e) { this->onChannelError(e); });
     channel_->sendSensorStartResponse(response, std::move(promise));
 
+    // Push current vehicle state for this sensor immediately. Gearhead defaults
+    // its driving-status restriction to FULLY_RESTRICTED(31) and only leaves
+    // that state once a real sample arrives (teardown: p000/rqd.java f65655d).
+    // A parked car generates no VHAL change events, so without this the phone
+    // stays restricted for the whole session — no Maps keyboard. Issue #61.
+    session_.notifySensorSubscribed(static_cast<int>(request.type()));
+
     channel_->receive(shared_from_this());
 }
 

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -216,6 +216,7 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     cbMethods_.onAudioFocusRequest = env->GetMethodID(cbClass, "onAudioFocusRequest", "(I)V");
     cbMethods_.onError = env->GetMethodID(cbClass, "onError", "(Ljava/lang/String;)V");
     cbMethods_.onNativeLog = env->GetMethodID(cbClass, "onNativeLog", "(ILjava/lang/String;Ljava/lang/String;)V");
+    cbMethods_.onSensorSubscribed = env->GetMethodID(cbClass, "onSensorSubscribed", "(I)V");
     env->DeleteLocalRef(cbClass);
 
     // Read SDR config from Kotlin
@@ -465,8 +466,20 @@ void JniSession::nativeDiag(int level, const char* tag, const std::string& msg)
     releaseEnv(attached);
 }
 
+void JniSession::notifySensorSubscribed(int sensorType)
+{
+    if (!cbMethods_.onSensorSubscribed || !callbackRef_) return;
+    bool attached;
+    JNIEnv* env = getEnv(attached);
+    if (env) {
+        env->CallVoidMethod(callbackRef_, cbMethods_.onSensorSubscribed,
+                            static_cast<jint>(sensorType));
+    }
+    releaseEnv(attached);
+}
+
 // ============================================================================
-// IControlServiceChannelEventHandler Ã¢â‚¬â€ AA handshake + session control
+// IControlServiceChannelEventHandler — AA handshake + session control
 // ============================================================================
 
 void JniSession::onVersionResponse(uint16_t majorCode, uint16_t minorCode,

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -302,6 +302,15 @@ public:
     void reportChannelError(const char* channelName, const aasdk::error::Error& e);
 
     /**
+     * Notify Kotlin that the phone subscribed to a sensor type, so the VHAL
+     * layer can push current state immediately. Gearhead treats a missing
+     * SENSOR_DRIVING_STATUS_DATA sample as FULLY_RESTRICTED(31) rather than
+     * unknown, so waiting for a VHAL change event leaves a parked car with no
+     * keyboard/voice input forever. See issue #61.
+     */
+    void notifySensorSubscribed(int sensorType);
+
+    /**
      * Force-stop the session asynchronously without joining ioThread (safe
      * to call from io thread). Notifies Kotlin via onSessionStopped, which
      * triggers the auto-reconnect path. Idempotent.
@@ -372,6 +381,7 @@ private:
         jmethodID onAudioFocusRequest = nullptr;
         jmethodID onError = nullptr;
         jmethodID onNativeLog = nullptr;
+        jmethodID onSensorSubscribed = nullptr;
     };
     CallbackMethods cbMethods_;
 };

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -80,6 +80,11 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         // App-side settings
         val DRIVE_SIDE = stringPreferencesKey("drive_side")
         val GPS_FORWARDING = booleanPreferencesKey("gps_forwarding")
+        // Force the phone to always see the car as parked. Off by default, in
+        // which case the real VHAL gear/driving state is forwarded as-is.
+        // Intended for bench/diagnostic use and for head units whose VHAL never
+        // reports a usable gear. See issue #61.
+        val ALWAYS_IN_PARK = booleanPreferencesKey("always_in_park")
         val CLUSTER_NAVIGATION = booleanPreferencesKey("cluster_navigation")
         val OVERLAY_STATS_BUTTON = booleanPreferencesKey("overlay_stats_button")
         val FILE_LOGGING_ENABLED = booleanPreferencesKey("file_logging_enabled")
@@ -225,6 +230,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_AA_DECODER_ADDITIONAL_DEPTH = 1
         const val DEFAULT_DRIVE_SIDE = "left"
         const val DEFAULT_GPS_FORWARDING = true
+        const val DEFAULT_ALWAYS_IN_PARK = false
         const val DEFAULT_CLUSTER_NAVIGATION = true
         const val DEFAULT_OVERLAY_STATS_BUTTON = true
         const val DEFAULT_FILE_LOGGING_ENABLED = false
@@ -406,6 +412,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val gpsForwarding: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[GPS_FORWARDING] ?: DEFAULT_GPS_FORWARDING
+    }
+
+    val alwaysInPark: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[ALWAYS_IN_PARK] ?: DEFAULT_ALWAYS_IN_PARK
     }
 
     val clusterNavigation: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -612,6 +622,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setGpsForwarding(enabled: Boolean) {
         dataStore.edit { it[GPS_FORWARDING] = enabled }
+    }
+
+    suspend fun setAlwaysInPark(enabled: Boolean) {
+        dataStore.edit { it[ALWAYS_IN_PARK] = enabled }
     }
 
     suspend fun setClusterNavigation(enabled: Boolean) {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -67,6 +67,14 @@ class SessionManager(
     companion object {
         private const val TAG = "SessionManager"
 
+        // aasdk SensorType ordinals (app/src/main/proto/oal/sensors.proto).
+        // Used to answer the phone's SensorStartRequest with current state.
+        private const val SENSOR_TYPE_SPEED = 3
+        private const val SENSOR_TYPE_PARKING_BRAKE = 7
+        private const val SENSOR_TYPE_GEAR = 8
+        private const val SENSOR_TYPE_NIGHT_MODE = 10
+        private const val SENSOR_TYPE_DRIVING_STATUS = 13
+
         // Activity-sourced UI-mode snapshot that can be published before
         // SessionManager exists (ViewModel lazy creation path).
         @Volatile
@@ -354,6 +362,12 @@ class SessionManager(
     @Volatile private var lastSentNightMode: Boolean? = null
     @Volatile private var lastSentParkingBrake: Boolean? = null
     @Volatile private var lastSentDriving: Boolean? = null
+    /**
+     * When true, the phone is always told the car is parked, regardless of the
+     * real VHAL gear. Off by default (real state is forwarded). Issue #61.
+     */
+    @Volatile private var alwaysInPark: Boolean = AppPreferences.DEFAULT_ALWAYS_IN_PARK
+    @Volatile private var alwaysInParkObserverStarted = false
     @Volatile private var lastSentGearRaw: Int? = null
 
     // Cluster manager
@@ -436,6 +450,73 @@ class SessionManager(
         lastSentDriving = null
         lastSentGearRaw = null
         OalLog.d(TAG, "Reset latched vehicle sensor state: $reason")
+    }
+
+    /**
+     * Observe the "always in park" override. Started from [start] so it is live
+     * for the whole session; toggling mid-session re-pushes driving status so
+     * the phone reacts without a reconnect. Issue #61.
+     */
+    private fun observeAlwaysInPark() {
+        if (alwaysInParkObserverStarted) return
+        val ctx = context ?: return
+        alwaysInParkObserverStarted = true
+        val prefs = AppPreferences.getInstance(ctx)
+        scope.launch {
+            prefs.alwaysInPark.collect { enabled ->
+                val changed = alwaysInPark != enabled
+                alwaysInPark = enabled
+                if (changed) {
+                    val real = _vehicleDataForwarder?.latestVehicleData?.value?.driving ?: false
+                    val driving = if (enabled) false else real
+                    lastSentDriving = driving
+                    aasdkSession?.sendDrivingStatus(driving)
+                    DiagnosticLog.i("vhal", "alwaysInPark=$enabled — re-pushed driving=$driving (real=$real)")
+                }
+            }
+        }
+    }
+
+    /**
+     * The phone subscribed to a sensor type. Push current vehicle state now.
+     *
+     * Gearhead defaults driving status to FULLY_RESTRICTED(31) and only leaves
+     * that state on a real sample; a parked car emits no VHAL change events, so
+     * a change-driven pipeline never answers and Maps blocks the keyboard for
+     * the whole session. The latches are cleared first because the initial
+     * VHAL burst fires ~130ms BEFORE the sensor channel opens — those sends are
+     * dropped by the native `!streaming_ || !sensorChannel_` guard, yet still
+     * recorded as sent, which would otherwise suppress this re-push. Issue #61.
+     */
+    private fun onPhoneSubscribedSensor(sensorType: Int) {
+        val session = aasdkSession ?: return
+        val vd = _vehicleDataForwarder?.latestVehicleData?.value
+        resetLatchedVehicleSensorState("sensor_subscribe_$sensorType")
+        when (sensorType) {
+            SENSOR_TYPE_DRIVING_STATUS -> {
+                // Default to "parked" when VHAL has not reported a gear yet.
+                // Being wrong here is strictly safer than silence: silence is
+                // read by the phone as fully restricted, and a real gear change
+                // corrects it within one VHAL event.
+                val driving = if (alwaysInPark) false else (vd?.driving ?: false)
+                lastSentDriving = driving
+                session.sendDrivingStatus(driving)
+                DiagnosticLog.i("vhal", "pushed driving=$driving on subscribe (gear=${vd?.gearRaw})")
+            }
+            SENSOR_TYPE_GEAR -> vd?.gearRaw?.let {
+                lastSentGearRaw = it; session.sendGear(it)
+            }
+            SENSOR_TYPE_PARKING_BRAKE -> vd?.parkingBrake?.let {
+                lastSentParkingBrake = it; session.sendParkingBrake(it)
+            }
+            SENSOR_TYPE_NIGHT_MODE -> {
+                val night = vd?.nightMode ?: lastKnownUiNightMode ?: currentUiNightMode()
+                night?.let { lastSentNightMode = it; session.sendNightMode(it) }
+            }
+            SENSOR_TYPE_SPEED -> vd?.speedKmh?.let {
+                session.sendSpeed((it / 3.6f * 1000).toInt())
+            }
+        }
     }
 
     private fun seedCurrentUiNightMode(reason: String) {
@@ -536,6 +617,7 @@ class SessionManager(
         // unconditionally publishes nightMode / parking / driving / gear to
         // the phone — the phone has no prior state from us.
         resetLatchedVehicleSensorState("start_session")
+        observeAlwaysInPark()
         _vehicleDataForwarder = context?.let { ctx ->
             VehicleDataForwarderImpl(
                 ctx,
@@ -558,7 +640,8 @@ class SessionManager(
                         if (lastSentNightMode != it) { lastSentNightMode = it; session.sendNightMode(it) }
                     }
                     vd.driving?.let {
-                        if (lastSentDriving != it) { lastSentDriving = it; session.sendDrivingStatus(it) }
+                        val drv = if (alwaysInPark) false else it
+                        if (lastSentDriving != drv) { lastSentDriving = drv; session.sendDrivingStatus(drv) }
                     }
                     if (vd.fuelLevelPct != null || vd.rangeKm != null) {
                         session.sendFuel(
@@ -972,6 +1055,10 @@ class SessionManager(
         _effectiveDpi.value = effectiveDpi
 
         aasdkSession = session
+        // Answer the phone's SensorStartRequest with current vehicle state.
+        // Without this, a parked car never sends driving status and the phone
+        // stays FULLY_RESTRICTED (no Maps keyboard). Issue #61.
+        session.onSensorSubscribedListener = { type -> onPhoneSubscribedSensor(type) }
         // Reset the mirrored reconnect counter at session boundary. The
         // per-session collector below will republish updates as they fire.
         _reconnectAttempt.value = 0
@@ -1679,7 +1766,8 @@ class SessionManager(
                     if (lastSentNightMode != it) { lastSentNightMode = it; session.sendNightMode(it) }
                 }
                 message.driving?.let {
-                    if (lastSentDriving != it) { lastSentDriving = it; session.sendDrivingStatus(it) }
+                    val drv = if (alwaysInPark) false else it
+                    if (lastSentDriving != drv) { lastSentDriving = drv; session.sendDrivingStatus(drv) }
                 }
             }
             is ControlMessage.Gnss -> {

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -345,6 +345,14 @@ class AasdkSession(
         AasdkNative.nativeRequestKeyframe()
     }
 
+    /**
+     * Invoked when the phone subscribes to a sensor type, so the owner
+     * (SessionManager) can push current vehicle state immediately instead of
+     * waiting for a VHAL change event that a parked car never produces.
+     * See issue #61.
+     */
+    @Volatile var onSensorSubscribedListener: ((Int) -> Unit)? = null
+
     // -- AasdkSessionCallback (called from native thread → dispatch to flows) --
 
     override fun onSessionStarted() {
@@ -688,6 +696,17 @@ class AasdkSession(
             2 -> com.openautolink.app.diagnostics.DiagnosticLog.w(tag, message)
             3 -> com.openautolink.app.diagnostics.DiagnosticLog.e(tag, message)
             else -> com.openautolink.app.diagnostics.DiagnosticLog.i(tag, message)
+        }
+    }
+
+    override fun onSensorSubscribed(sensorType: Int) {
+        com.openautolink.app.diagnostics.DiagnosticLog.i(
+            "vhal", "phone subscribed sensor type=$sensorType — pushing current state"
+        )
+        try {
+            onSensorSubscribedListener?.invoke(sensorType)
+        } catch (t: Throwable) {
+            OalLog.w(TAG, "onSensorSubscribed($sensorType): ${t.message}")
         }
     }
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
@@ -118,4 +118,19 @@ interface AasdkSessionCallback {
      * @param message the log message
      */
     fun onNativeLog(level: Int, tag: String, message: String)
+
+    /**
+     * The phone subscribed to a sensor type (SensorStartRequest). The current
+     * value for that sensor must be pushed immediately.
+     *
+     * Gearhead defaults its driving-status restriction to FULLY_RESTRICTED(31)
+     * and only leaves that state once a real SENSOR_DRIVING_STATUS_DATA sample
+     * arrives — a missing sample is treated as "restricted", not "unknown". A
+     * parked car produces no VHAL change events, so a purely change-driven
+     * sensor pipeline never answers and the phone blocks keyboard/voice input
+     * for the whole session. See issue #61.
+     *
+     * @param sensorType aasdk SensorType ordinal (13 = DRIVING_STATUS)
+     */
+    fun onSensorSubscribed(sensorType: Int)
 }

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -768,6 +768,36 @@ private fun DisplayTab(
             )
         }
 
+        // Always in Park
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Always in Park",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = "Always tell the phone the car is parked, so Android Auto " +
+                        "keeps the on-screen keyboard and other features unlocked. " +
+                        "Off by default, which reports the car's real gear. " +
+                        "Only enable it if you are not the one driving — it disables " +
+                        "Android Auto's driving safety restrictions.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = uiState.alwaysInPark,
+                onCheckedChange = { viewModel.updateAlwaysInPark(it) },
+                modifier = Modifier.testTag("alwaysInParkToggle"),
+            )
+        }
+
         // Cluster Navigation
         Row(
             modifier = Modifier

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -39,6 +39,7 @@ data class SettingsUiState(
     // App-side
     val driveSide: String = AppPreferences.DEFAULT_DRIVE_SIDE,
     val gpsForwarding: Boolean = AppPreferences.DEFAULT_GPS_FORWARDING,
+    val alwaysInPark: Boolean = AppPreferences.DEFAULT_ALWAYS_IN_PARK,
     val clusterNavigation: Boolean = AppPreferences.DEFAULT_CLUSTER_NAVIGATION,
     val overlayStatsButton: Boolean = AppPreferences.DEFAULT_OVERLAY_STATS_BUTTON,
     val fileLoggingEnabled: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_ENABLED,
@@ -129,6 +130,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.logUploadToken,
         preferences.logUploadDeviceLabel,
         preferences.logPersistEnabled,
+        preferences.alwaysInPark,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -177,6 +179,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             logUploadToken = values[43] as String,
             logUploadDeviceLabel = values[44] as String,
             logPersistEnabled = values[45] as Boolean,
+            alwaysInPark = values[46] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -379,6 +382,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateGpsForwarding(enabled: Boolean) {
         viewModelScope.launch { preferences.setGpsForwarding(enabled) }
+    }
+
+    fun updateAlwaysInPark(enabled: Boolean) {
+        viewModelScope.launch { preferences.setAlwaysInPark(enabled) }
     }
 
     fun updateClusterNavigation(enabled: Boolean) {


### PR DESCRIPTION
Fixes #61.

## What was wrong

Gearhead defaults its driving-status restriction to `FULLY_RESTRICTED(31)` and only leaves that state once a real `SENSOR_DRIVING_STATUS_DATA` sample arrives — teardown `p000/rqd.java`:

```java
public int f65655d = 31;   // default, before any sample arrives
```

**Silence is read as "restricted", not "unknown".**

OAL only sent sensor data from VHAL change events (`handleChangeEvent` -> `throttledSend`). A parked car — gear steady in P, brake steady, speed 0 — produces no change events, so **no driving-status sample was ever sent**. The phone stayed fully restricted for the entire session: no Maps keyboard, no voice input, capped message length.

Two further defects compounded it, both visible in `oal_2026-07-25_18-13-29.log`:

```
18:13:34.978 vhal: SPEED edge: stopped (0.0 km/h)   <- the single throttledSend()
18:13:34.986 vhal: GEAR_SELECTION -> P (4)
18:13:34.990 OAL-Handlers: Sensor channel open      <- channel opens AFTER
18:13:35.112 OAL-Handlers: Sensor start request: type=13
```

- With `SEND_INTERVAL_MS = 500` the initial property burst collapses to one send that fires ~130 ms **before** the sensor channel exists, so native `if (!streaming_ || !sensorChannel_) return;` silently discards it.
- `lastSentDriving` was set **unconditionally**, recording that dropped send as delivered — the edge-trigger then guaranteed it was never retried.

## The fix

- New `onSensorSubscribed(sensorType)` callback bridged from native `JniSensorHandler::onSensorStartRequest` through `AasdkSessionCallback` -> `AasdkSession` -> `SessionManager`.
- `SessionManager.onPhoneSubscribedSensor` answers the subscribe with current state for driving status, gear, parking brake, night mode and speed, **clearing the latches first** so a pre-channel dropped send cannot suppress the real one.
- Driving status defaults to **parked** when VHAL has not yet reported a gear. Silence is strictly worse than a value, and a real gear change corrects it within one VHAL event.

## New setting: "Always in Park"

Added to Settings, **off by default** (real gear state is forwarded exactly as before). When on, the phone is always told the car is parked, keeping the AA keyboard and other features unlocked. Intended for bench/diagnostic use and head units whose VHAL never reports a usable gear. The description warns that it disables Android Auto's driving safety restrictions. Toggling it mid-session re-pushes driving status, so it applies without a reconnect.

## Outbound-protocol check (per the #35 focus-bounce lesson)

The phone's *reaction* was verified, not just our own teardown safety. `rqd.mo20807a(int i, byte[] bArr)` decodes `i == 13` unconditionally — no solicited/state gate — and applies the value straight to `f65655d`. An indication sent immediately after the start-response is handled normally.

## Verification status

Compiles clean: `:app:compileDebugKotlin` + `:app:externalNativeBuildDebug` (both ABIs; native signature changes only fail the latter, so both were run).

**Not verified on the car.** This is an attempt pending a real session — parked with the engine on, open Maps and confirm the keyboard is actually available. Deliberately not claiming resolution until that happens.
