### PR TITLE
fix(usb): stop the wireless stack from fighting USB mode (ANR fix)

### DIFF
--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -201,6 +201,8 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_VIDEO_SCALING_MODE = "crop" // "letterbox" or "crop"
         const val DEFAULT_HOTSPOT_SSID = ""
         const val DEFAULT_HOTSPOT_PASSWORD = ""
+        const val DIRECT_TRANSPORT_HOTSPOT = "hotspot"
+        const val DIRECT_TRANSPORT_USB = "usb"
         const val DEFAULT_DIRECT_TRANSPORT = "hotspot" // "hotspot" (TCP over shared WiFi), "usb" (AOAv2)
         const val DEFAULT_MANUAL_IP_ENABLED = false
         const val DEFAULT_MANUAL_IP_ADDRESS = ""

--- a/app/src/main/java/com/openautolink/app/transport/usb/UsbConnectionManager.kt
+++ b/app/src/main/java/com/openautolink/app/transport/usb/UsbConnectionManager.kt
@@ -95,6 +95,28 @@ class UsbConnectionManager(
     @Volatile
     private var currentPipe: UsbTransportPipe? = null
 
+    /**
+     * Guards the connect path against being entered twice for the same
+     * accessory. Two independent callers race here on every USB session:
+     *
+     *  1. the [ACTION_USB_PERMISSION] broadcast → [onPermissionGranted], and
+     *  2. the [performAoaSwitch] re-enumeration poll loop, which rescans for
+     *     the switched accessory and calls [requestPermissionOrConnect] again.
+     *
+     * Before this guard both paths reached [connectToAccessory] and each one
+     * invoked [onTransportReady], so `AasdkSession` ran `nativeCreateSession`
+     * + `nativeStartSession` a second time on a live session. The duplicate
+     * start forced a `nativeStopSession` from the wrong thread and tripped the
+     * `JniSession::stop()` io_service join — an ANR (observed 2026-07-27 on
+     * car app 0.1.371: two tombstoned dumps in three minutes, every session
+     * showing a duplicate "USB endpoints opened" / "Starting native aasdk
+     * session (USB)" pair ~5ms apart).
+     *
+     * Claiming is atomic via [connectClaimed] so whichever path arrives first
+     * wins and the loser becomes a no-op.
+     */
+    private val connectClaimed = java.util.concurrent.atomic.AtomicBoolean(false)
+
     @Volatile
     private var currentConnection: UsbDeviceConnection? = null
 
@@ -267,6 +289,14 @@ class UsbConnectionManager(
     }
 
     private fun requestPermissionOrConnect(device: UsbDevice) {
+        // Idempotency gate — see [connectClaimed]. A session is already
+        // established or being established; a second caller must not start
+        // another native session on top of it.
+        if (currentPipe != null || connectClaimed.get()) {
+            OalLog.i(TAG, "Ignoring duplicate connect for ${device.deviceName} — " +
+                    "a USB session is already claimed (state=${_connectionState.value})")
+            return
+        }
         if (usbManager.hasPermission(device)) {
             onPermissionGranted(device)
         } else {
@@ -310,9 +340,16 @@ class UsbConnectionManager(
         _status.value = "Waiting for accessory re-enumeration..."
         delay(AOA_SWITCH_SETTLE_MS)
 
-        // Poll for the accessory device
+        // Poll for the accessory device. Bail out early if another path (the
+        // ACTION_USB_PERMISSION broadcast, which commonly lands first once the
+        // accessory re-enumerates) has already claimed the connect slot —
+        // otherwise this loop races it into a duplicate native session start.
         var attempts = 0
         while (isRunning && attempts < ACCESSORY_SCAN_MAX_ATTEMPTS) {
+            if (currentPipe != null || connectClaimed.get()) {
+                OalLog.i(TAG, "AOA re-enumeration poll stopping — connect already claimed")
+                return
+            }
             val devices = usbManager.deviceList
             for ((_, d) in devices) {
                 if (UsbConstants.isAccessoryDevice(d.vendorId, d.productId)) {
@@ -331,6 +368,14 @@ class UsbConnectionManager(
     }
 
     private fun connectToAccessory(device: UsbDevice) {
+        // Atomically claim the connect slot. If another path (permission
+        // broadcast vs. AOA re-enumeration poll) beat us here, abort — a
+        // duplicate onTransportReady() starts a second native aasdk session
+        // on a live transport and deadlocks JniSession::stop().
+        if (!connectClaimed.compareAndSet(false, true)) {
+            OalLog.i(TAG, "connectToAccessory skipped — slot already claimed by another path")
+            return
+        }
         _connectionState.value = UsbConnectionState.CONNECTING
         _status.value = "Opening USB endpoints..."
 
@@ -339,6 +384,7 @@ class UsbConnectionManager(
             OalLog.e(TAG, "Failed to open accessory device")
             _status.value = "Failed to open device"
             _connectionState.value = UsbConnectionState.IDLE
+            connectClaimed.set(false)
             return
         }
 
@@ -349,6 +395,7 @@ class UsbConnectionManager(
             connection.close()
             _status.value = "No bulk endpoints"
             _connectionState.value = UsbConnectionState.IDLE
+            connectClaimed.set(false)
             return
         }
 
@@ -357,6 +404,7 @@ class UsbConnectionManager(
             connection.close()
             _status.value = "Failed to claim interface"
             _connectionState.value = UsbConnectionState.IDLE
+            connectClaimed.set(false)
             return
         }
 
@@ -407,6 +455,9 @@ class UsbConnectionManager(
         currentPipe?.close()
         currentPipe = null
         currentConnection = null
+        // Release the connect slot so a genuine re-attach (cable replug,
+        // detach broadcast, session restart) can establish a new session.
+        connectClaimed.set(false)
     }
 
     private fun isHubOrSystemDevice(device: UsbDevice): Boolean {

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -440,7 +440,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 var settle = false
                 try {
                     val mode = preferences.connectionMode.first()
-                    if (mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
+                    val usbMode = preferences.directTransport.first() ==
+                        AppPreferences.DIRECT_TRANSPORT_USB
+                    if (!usbMode && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
                         val defaultId = preferences.defaultPhoneId.first()
                         val askMode = preferences.alwaysAskPhone.first()
                         val noDefault = defaultId.isBlank()
@@ -569,7 +571,11 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             //      briefly before giving up.
             //   3. Fall back to the persistent manual-IP setting.
             val mode = preferences.connectionMode.first()
-            val carHotspotPhone = if (overrideIp == null && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
+            // USB transport short-circuits wireless resolution entirely: no
+            // mDNS grace, no UDP broadcast, no /24 sweep. The phone is on the
+            // cable and UsbConnectionManager owns the connection.
+            val carHotspotPhone = if (directTransport != AppPreferences.DIRECT_TRANSPORT_USB &&
+                overrideIp == null && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
                 // Long budget: with directed probing (no /24 sweep) this is
                 // cheap — just one TCP probe per known IP every
                 // [WARM_CACHE_RETRY_GAP_MS]. The user's guidance is to set a
@@ -737,6 +743,38 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         AppPreferences.DEFAULT_CONNECTION_MODE,
     )
 
+    /**
+     * True when the user has selected the USB (AOAv2) transport.
+     *
+     * `directTransport` and `connectionMode` are independent preferences, and
+     * historically only `AasdkSession` branched on the former — every wireless
+     * behaviour in this ViewModel gated on `connectionMode`, which stays
+     * `car_hotspot` while USB is selected. The result (car app 0.1.371,
+     * 2026-07-27): in USB mode the app still ran mDNS discovery, the UDP
+     * broadcast, the /24 sweep, the "no default phone" chooser gate (20s of
+     * dead time before the USB session even started) and, worst of all, fired
+     * `src=SWEEP` wireless auto-connects on top of a live USB session.
+     *
+     * The Settings help text already promises the correct behaviour — "The
+     * Wi-Fi connection mode below is ignored" — so every wireless trigger now
+     * consults this flow first.
+     */
+    val usbTransportActive: StateFlow<Boolean> = preferences.directTransport
+        .map { it == AppPreferences.DIRECT_TRANSPORT_USB }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5000),
+            AppPreferences.DEFAULT_DIRECT_TRANSPORT == AppPreferences.DIRECT_TRANSPORT_USB,
+        )
+
+    /**
+     * True when wireless phone discovery / auto-connect should run at all.
+     * Car Hotspot mode drives the multi-phone UX, but USB overrides it.
+     */
+    private val wirelessDiscoveryEnabled: Boolean
+        get() = !usbTransportActive.value &&
+            connectionMode.value == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT
+
     /** Persistent known-phones list, surfaced for the chooser + settings. */
     val knownPhones: StateFlow<List<KnownPhone>> = knownPhonesStore.phones.stateIn(
         viewModelScope,
@@ -829,13 +867,19 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         // keeps `knownPhones` "online" status fresh and lets the floating
         // switcher button surface phones the moment they appear on the AP.
         viewModelScope.launch {
-            connectionMode.collect { mode ->
-                if (mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
-                    phoneDiscovery.start()
-                } else {
-                    phoneDiscovery.stop()
+            kotlinx.coroutines.flow.combine(
+                connectionMode,
+                usbTransportActive,
+            ) { mode, usb -> mode to usb }
+                .collect { (mode, usb) ->
+                    if (!usb && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
+                        phoneDiscovery.start()
+                    } else {
+                        // USB transport: the phone is on the cable, there is
+                        // nothing to discover. Keep mDNS/sweep off entirely.
+                        phoneDiscovery.stop()
+                    }
                 }
-            }
         }
         // Debug aid for emulator testing: when manualIpEnabled is on, inject
         // a synthetic resolved phone into PhoneDiscovery so the picker /
@@ -873,8 +917,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 }
                 .distinctUntilChanged()
                 .collect { tuples ->
-                    val mode = connectionMode.value
-                    if (mode != AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) return@collect
+                    if (!wirelessDiscoveryEnabled) return@collect
                     tuples.forEach { (id, name) ->
                         knownPhonesStore.touch(
                             phoneId = id,
@@ -907,7 +950,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 // sit idle. The wake event is a level signal — use it to
                 // resync. Gate on the same conditions as the edge collector.
                 if (event.gapMs >= WAKE_AUTO_RECONNECT_MIN_GAP_MS &&
-                    connectionMode.value == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT &&
+                    wirelessDiscoveryEnabled &&
                     !alwaysAskPhone.value &&
                     defaultPhoneId.value.isNotBlank() &&
                     !connectInFlight &&
@@ -937,7 +980,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 .collect { state ->
                     val on = state == 4 || state == 5
                     if (!on) return@collect
-                    if (connectionMode.value != AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) return@collect
+                    if (!wirelessDiscoveryEnabled) return@collect
                     if (alwaysAskPhone.value) return@collect
                     if (defaultPhoneId.value.isBlank()) return@collect
                     if (connectInFlight) return@collect
@@ -979,8 +1022,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     // message.
                     if (_showPhoneChooser.value) return@collect
                     if (alwaysAskPhone.value) return@collect
-                    val mode = connectionMode.value
-                    if (mode != AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) return@collect
+                    // USB has no phone picker — escalating there would pop a
+                    // wireless chooser over a working cable session.
+                    if (!wirelessDiscoveryEnabled) return@collect
 
                     val activeId = _activePhoneId.value
                     val defaultId = defaultPhoneId.value
@@ -1045,6 +1089,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     val haveDefault = defaultPhoneId.value.isNotBlank()
                     val idleAndCarHotspot = mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT &&
                         state == SessionState.IDLE
+                    if (usbTransportActive.value) continue  // USB: nothing to sweep for
                     if (!idleAndCarHotspot) continue
                     if (askMode) continue          // user wants to pick manually
                     if (!haveDefault) continue     // no default → chooser path handles it
@@ -1073,8 +1118,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 .build()
             val cb = object : ConnectivityManager.NetworkCallback() {
                 override fun onAvailable(network: Network) {
-                    val mode = connectionMode.value
-                    if (mode != AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) return
+                    if (!wirelessDiscoveryEnabled) return
                     if (sessionManager.sessionState.value != SessionState.IDLE) return
                     if (!defaultPhoneId.value.isNotBlank()) return
                     if (alwaysAskPhone.value) return
@@ -1100,8 +1144,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 .map { list -> list.any { it.isResolved } }
                 .distinctUntilChanged()
                 .collect { anyResolved ->
-                    val mode = connectionMode.value
-                    if (mode != AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) return@collect
+                    if (!wirelessDiscoveryEnabled) return@collect
                     if (alwaysAskPhone.value) return@collect
                     if (!anyResolved) return@collect
                     // First-run / data-wipe path: no default yet. Promote the
@@ -1438,7 +1481,13 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     ): com.openautolink.app.transport.PhoneDiscovery.DiscoveredPhone? {
         // Make sure discovery is actually running. The init-block flow starts
         // it on connectionMode change, but the user might call connect()
-        // before that emit lands.
+        // before that emit lands. Never start it in USB mode — doConnect()
+        // already short-circuits, but guard here too so no future caller
+        // resurrects the sweep on a cable session.
+        if (usbTransportActive.value) {
+            OalLog.i(TAG, "USB transport — skipping wireless phone resolution")
+            return null
+        }
         phoneDiscovery.start()
 
         val defaultId = try {


### PR DESCRIPTION
USB and wireless projection were implemented as independent settings that both ran at once. Diagnosed from car app 0.1.371 logs uploaded 2026-07-27 (four sessions in 10 minutes, **two ANRs**).

## Defect 1 — duplicate native session start (the ANR trigger)

`UsbConnectionManager` fired `onTransportReady()` twice for the same accessory: the `ACTION_USB_PERMISSION` broadcast and the `performAoaSwitch` re-enumeration poll loop both reached `connectToAccessory()`. `AasdkSession` therefore ran `nativeCreateSession`/`nativeStartSession` a second time on a live session ~5ms later, forcing `nativeStopSession` from the wrong thread and tripping the `JniSession::stop()` io_service join.

```
15:14:50.741 Starting native aasdk session (USB): 2560x1440
15:14:50.797 AA session started (native)
15:14:50.805 Accessory device found after AOA switch: /dev/bus/usb/002/009
15:14:50.810 Starting native aasdk session (USB): 2560x1440   <- duplicate
15:14:50.810 W/session: stop() closing transport WITHOUT ByeBye
...
15:16:39.857 Wrote stack traces to tombstoned                 <- ANR
```

Fixed with an atomic connect claim, released on every failure path and in `closePipe()` so genuine re-attach still works. The AOA poll loop bails out once the slot is claimed.

## Defect 2 — wireless stack ignores USB mode

`directTransport` was read only by `AasdkSession`; every wireless behaviour gated on `connectionMode`, which stays `car_hotspot` in USB mode. USB sessions still ran mDNS + UDP broadcast + /24 sweep (5.6s dead time), hit the no-default-phone chooser gate (20s stall), and fired `src=SWEEP` wireless auto-connects on top of a live USB session.

Added `DIRECT_TRANSPORT_USB` + `usbTransportActive`/`wirelessDiscoveryEnabled` and gated all 11 wireless trigger sites. This is what the Settings help text already promises: *The Wi-Fi connection mode below is ignored*.

## Not in scope

The underlying `JniSession::stop()` deadlock (`jni_session.cpp`) is still a latent ANR on any abort path — separate native-lifetime fix.

## Verification

`:app:compileReleaseKotlin` BUILD SUCCESSFUL (only pre-existing `allNetworks` deprecation warnings). Road verification: USB drive should show no mDNS/sweep lines, a single `Starting native aasdk session (USB)` per session, and no tombstoned dumps.