### PR TITLE
docs: add Android Auto 17.4 wireless-startup breakage notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@
 
 OpenAutoLink runs the full Android Auto protocol stack natively on an AAOS head unit using the [aasdk](https://github.com/opencardev/aasdk) C++ library via JNI. No SBC, no USB adapter, no extra hardware — the car and phone talk directly over WiFi.
 
+> ## ⚠️ Android Auto 17.4 breaks wireless startup
+>
+> **Google disabled the entry point that lets a companion app start wireless projection.** In Android Auto 17.4 the `WirelessStartupReceiver` ships `android:enabled="false"`, and the `WirelessStartupActivity` it forwards to is `android:exported="false"` — so the broadcast is silently swallowed (`result=0`, no log, no error) and the activity cannot be launched by any other app. Verified against the 17.4 manifest and confirmed on-device: `cmd package query-receivers` reports **"No receivers found"**, and even `adb pm enable` is refused with a `SecurityException`.
+>
+> This affects **every** third-party wireless implementation, not just OpenAutoLink — see the same notice on [Open Headunit](https://github.com/andreknieriem/open-headunit).
+>
+> **What still works:**
+> - **An already-running Android Auto session.** The break is in *cold start* — if Android Auto is already running, the bridge connects normally.
+> - **USB mode.** USB raises a system-level accessory event that Google's own handler always services, so it is unaffected.
+>
+> **Symptom:** the car connects and shows "connected" but projection never starts. The companion logs `AA broadcast sent`, then `AA didn't connect to proxy in 8000ms` on repeat.
+>
+> We're investigating supported alternatives. Until then, if wireless cold-start fails, use USB to begin the session.
+
+
 <p align="center">
   <img src="docs/screenshots/AA-Streaming-Screenshot.jpg" alt="Android Auto streaming on a 2024 Blazer EV via OpenAutoLink" width="720">
   <br>
@@ -300,6 +315,7 @@ The original architecture used an SBC (single-board computer) running a C++ brid
 
 ## Known Issues
 
+- **Android Auto 17.4 breaks wireless cold-start** — Google shipped `WirelessStartupReceiver` disabled and `WirelessStartupActivity` unexported, so no companion app can start projection from cold. Affects all third-party wireless implementations. See the [notice above](#-android-auto-174-breaks-wireless-startup). Workaround: start the session over USB, or keep an existing Android Auto session running.
 - **H.265 video may appear green-tinted** on first connection for 30–45 seconds. May be Qualcomm-specific — not yet confirmed on other SoCs
 
 If you encounter other problems, please [open an issue](https://github.com/mossyhub/openautolink/issues).


### PR DESCRIPTION
## Summary

Adds a prominent notice that **Android Auto 17.4 breaks wireless cold-start for all third-party implementations**, plus a Known Issues entry.

Prompted by [Open Headunit](https://github.com/andreknieriem/open-headunit) carrying the same warning — independent corroboration of what our own teardown found.

## The mechanism (AA 17.4 manifest)

```xml
<receiver android:enabled="false" android:exported="true"
          android:name="...wireless.setup.receiver.WirelessStartupReceiver"/>
<activity android:exported="false"
          android:name="...wireless.setup.service.impl.WirelessStartupActivity"/>
```

The receiver is the **only** legitimate route — it's what forwards to the activity, same-uid — and it ships disabled. The activity can't be started by any other app. So the broadcast is accepted and silently dropped.

## Confirmed on-device (AA 17.3.662814, OnePlus 13)

```
cmd package query-receivers -a ...wirelessstartup.START  ->  "No receivers found"
am broadcast ...                                          ->  result=0, zero GH.WSR output
adb pm enable <receiver>                                  ->  SecurityException
```

Not even shell may enable it.

## Why USB still works — verified, not assumed

From uploaded car logs (real IDR = keyframe ≥1000 B; the 8176 B splash frame doesn't count):

| Session | Transport | real IDRs |
|---|---|---|
| 07-27 15:20:49 | USB | **9** |
| 07-27 08:19:12 | USB | **5** |
| 07-26 20:52:42 | USB | **1** |
| 08-05 18:45:10 | TCP/hotspot | 0 |
| 08-05 18:46:50 | TCP/hotspot | 0 |

USB raises a system accessory event handled by `FirstActivityImpl`, which is exported and always serviced by the platform. Wireless has no equivalent.

## What the notice tells users

- The scope (all third-party wireless, not just us)
- The two paths that still work: an already-running AA session, or USB
- The exact symptom (`AA broadcast sent` → `AA didn't connect to proxy in 8000ms`) so they can self-identify

Docs only — no code changes.