### PR TITLE
feat: send ByeBye on ignition off instead of vanishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 >
 > **There is no wireless workaround.** Android Auto has no launcher icon — its only launcher activity (`VnLaunchPadActivity`) also ships `android:enabled="false"` — so you cannot start it by hand, and nothing else can tell it which IP and port to connect to. If the receiver is disabled, wireless projection cannot be started at all.
 >
-> This affects **every** third-party wireless implementation, not just OpenAutoLink — [Open Headunit](https://github.com/andreknieriem/open-headunit) carries the same notice and reached the same conclusion.
+> This affects **every** third-party wireless implementation, not just OpenAutoLink.
 >
 > **Symptom:** the car connects and shows "connected" but projection never starts. The companion logs `AA broadcast sent`, then `AA didn't connect to proxy in 8000ms` on repeat.
 >

--- a/app/src/main/cpp/aasdk_jni.cpp
+++ b/app/src/main/cpp/aasdk_jni.cpp
@@ -112,6 +112,35 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeStopSession(
 
 /*
  * Class:     com_openautolink_app_transport_aasdk_AasdkNative
+ * Method:    nativeShutdownGracefully
+ *
+ * Sends a ByeBye to the phone, then tears the session down. Use when the
+ * disconnect is EXPECTED (ignition off, user exit) so the phone is told rather
+ * than left to discover the drop via its ~9s ping timeout. Bounded by
+ * timeoutMs — the head unit may be seconds from losing power.
+ */
+JNIEXPORT void JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeShutdownGracefully(
+    JNIEnv* env, jclass /*clazz*/, jstring reason, jint timeoutMs)
+{
+    std::string reasonStr = "shutdown";
+    if (reason) {
+        const char* c = env->GetStringUTFChars(reason, nullptr);
+        if (c) { reasonStr = c; env->ReleaseStringUTFChars(reason, c); }
+    }
+    // Deliberately NOT holding gSessionMutex across the call: shutdownGracefully
+    // returns immediately (the teardown happens on a detached worker once the
+    // ByeBye resolves), and nativeStopSession may run concurrently.
+    auto session = std::atomic_load(&gSession);
+    if (session) {
+        session->shutdownGracefully(reasonStr, timeoutMs);
+    } else {
+        LOGI("nativeShutdownGracefully: no active session");
+    }
+}
+
+/*
+ * Class:     com_openautolink_app_transport_aasdk_AasdkNative
  * Method:    nativeSendTouchEvent
  */
 JNIEXPORT void JNICALL

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -411,6 +411,83 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
 }
 
 // ============================================================================
+// shutdownGracefully()
+//
+// Sends the protocol ByeBye (ShutdownRequest) before tearing down, so the phone
+// is TOLD the head unit is going away instead of discovering it when its ~9s
+// ping watchdog fires. That silent disappearance is what makes the reconnect
+// after ignition-off slow and messy on the phone side.
+//
+// Threading mirrors onByeByeRequest()/onVideoFocusRequest(): stop() joins
+// ioThread_, so it must never run on that thread. The send promise resolves on
+// the io thread, hence the detached workers below.
+// ============================================================================
+
+void JniSession::shutdownGracefully(const std::string& reason, int timeoutMs)
+{
+    // Only meaningful while a session is actually up; otherwise just tear down.
+    if (!controlChannel_ || !strand_ || !messenger_) {
+        nativeDiag(2, "session", "shutdownGracefully: no live session, plain stop reason=" + reason);
+        stopReason_ = reason;
+        stop();
+        return;
+    }
+
+    // Guard against a second caller racing in (e.g. ignition-off and user exit
+    // arriving together) and double-sending / double-stopping.
+    bool expected = false;
+    if (!byeByeSent_.compare_exchange_strong(expected, true)) {
+        nativeDiag(2, "session", "shutdownGracefully: ByeBye already in flight, ignoring " + reason);
+        return;
+    }
+
+    stopReason_ = reason;
+    nativeDiag(1, "session", "shutdownGracefully: sending ByeBye reason=" + reason +
+                             " timeout=" + std::to_string(timeoutMs) + "ms");
+
+    auto self = shared_from_this();
+    auto done = std::make_shared<std::atomic<bool>>(false);
+
+    // Watchdog: if the phone never acknowledges (or the write stalls on a link
+    // that is already half-dead), tear down anyway. The head unit may be only
+    // seconds from losing power, so this must be bounded and must never block.
+    std::thread([self, done, timeoutMs]() {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (done->load()) return;  // promise path already handled it
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        if (!done->exchange(true)) {
+            LOGW("ByeBye not acknowledged within %dms - stopping anyway", timeoutMs);
+            self->stop();
+        }
+    }).detach();
+
+    aap_protobuf::service::control::message::ByeByeRequest request;
+    // ByeByeReason has no VEHICLE_SHUTDOWN member (USER_SELECTION, DEVICE_SWITCH,
+    // NOT_SUPPORTED, NOT_CURRENTLY_SUPPORTED, PROBE_SUPPORTED). USER_SELECTION is
+    // the closest honest fit for "this head unit is going away deliberately" and
+    // is already handled by gearhead as a clean teardown.
+    request.set_reason(aap_protobuf::service::control::message::USER_SELECTION);
+
+    auto promise = aasdk::channel::SendPromise::defer(*strand_);
+    promise->then(
+        [self, done]() {
+            if (!done->exchange(true)) {
+                LOGI("ByeBye sent - tearing down");
+                std::thread([self] { self->stop(); }).detach();
+            }
+        },
+        [self, done](const aasdk::error::Error& e) {
+            if (!done->exchange(true)) {
+                LOGW("ByeBye send failed (%s) - tearing down anyway", e.what());
+                std::thread([self] { self->stop(); }).detach();
+            }
+        });
+    controlChannel_->sendShutdownRequest(request, std::move(promise));
+}
+
+// ============================================================================
 // stop()
 // ============================================================================
 

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -92,8 +92,24 @@ public:
      */
     void start(JNIEnv* env, jobject transportPipe, jobject callback, jobject sdrConfig);
 
-    /** Stop the session gracefully (sends ByeBye). */
+    /**
+     * Stop the session. NOTE: this does NOT send a ByeBye — it closes the
+     * transport abruptly. Use [shutdownGracefully] when the disconnect is
+     * expected (ignition off, user exit) so the phone is told rather than left
+     * to discover it via its ping timeout.
+     */
     void stop();
+
+    /**
+     * Graceful disconnect: send the protocol's ByeBye (ShutdownRequest) so the
+     * phone learns the head unit is going away, then tear down.
+     *
+     * Without this, stop() closes the socket abruptly and the phone only
+     * notices when its ~9s ping watchdog fires — which is what makes a
+     * post-ignition-off reconnect slow and messy. Falls back to a plain stop()
+     * if the ByeBye cannot be sent or is not acknowledged within timeoutMs.
+     */
+    void shutdownGracefully(const std::string& reason, int timeoutMs);
 
     /** Send touch event to phone. */
     void sendTouchEvent(int action, int pointerId, float x, float y, int pointerCount);
@@ -270,6 +286,8 @@ private:
     // the user taps the Exit button in the AA app launcher) so Kotlin can decide
     // whether to suppress auto-reconnect.
     std::string stopReason_{"stopped"};
+    /** Set once a ByeBye has been dispatched, so two callers cannot double-send. */
+    std::atomic<bool> byeByeSent_{false};
     std::atomic<int> negotiatedCodecType_{0};
     // Current video focus state for the main display.
     // 1 = VIDEO_FOCUS_PROJECTED (default — we always project on AAOS).

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -67,6 +67,16 @@ class SessionManager(
     companion object {
         private const val TAG = "SessionManager"
 
+        /**
+         * How long to let a ByeBye flush before tearing the session down anyway.
+         *
+         * A single encrypted control frame on an already-open socket needs only
+         * milliseconds, so this is generous. It must stay short: on ignition-off
+         * the head unit may be seconds away from losing power, and a graceful
+         * goodbye is never worth delaying shutdown for.
+         */
+        private const val BYEBYE_TIMEOUT_MS = 400
+
         // aasdk SensorType ordinals (app/src/main/proto/oal/sensors.proto).
         // Used to answer the phone's SensorStartRequest with current state.
         private const val SENSOR_TYPE_SPEED = 3
@@ -1191,6 +1201,39 @@ class SessionManager(
             lm?.removeUpdates(listener)
         }
         _directLocationListener = null
+    }
+
+    /**
+     * Tell the phone we are going away, then stop.
+     *
+     * Sends the Android Auto protocol ByeBye so the phone treats this as a clean,
+     * expected teardown instead of waiting out its ~9s ping timeout and then
+     * assuming it drove out of range. Use for EXPECTED disconnects — ignition
+     * off, user exit — never for error paths, where the link is already gone.
+     *
+     * The native call returns immediately and completes the transport teardown on
+     * its own worker once the ByeBye is acknowledged (or [timeoutMs] elapses), so
+     * we must NOT call [stop] synchronously here — that would close the socket out
+     * from under the frame we just queued and defeat the whole point. Instead we
+     * let the ByeBye settle, then run the Kotlin-side cleanup (decoders, audio,
+     * forwarders), which is safe to do after the native session has gone.
+     */
+    fun shutdownGracefully(reason: String, timeoutMs: Int = BYEBYE_TIMEOUT_MS) {
+        val dispatched = runCatching {
+            aasdkSession?.shutdownGracefully(reason, timeoutMs) ?: error("no active session")
+        }.onFailure {
+            OalLog.w(TAG, "ByeBye dispatch failed (${it.message}) — stopping immediately")
+        }.isSuccess
+
+        if (!dispatched) { stop(); return }
+
+        scope.launch {
+            // Give the ByeBye its bounded window to flush and be acknowledged.
+            // The native watchdog uses the same budget, so by the time this
+            // returns the native session has already torn itself down.
+            delay(timeoutMs.toLong())
+            stop()
+        }
     }
 
     fun stop() {

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
@@ -43,6 +43,17 @@ object AasdkNative {
     @JvmStatic
     external fun nativeStopSession()
 
+    /**
+     * Send a ByeBye to the phone, then tear the session down.
+     *
+     * Use whenever the disconnect is EXPECTED (ignition off, user exit) so the
+     * phone is told the head unit is leaving instead of discovering it when its
+     * ~9s ping watchdog fires. Returns immediately; teardown completes on a
+     * native worker once the ByeBye resolves or [timeoutMs] elapses.
+     */
+    @JvmStatic
+    external fun nativeShutdownGracefully(reason: String, timeoutMs: Int)
+
     // -- Input (app → phone) --
 
     @JvmStatic

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -245,6 +245,21 @@ class AasdkSession(
         }
     }
 
+    /**
+     * Queue a ByeBye to the phone. Returns immediately; the native side sends the
+     * frame and then tears the transport down on its own worker once the phone
+     * acknowledges or [timeoutMs] elapses.
+     *
+     * Marks the stop as explicit so the reconnect logic treats the resulting
+     * disconnect as intentional rather than a dropout to be recovered from.
+     */
+    fun shutdownGracefully(reason: String, timeoutMs: Int) {
+        explicitStop = true
+        OalLog.i(TAG, "Graceful shutdown requested (reason=$reason, timeout=${timeoutMs}ms)")
+        cancelPendingReconnect("graceful shutdown")
+        AasdkNative.nativeShutdownGracefully(reason, timeoutMs)
+    }
+
     fun stop() {
         explicitStop = true
         OalLog.i(TAG, "Stopping aasdk session")

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -993,6 +993,34 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     connect()
                 }
         }
+        // Ignition OFF edge: tell the phone we're going away.
+        //
+        // Previously the head unit just stopped — the socket died with the
+        // process and the phone only noticed when its ~9s ping watchdog fired.
+        // From the phone's point of view that is indistinguishable from driving
+        // out of range, so it burns the full timeout and then flails through a
+        // reconnect storm. Sending the protocol ByeBye turns an ambiguous
+        // disappearance into a clean, expected teardown.
+        //
+        // Deliberately narrow: only fires on a real ON -> OFF/LOCK transition
+        // while a session is actually up. The initial null -> OFF read on a cold
+        // start must not count, or we would ByeBye a session we never had.
+        viewModelScope.launch {
+            var wasOn = false
+            com.openautolink.app.input.IgnitionMonitor.ignitionState
+                .collect { state ->
+                    if (state == null) return@collect
+                    val on = state == 4 || state == 5
+                    if (on) { wasOn = true; return@collect }
+                    // OFF (2) or LOCK (1), and we previously saw ON.
+                    if (!wasOn) return@collect
+                    if (state != 1 && state != 2) return@collect
+                    wasOn = false
+                    if (sessionManager.sessionState.value == SessionState.IDLE) return@collect
+                    OalLog.i(TAG, "Ignition OFF — sending ByeBye before teardown")
+                    sessionManager.shutdownGracefully("ignition_off")
+                }
+        }
         // Auto-close the phone chooser once we successfully reach STREAMING.
         // Without this the picker stays up after a successful tap-reconnect
         // and the user has to dismiss it manually.


### PR DESCRIPTION
## Summary

The head unit never told the phone it was going away. `stop()` closed the socket abruptly — OAL's own code said so:

```cpp
nativeDiag(2, "session", "stop() closing transport WITHOUT ByeBye ...");
```

From the phone's side that is indistinguishable from driving out of range, so it burns its full **~9s ping watchdog** before reacting, then flails through a reconnect. That's the "phone is confused after the car sleeps" behaviour.

## Both halves already existed

- **`IgnitionMonitor`** watches VHAL `IGNITION_STATE` (`0x11400409`) live. Logs prove it works today:
  ```
  Auto-connect suppressed — ignition state = 2 (off 86750ms ago)
  ```
- **aasdk** exposes `ControlServiceChannel::sendShutdownRequest()` — the protocol's ByeBye frame.

They were simply never wired together.

## Implementation

`JniSession::shutdownGracefully(reason, timeoutMs)`:
- sends ByeBye, tears down once acknowledged
- **bounded watchdog** tears down anyway if unacknowledged — the head unit may be seconds from losing power, so a polite goodbye must never delay shutdown
- `byeByeSent_` CAS guards two callers racing (ignition off + user exit)
- teardown on a detached worker: `stop()` joins `ioThread_` and the promise resolves **on** that thread, so calling `stop()` inline would join self. Mirrors the existing `onByeByeRequest` / `onVideoFocusRequest` pattern.

Wired to the ignition OFF edge, deliberately narrow: only a real **ON → OFF/LOCK** transition with a live session. The initial `null → OFF` read on a cold start must not fire, or we'd ByeBye a session that never existed.

`SessionManager.shutdownGracefully()` does **not** call `stop()` synchronously — that would close the socket out from under the frame just queued. It lets the ByeBye settle for 400ms, then runs Kotlin-side cleanup. Routed through `AasdkSession` so `explicitStop` is set and the reconnect logic treats the drop as intentional.

`ByeByeReason` has no `VEHICLE_SHUTDOWN` member (`USER_SELECTION`, `DEVICE_SWITCH`, `NOT_SUPPORTED`, `NOT_CURRENTLY_SUPPORTED`, `PROBE_SUPPORTED`), so `USER_SELECTION` is the closest honest fit — already handled by gearhead as a clean teardown.

Also corrects the `jni_session.h` comment claiming `stop()` "sends ByeBye" — it never did, and that's presumably why this went unnoticed.

## Verified

- `:app:compileDebugKotlin` + `:app:externalNativeBuildDebug` → BUILD SUCCESSFUL
- The JNI symbol is **actually exported** in the built library, not just compiled:
  ```
  llvm-nm -D libopenautolink-jni.so | grep shutdown
  -> T Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeShutdownGracefully
  ```

## Not verified

Runtime. Needs an ignition-off cycle in the car — expect `Ignition OFF — sending ByeBye before teardown` followed by `ByeBye sent - tearing down`, and a faster, quieter reconnect on next start.

Also drops the named third-party project reference from the AA 17.4 README notice.