### PR TITLE
feat(wireless): restore wireless Android Auto on 17.4 via Bluetooth + WPP

### DIFF
--- a/app/src/main/java/com/openautolink/app/OalApplication.kt
+++ b/app/src/main/java/com/openautolink/app/OalApplication.kt
@@ -43,6 +43,20 @@ class OalApplication : Application() {
         // shutdown burns a 45s timeout into a dead WiFi.
         com.openautolink.app.input.IgnitionMonitor.start(this)
 
+        // Android Auto Wireless BT advertiser.
+        //
+        // Must run at PROCESS scope, not session scope: its whole job is to make
+        // the phone start a session, so gating it behind an existing session is
+        // circular. Publishing the SDP record is cheap (one RFCOMM listener) and
+        // idempotent, and the handshake is only answered once credentials have
+        // been supplied.
+        //
+        // Currently opt-in while we validate that gearhead reacts to our record —
+        // enable with:
+        //   adb shell am broadcast -a com.openautolink.app.DEBUG_AAW_BT \
+        //     --es ssid <SSID> --es psk <KEY> --es ip <CAR_IP> --ei port 5277
+        com.openautolink.app.transport.bluetooth.AaWirelessBtControl.init(this)
+
         // Create the process-wide MediaSession and publish its token to the
         // MediaBrowserService exactly once, at process start. The GM AAOS
         // cluster media widget binds a MediaController to this token, and

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -203,6 +203,17 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_HOTSPOT_PASSWORD = ""
         const val DIRECT_TRANSPORT_HOTSPOT = "hotspot"
         const val DIRECT_TRANSPORT_USB = "usb"
+
+        /**
+         * Google WiFi Projection Protocol — the phone connects TO the head unit
+         * after a Bluetooth handshake, rather than the head unit dialling out.
+         *
+         * This is the transport real OEM head units use, and the only one that
+         * still works on Android Auto 17.4, which disabled the broadcast/intent
+         * route every third-party app relied on. Requires the AA Wireless BT
+         * advertiser to be running so the phone learns our {ip, port}.
+         */
+        const val DIRECT_TRANSPORT_WPP = "wpp"
         const val DEFAULT_DIRECT_TRANSPORT = "hotspot" // "hotspot" (TCP over shared WiFi), "usb" (AOAv2)
         const val DEFAULT_MANUAL_IP_ENABLED = false
         const val DEFAULT_MANUAL_IP_ADDRESS = ""

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -54,6 +54,15 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val VIDEO_SCALING_MODE = stringPreferencesKey("video_scaling_mode")
         val HOTSPOT_SSID = stringPreferencesKey("hotspot_ssid")
         val HOTSPOT_PASSWORD = stringPreferencesKey("hotspot_password")
+
+        /**
+         * BSSID of the access point the phone should join for WPP.
+         *
+         * Must be typed in: an unprivileged app cannot read a running SoftAP's
+         * BSSID, and gearhead hard-rejects empty, zero and broadcast MACs
+         * (WIFI_INVALID_BSSID) before it will attempt projection.
+         */
+        val WPP_BSSID = stringPreferencesKey("wpp_bssid")
         val DIRECT_TRANSPORT = stringPreferencesKey("direct_transport")
         val MANUAL_IP_ENABLED = booleanPreferencesKey("manual_ip_enabled")
         val MANUAL_IP_ADDRESS = stringPreferencesKey("manual_ip_address")
@@ -364,6 +373,11 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         prefs[HOTSPOT_PASSWORD] ?: DEFAULT_HOTSPOT_PASSWORD
     }
 
+    /** AP BSSID advertised to the phone during the WPP handshake. */
+    val wppBssid: Flow<String> = dataStore.data.map { prefs ->
+        prefs[WPP_BSSID] ?: ""
+    }
+
     val directTransport: Flow<String> = dataStore.data.map { prefs ->
         // Migrate any saved "nearby" preference to "hotspot" — Nearby Connections
         // is no longer used; the companion app speaks TCP over the shared WiFi.
@@ -501,6 +515,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setHotspotSsid(ssid: String) {
         dataStore.edit { it[HOTSPOT_SSID] = ssid }
+    }
+
+    suspend fun setWppBssid(bssid: String) {
+        dataStore.edit { it[WPP_BSSID] = bssid.trim() }
     }
 
     suspend fun setHotspotPassword(password: String) {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -212,6 +212,7 @@ class SessionManager(
     // [com.openautolink.app.transport.bluetooth.HfpPresenceServer].
     private var _hfpPresence: com.openautolink.app.transport.bluetooth.HfpPresenceServer? = null
 
+
     val callState: StateFlow<CallState>? get() = _audioPlayer?.callState
 
     // GNSS forwarder

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -88,6 +88,12 @@ class AasdkSession(
     // TCP connector — used in "hotspot" transport mode (Car Hotspot / Phone Hotspot)
     private var _tcpConnector: TcpConnector? = null
 
+    /**
+     * WPP inbound listener. Only non-null in "wpp" transport mode, where the phone
+     * connects to us rather than the other way round.
+     */
+    private var _wppServer: com.openautolink.app.transport.hotspot.WppTcpServer? = null
+
     // -- (A) Video frame-flow diagnostic counters --
     // Periodically summarize inbound frame flow into the triaged DiagnosticLog
     // so a black-video gap definitively shows whether bytes are still arriving
@@ -166,8 +172,35 @@ class AasdkSession(
 
         when (transportMode) {
             "usb" -> startUsb()
+            "wpp" -> startWpp()
             else -> startTcp()
         }
+    }
+
+    /**
+     * Google WiFi Projection Protocol: the phone connects to US.
+     *
+     * The opposite direction to [startTcp]. In WPP the head unit advertises its
+     * `{ip, port}` over Bluetooth RFCOMM (see `AaWirelessBtServer`) and the phone
+     * then opens the TCP connection inbound. Proven against AA 17.4 on 2026-08-06:
+     * full BT handshake, WiFi association, then an inbound connection from the phone.
+     *
+     * The native session neither knows nor cares which side dialled — it needs a
+     * connected socket — so this reuses [handleConnection] unchanged.
+     */
+    private fun startWpp() {
+        OalLog.i(TAG, "Starting aasdk session (WPP transport — phone connects to us)")
+        _wppServer?.stop()
+        _wppServer = com.openautolink.app.transport.hotspot.WppTcpServer(
+            scope = scope,
+            onSocketReady = { wppSocket ->
+                scope.launch(Dispatchers.IO) {
+                    OalLog.i(TAG, "WPP socket accepted — starting aasdk native session")
+                    handleConnection(wppSocket)
+                }
+            },
+        )
+        _wppServer?.start()
     }
 
     private fun startTcp() {
@@ -266,6 +299,8 @@ class AasdkSession(
         cancelPendingReconnect("explicit stop")
         _tcpConnector?.stop()
         _tcpConnector = null
+        _wppServer?.stop()
+        _wppServer = null
         _usbConnectionManager?.stop()
         _usbConnectionManager = null
         AasdkNative.nativeStopSession()
@@ -290,6 +325,8 @@ class AasdkSession(
         cancelPendingReconnect("force reconnect")
         _tcpConnector?.stop()
         _tcpConnector = null
+        _wppServer?.stop()
+        _wppServer = null
         _usbConnectionManager?.stop()
         _usbConnectionManager = null
         AasdkNative.nativeStopSession()

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -1,0 +1,136 @@
+package com.openautolink.app.transport.bluetooth
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.openautolink.app.diagnostics.OalLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Process-scoped owner of [AaWirelessBtServer].
+ *
+ * Lives at Application scope on purpose. The advertiser's entire job is to make the
+ * phone *initiate* a projection session, so hanging it off SessionManager — which
+ * only exists once a session is already running — would be circular. That mistake
+ * cost a test cycle: the DEBUG broadcast was delivered (`result=0`) but nothing
+ * listened, because no session had started to register the receiver.
+ *
+ * Kept opt-in via broadcast while we establish whether gearhead reacts to our SDP
+ * record at all. Once proven, the credentials should come from the live network
+ * state rather than adb extras.
+ *
+ * ```
+ * # start advertising + set the details handed to the phone
+ * adb shell am broadcast -a com.openautolink.app.DEBUG_AAW_BT \
+ *   --es ssid Fortress --es psk '<key>' --es bssid aa:bb:cc:dd:ee:ff \
+ *   --es ip 192.168.1.100 --ei port 5277
+ *
+ * # stop
+ * adb shell am broadcast -a com.openautolink.app.DEBUG_AAW_BT_STOP
+ * ```
+ */
+object AaWirelessBtControl {
+
+    private const val TAG = "AaWirelessBtControl"
+    private const val ACTION_START = "com.openautolink.app.DEBUG_AAW_BT"
+    private const val ACTION_STOP = "com.openautolink.app.DEBUG_AAW_BT_STOP"
+
+    /**
+     * Set the direct-transport preference. Lives here rather than in
+     * SessionManager because SessionManager's debug receiver only registers once
+     * a session is running — and switching to "wpp" is a precondition for the
+     * session starting at all. Same circular-dependency trap the advertiser hit.
+     */
+    private const val ACTION_SET_TRANSPORT = "com.openautolink.app.DEBUG_SET_TRANSPORT"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile
+    private var btServer: AaWirelessBtServer? = null
+
+
+    @Volatile
+    private var started = false
+
+    fun init(context: Context) {
+        synchronized(this) {
+            if (started) return
+            started = true
+        }
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(c: Context?, intent: Intent?) {
+                when (intent?.action) {
+                    ACTION_START -> handleStart(context, intent)
+                    ACTION_SET_TRANSPORT -> {
+                        val mode = intent.getStringExtra("mode").orEmpty()
+                        if (mode.isBlank()) {
+                            OalLog.w(TAG, "$ACTION_SET_TRANSPORT missing 'mode' extra")
+                            return
+                        }
+                        scope.launch {
+                            com.openautolink.app.data.AppPreferences.getInstance(context)
+                                .setDirectTransport(mode)
+                            OalLog.i(TAG, "Direct transport set to '$mode'")
+                        }
+                    }
+                    ACTION_STOP -> {
+                        OalLog.i(TAG, "Stopping AA wireless BT advertiser on request")
+                        btServer?.stop()
+                        btServer = null
+                    }
+                }
+            }
+        }
+        val filter = IntentFilter().apply {
+            addAction(ACTION_START)
+            addAction(ACTION_STOP)
+            addAction(ACTION_SET_TRANSPORT)
+        }
+        // Exported so it can be driven from adb during bring-up. This is a debug
+        // affordance; when the advertiser starts automatically it should stop being
+        // externally triggerable.
+        androidx.core.content.ContextCompat.registerReceiver(
+            context, receiver, filter,
+            androidx.core.content.ContextCompat.RECEIVER_EXPORTED,
+        )
+        OalLog.i(TAG, "AA wireless BT control ready (send $ACTION_START to begin advertising)")
+    }
+
+    private fun handleStart(context: Context, intent: Intent) {
+        val ssid = intent.getStringExtra("ssid").orEmpty()
+        if (ssid.isBlank()) {
+            OalLog.w(TAG, "$ACTION_START missing required 'ssid' extra")
+            return
+        }
+        val creds = AaWirelessBtServer.WifiCredentials(
+            ssid = ssid,
+            psk = intent.getStringExtra("psk").orEmpty(),
+            bssid = intent.getStringExtra("bssid").orEmpty(),
+            ip = intent.getStringExtra("ip").orEmpty(),
+            port = intent.getIntExtra("port", 5277),
+        )
+
+        // Switching the session into WPP mode is what binds the listener — see
+        // AasdkSession.startWpp(). Doing it here rather than starting our own
+        // server avoids two components racing for the same port.
+        //
+        // The session must already be running in "wpp" transport mode for the
+        // advertised port to be listening when the phone dials in. Set
+        // Settings -> Direct transport -> wpp (or DEBUG_SET_TRANSPORT) first.
+        OalLog.i(TAG, "Advertising ${creds.ip}:${creds.port} — session must be in 'wpp' " +
+                "transport mode for that port to be bound")
+
+        btServer?.stop()
+        val bt = AaWirelessBtServer(context, scope)
+        btServer = bt
+        // Probe first: if the BT stack refuses to publish the record we want that
+        // stated plainly in the log, not inferred later from the phone's silence.
+        OalLog.i(TAG, "SDP advertise capability: ${bt.canAdvertise()}")
+        bt.updateCredentials(creds)
+        bt.start()
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -8,6 +8,7 @@ import com.openautolink.app.diagnostics.OalLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -46,6 +47,11 @@ object AaWirelessBtControl {
      * session starting at all. Same circular-dependency trap the advertiser hit.
      */
     private const val ACTION_SET_TRANSPORT = "com.openautolink.app.DEBUG_SET_TRANSPORT"
+
+    /** Reserved MACs gearhead rejects outright — see pev.smali validation. */
+    private const val ZERO_MAC = "00:00:00:00:00:00"
+    private const val BROADCAST_MAC = "ff:ff:ff:ff:ff:ff"
+    private val BSSID_RE = Regex("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -100,20 +106,79 @@ object AaWirelessBtControl {
         OalLog.i(TAG, "AA wireless BT control ready (send $ACTION_START to begin advertising)")
     }
 
+    /**
+     * Start advertising using the credentials stored in Settings.
+     *
+     * Intent extras are honoured when present, but are only a bring-up
+     * convenience — the normal path is Settings → Wireless (WPP), because in a
+     * real vehicle nobody can run `adb` mid-drive.
+     *
+     * ### Why the credentials must be typed in
+     *
+     * These describe the network the phone should join to reach the head unit.
+     * On AAOS that is usually the car's own hotspot, and an unprivileged app
+     * cannot read a running SoftAP's SSID or passphrase:
+     * `WifiManager.getWifiApConfiguration()` needs a system signature, and
+     * `LocalOnlyHotspot` only reports credentials for an AP the app itself
+     * started — not the vehicle's. So the values come from the user.
+     *
+     * Missing or malformed credentials are a hard failure on the phone side, so
+     * they are validated before anything is advertised:
+     *   - empty SSID              → nothing to join
+     *   - empty/zero/broadcast BSSID → `WIFI_INVALID_BSSID`
+     *   - empty PSK on a secured network → `WIFI_SECURITY_NOT_SUPPORTED`
+     *     (we send `securityMode=OPEN`, which gearhead rejects for a WPA2 AP)
+     */
     private fun handleStart(context: Context, intent: Intent) {
-        val ssid = intent.getStringExtra("ssid").orEmpty()
-        if (ssid.isBlank()) {
-            OalLog.w(TAG, "$ACTION_START missing required 'ssid' extra")
-            return
-        }
-        val creds = AaWirelessBtServer.WifiCredentials(
-            ssid = ssid,
-            psk = intent.getStringExtra("psk").orEmpty(),
-            bssid = intent.getStringExtra("bssid").orEmpty(),
-            ip = intent.getStringExtra("ip").orEmpty(),
-            port = intent.getIntExtra("port", 5277),
-        )
+        scope.launch {
+            val prefs = com.openautolink.app.data.AppPreferences.getInstance(context)
 
+            val ssid = intent.getStringExtra("ssid")?.takeIf { it.isNotBlank() }
+                ?: prefs.hotspotSsid.first()
+            val psk = intent.getStringExtra("psk")
+                ?: prefs.hotspotPassword.first()
+            val bssid = intent.getStringExtra("bssid")?.takeIf { it.isNotBlank() }
+                ?: prefs.wppBssid.first()
+            val port = intent.getIntExtra("port", 5277)
+            // The address the phone is told to dial. Detected from the live
+            // interface rather than stored, because it changes with the network.
+            val ip = intent.getStringExtra("ip")?.takeIf { it.isNotBlank() }
+                ?: localIpv4Address()
+                ?: ""
+
+            val problems = buildList {
+                if (ssid.isBlank()) add("SSID is empty")
+                if (bssid.isBlank()) add("BSSID is empty")
+                else if (!BSSID_RE.matches(bssid)) add("BSSID '$bssid' is not a MAC address")
+                else if (bssid.equals(ZERO_MAC, true) || bssid.equals(BROADCAST_MAC, true)) {
+                    add("BSSID $bssid is reserved (zero/broadcast)")
+                }
+                if (ip.isBlank()) add("could not determine this device's IPv4 address")
+            }
+            if (problems.isNotEmpty()) {
+                OalLog.w(TAG, "Not advertising — ${problems.joinToString("; ")}. " +
+                        "Set these in Settings → Wireless (WPP).")
+                return@launch
+            }
+
+            val creds = AaWirelessBtServer.WifiCredentials(
+                ssid = ssid, psk = psk, bssid = bssid, ip = ip, port = port,
+            )
+            startAdvertising(context, creds)
+        }
+    }
+
+    /** Best-effort local IPv4, skipping loopback and virtual interfaces. */
+    private fun localIpv4Address(): String? = runCatching {
+        java.net.NetworkInterface.getNetworkInterfaces().toList()
+            .filter { it.isUp && !it.isLoopback && !it.isVirtual }
+            .flatMap { it.inetAddresses.toList() }
+            .filterIsInstance<java.net.Inet4Address>()
+            .firstOrNull { !it.isLoopbackAddress && !it.isLinkLocalAddress }
+            ?.hostAddress
+    }.getOrNull()
+
+    private fun startAdvertising(context: Context, creds: AaWirelessBtServer.WifiCredentials) {
         // Switching the session into WPP mode is what binds the listener — see
         // AasdkSession.startWpp(). Doing it here rather than starting our own
         // server avoids two components racing for the same port.

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -1,0 +1,414 @@
+package com.openautolink.app.transport.bluetooth
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothServerSocket
+import android.bluetooth.BluetoothSocket
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.openautolink.app.diagnostics.OalLog
+import com.openautolink.app.proto.Wireless
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.DataInputStream
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.util.UUID
+
+/**
+ * Advertises the head unit as an Android Auto Wireless source over Bluetooth, and
+ * performs the small RFCOMM handshake that hands the phone our IP, port and WiFi
+ * credentials.
+ *
+ * ## Why this exists
+ *
+ * Android Auto 17.4 shipped `WirelessStartupReceiver` with `android:enabled="false"`
+ * and `WirelessStartupActivity` with `android:exported="false"`, which killed the
+ * broadcast/intent route every third-party head unit used to start wireless
+ * projection. That route is unrecoverable from app code — not even `adb pm enable`
+ * can turn the receiver back on.
+ *
+ * The Bluetooth route that real OEM head units use is **untouched**. Verified in the
+ * 17.4 teardown:
+ *
+ * ```
+ * WifiBluetoothReceiver          exported="true"  enabled="true"  permission=(none)
+ *   listens: android.bluetooth.device.action.ACL_CONNECTED
+ *   emits:   com.google.android.projection.gearhead.START_WIRELESS_PROJECTION
+ * WirelessSetupSharedService     exported="true"  enabled="true"
+ * ```
+ *
+ * Gearhead decides whether a bonded device is "AAW capable" by running an SDP query
+ * against it (`owv` / `CAR.BTCapsStore`: `fetchUuidsWithSdp()`, then matching against
+ * [AA_UUID] or [AA_UUID_ALT]). If it matches, the phone dials **back** to us on that
+ * same UUID (`ohp`: `createRfcommSocketToServiceRecord`) and expects the handshake
+ * implemented below.
+ *
+ * So advertising alone is not enough — we must actually answer. Fortunately the
+ * exchange is three messages.
+ *
+ * ## Wire format
+ *
+ * ```
+ * [2 bytes payload length, big-endian][2 bytes message type][protobuf payload]
+ * ```
+ *
+ * ## Exchange
+ *
+ * ```
+ * car   -> type 1  WifiStartRequest  { ip_address, port, status }
+ * phone -> type 2  (phone asks for the network's security details)
+ * car   -> type 3  WifiInfoResponse  { ssid, key, bssid, security_mode, access_point_type }
+ * ```
+ *
+ * Then the socket is held open while the phone associates and opens the TCP session.
+ *
+ * ## Note on "the phone is already on this network"
+ *
+ * The credentials we send do not have to describe a network the phone must *join*.
+ * Gearhead short-circuits when it is already associated
+ * (`pdp`: `"already connected to desired network: %s, starting"`), so naming the
+ * network both devices already share is a valid, and in fact simpler, configuration.
+ *
+ * ## Scope
+ *
+ * This is a presence + handshake advertiser. It does not carry projection data —
+ * once the phone has our IP and port it connects over TCP exactly as before.
+ */
+class AaWirelessBtServer(
+    private val context: Context,
+    parentScope: CoroutineScope,
+) {
+    private val scope =
+        CoroutineScope(parentScope.coroutineContext + SupervisorJob() + Dispatchers.IO)
+
+    private var aaServerSocket: BluetoothServerSocket? = null
+    private var hfpServerSocket: BluetoothServerSocket? = null
+    private var acceptJob: Job? = null
+    private var hfpJob: Job? = null
+
+    @Volatile
+    private var running = false
+
+    @Volatile
+    private var credentials: WifiCredentials? = null
+
+    /**
+     * Network details handed to the phone during the handshake.
+     *
+     * @param ssid    network the phone should be on to reach us
+     * @param psk     pre-shared key; may be empty when the phone is already associated
+     * @param bssid   AP BSSID; may be empty if unknown
+     * @param ip      address the phone should open the projection socket to (ours)
+     * @param port    projection TCP port (OAL's companion/direct port)
+     */
+    data class WifiCredentials(
+        val ssid: String,
+        val psk: String,
+        val bssid: String,
+        val ip: String,
+        val port: Int,
+    )
+
+    /**
+     * Supply/refresh the details sent on the next handshake. Safe to call at any
+     * time; a handshake that arrives before this is set is rejected rather than
+     * answered with placeholder data the phone would act on.
+     */
+    fun updateCredentials(creds: WifiCredentials) {
+        credentials = creds
+        OalLog.i(TAG, "Credentials set: ssid=${creds.ssid} ip=${creds.ip}:${creds.port} " +
+                "bssid=${creds.bssid.ifEmpty { "(none)" }} psk=${if (creds.psk.isEmpty()) "(open/none)" else "****"}")
+    }
+
+    /**
+     * Probe whether this device can publish an SDP record on the Android Auto UUID
+     * at all. Cheap: opens a listener and immediately closes it.
+     *
+     * Worth calling before relying on this path — on a locked-down BT stack the
+     * `listenUsingRfcommWithServiceRecord` call is where it would fail, and knowing
+     * that is far more useful than a silent no-op.
+     */
+    @SuppressLint("MissingPermission")
+    fun canAdvertise(): Boolean {
+        if (!hasBtPermission()) return false
+        @Suppress("DEPRECATION")
+        val adapter = BluetoothAdapter.getDefaultAdapter() ?: return false
+        if (!adapter.isEnabled) return false
+        return try {
+            adapter.listenUsingRfcommWithServiceRecord("OAL AAW Probe", AA_UUID).close()
+            OalLog.i(TAG, "SDP advertise probe OK — this device can publish the AA Wireless UUID")
+            true
+        } catch (e: Exception) {
+            OalLog.w(TAG, "SDP advertise probe FAILED: ${e.message}")
+            false
+        }
+    }
+
+    fun start() {
+        if (running) return
+        if (!hasBtPermission()) {
+            OalLog.w(TAG, "BLUETOOTH_CONNECT not granted — AA wireless BT advertising disabled")
+            return
+        }
+        running = true
+        acceptJob = scope.launch(CoroutineName("AaWirelessBt-Accept")) { acceptLoop() }
+        hfpJob = scope.launch(CoroutineName("AaWirelessBt-Hfp")) { hfpPresenceLoop() }
+    }
+
+    /**
+     * Secondary RFCOMM listener on the Hands-Free Profile UUID.
+     *
+     * Purpose is narrow and worth stating, because it is easy to mistake for a car
+     * feature: on a **non-automotive** device (a tablet standing in for a head unit)
+     * nothing else claims an audio profile, so the phone tears the ACL link down
+     * moments after pairing — before gearhead can act on `AAW status (SUPPORTED)`.
+     * Holding an HFP service record makes the tablet look enough like a hands-free
+     * device for the link to persist.
+     *
+     * In a real head unit this is redundant: the OEM Bluetooth stack owns HFP/A2DP
+     * and keeps the link up. Confirmed from vehicle logs — the car's own
+     * `HfpPresenceServer` publishes its record on every session, and the phone has
+     * connected to it **zero** times, because it is already talking to the genuine
+     * hands-free device.
+     *
+     * This is presence only. We never speak AT commands and never accept SCO; call
+     * audio from an unprivileged app is gated behind `BLUETOOTH_PRIVILEGED`.
+     */
+    @SuppressLint("MissingPermission")
+    private suspend fun hfpPresenceLoop() {
+        @Suppress("DEPRECATION")
+        val adapter = BluetoothAdapter.getDefaultAdapter() ?: return
+        if (!adapter.isEnabled) return
+        try {
+            hfpServerSocket = adapter.listenUsingRfcommWithServiceRecord("Hands-Free Unit", HFP_UUID)
+            OalLog.i(TAG, "HFP presence record published (holds the ACL link on non-automotive devices)")
+        } catch (e: Exception) {
+            OalLog.w(TAG, "HFP presence record failed: ${e.message}")
+            return
+        }
+        while (running && scope.isActive) {
+            val client = try {
+                hfpServerSocket?.accept()
+            } catch (e: Exception) {
+                if (running) OalLog.w(TAG, "HFP accept() failed: ${e.message}")
+                try { delay(1000) } catch (_: Throwable) { break }
+                if (hfpServerSocket == null) break
+                continue
+            }
+            if (client != null) {
+                val remote = runCatching { client.remoteDevice?.address ?: "?" }.getOrDefault("?")
+                OalLog.i(TAG, "HFP presence connection from $remote — draining and holding briefly")
+                scope.launch {
+                    runCatching {
+                        // Read once so the phone sees a live peer rather than an
+                        // instant close, then let it go. We cannot serve HFP.
+                        client.inputStream.read(ByteArray(1024))
+                    }
+                    runCatching { client.close() }
+                }
+            }
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private suspend fun acceptLoop() {
+        @Suppress("DEPRECATION")
+        val adapter = BluetoothAdapter.getDefaultAdapter()
+        if (adapter == null || !adapter.isEnabled) {
+            OalLog.w(TAG, "No BT adapter or adapter disabled — AA wireless BT not started")
+            running = false
+            return
+        }
+
+        try {
+            aaServerSocket = adapter.listenUsingRfcommWithServiceRecord(SDP_NAME, AA_UUID)
+            OalLog.i(TAG, "Listening on Android Auto Wireless UUID $AA_UUID — " +
+                    "phone should now see this head unit as AAW capable")
+        } catch (e: Exception) {
+            OalLog.w(TAG, "Failed to publish AA Wireless SDP record: ${e.message}")
+            running = false
+            return
+        }
+
+        while (running && scope.isActive) {
+            var threw = false
+            val client: BluetoothSocket? = try {
+                aaServerSocket?.accept()
+            } catch (e: Exception) {
+                if (running) OalLog.w(TAG, "AA BT accept() failed: ${e.message}")
+                threw = true
+                null
+            }
+
+            if (client != null) {
+                val remote = runCatching { client.remoteDevice?.address ?: "?" }.getOrDefault("?")
+                OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote")
+                scope.launch(CoroutineName("AaWirelessBt-Handshake")) { handleHandshake(client) }
+                continue
+            }
+
+            // accept() returned null or threw. Mirrors HfpPresenceServer: if the
+            // socket is gone we cannot recover, otherwise back off so a torn-down
+            // socket (BT cycling on car shutdown) cannot pin a thread spinning.
+            if (aaServerSocket == null) {
+                if (running) OalLog.w(TAG, "AA BT server socket closed — exiting accept loop")
+                break
+            }
+            if (threw) {
+                try { delay(1000) } catch (_: Throwable) { break }
+            }
+        }
+    }
+
+    private suspend fun handleHandshake(socket: BluetoothSocket) {
+        val creds = credentials
+        if (creds == null) {
+            OalLog.w(TAG, "Handshake attempted with no credentials set — closing. " +
+                    "updateCredentials() must be called before the phone connects.")
+            runCatching { socket.close() }
+            return
+        }
+
+        try {
+            val input = DataInputStream(socket.inputStream)
+            val output = socket.outputStream
+
+            OalLog.i(TAG, "Handshake: sending WifiStartRequest (type 1) -> ${creds.ip}:${creds.port}")
+            sendMessage(
+                output,
+                MSG_WIFI_START_REQUEST,
+                Wireless.WifiStartRequest.newBuilder()
+                    .setIpAddress(creds.ip)
+                    .setPort(creds.port)
+                    .setStatus(0)
+                    .build()
+                    .toByteArray(),
+            )
+
+            val reply = readMessage(input)
+            OalLog.i(TAG, "Handshake: phone replied type=${reply.type} (${reply.payload.size} bytes)")
+
+            if (reply.type != MSG_WIFI_INFO_REQUEST) {
+                OalLog.w(TAG, "Handshake: unexpected reply type ${reply.type}, expected $MSG_WIFI_INFO_REQUEST — aborting")
+                return
+            }
+
+            OalLog.i(TAG, "Handshake: phone requested security info — sending WifiInfoResponse (type 3)")
+            sendMessage(
+                output,
+                MSG_WIFI_INFO_RESPONSE,
+                Wireless.WifiInfoResponse.newBuilder()
+                    .setSsid(creds.ssid)
+                    .setKey(creds.psk)
+                    .setBssid(creds.bssid)
+                    .setSecurityMode(
+                        if (creds.psk.isEmpty()) Wireless.SecurityMode.OPEN
+                        else Wireless.SecurityMode.WPA2_PERSONAL
+                    )
+                    .setAccessPointType(Wireless.AccessPointType.STATIC)
+                    .build()
+                    .toByteArray(),
+            )
+
+            OalLog.i(TAG, "Handshake complete — phone should now associate and open the projection socket")
+
+            // Hold the RFCOMM socket open. The phone keeps it as the control link
+            // while it associates and dials TCP; dropping it here makes the phone
+            // treat the head unit as having gone away mid-setup.
+            while (running && scope.isActive && socket.isConnected) {
+                delay(2000)
+            }
+            OalLog.i(TAG, "Handshake socket closing (running=$running connected=${socket.isConnected})")
+        } catch (e: IOException) {
+            OalLog.w(TAG, "Handshake I/O error: ${e.message}")
+        } catch (e: Exception) {
+            OalLog.w(TAG, "Handshake failed: ${e.message}")
+        } finally {
+            runCatching { socket.close() }
+        }
+    }
+
+    private fun sendMessage(output: OutputStream, type: Int, payload: ByteArray) {
+        val buf = ByteBuffer.allocate(payload.size + HEADER_BYTES)
+        buf.put((payload.size shr 8).toByte())
+        buf.put((payload.size and 0xFF).toByte())
+        buf.put((type shr 8).toByte())
+        buf.put((type and 0xFF).toByte())
+        buf.put(payload)
+        output.write(buf.array())
+        output.flush()
+    }
+
+    private fun readMessage(input: DataInputStream): Message {
+        val header = ByteArray(HEADER_BYTES)
+        input.readFully(header)
+        val size = ((header[0].toInt() and 0xFF) shl 8) or (header[1].toInt() and 0xFF)
+        val type = ((header[2].toInt() and 0xFF) shl 8) or (header[3].toInt() and 0xFF)
+        val payload = if (size > 0) ByteArray(size).also { input.readFully(it) } else ByteArray(0)
+        return Message(type, payload)
+    }
+
+    private data class Message(val type: Int, val payload: ByteArray)
+
+    private fun hasBtPermission(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.BLUETOOTH_CONNECT) ==
+                PackageManager.PERMISSION_GRANTED
+
+    fun stop() {
+        if (!running) return
+        running = false
+        runCatching { aaServerSocket?.close() }
+        aaServerSocket = null
+        runCatching { hfpServerSocket?.close() }
+        hfpServerSocket = null
+        acceptJob?.cancel()
+        acceptJob = null
+        hfpJob?.cancel()
+        hfpJob = null
+        scope.cancel()
+        OalLog.i(TAG, "AA wireless BT advertiser stopped")
+    }
+
+    companion object {
+        private const val TAG = "AaWirelessBt"
+
+        /** Name shown in the SDP record. Cosmetic. */
+        private const val SDP_NAME = "Android Auto"
+
+        /**
+         * The Android Auto Wireless service UUID. Gearhead matches on exactly this
+         * (`jki.a` / `owv.b` in the 17.4 teardown) when deciding whether a bonded
+         * device is a wireless-capable head unit, and dials back to it.
+         */
+        val AA_UUID: UUID = UUID.fromString("4de17a00-52cb-11e6-bdf4-0800200c9a66")
+
+        /**
+         * Second UUID gearhead accepts (`owv.c`). Not advertised by default — one
+         * record is enough and two risks confusing the SDP query — but kept here
+         * because it is the obvious next thing to try if the primary is ignored.
+         */
+        val AA_UUID_ALT: UUID = UUID.fromString("669a0c20-0008-f4bd-e611-cb52007ae14d")
+
+        /**
+         * Hands-Free Profile (HF unit role). Advertised only to keep the Bluetooth
+         * ACL link alive on non-automotive test devices — see [hfpPresenceLoop].
+         */
+        val HFP_UUID: UUID = UUID.fromString("0000111e-0000-1000-8000-00805f9b34fb")
+
+        private const val HEADER_BYTES = 4
+        private const val MSG_WIFI_START_REQUEST = 1
+        private const val MSG_WIFI_INFO_REQUEST = 2
+        private const val MSG_WIFI_INFO_RESPONSE = 3
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt
@@ -1,0 +1,200 @@
+package com.openautolink.app.transport.hotspot
+
+import android.os.ParcelFileDescriptor
+import android.system.Os
+import com.openautolink.app.diagnostics.OalLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+/**
+ * TCP **server** for Google's WiFi Projection Protocol (WPP).
+ *
+ * ## Why this exists
+ *
+ * OAL's original wireless design has the directions reversed relative to WPP:
+ *
+ * ```
+ *                     OAL (companion)        WPP (Google)
+ *   phone             ServerSocket           connects out
+ *   head unit         connects out           ServerSocket   <-- this class
+ * ```
+ *
+ * The companion app listens on 5277 and the car dials it. That works fine for
+ * OAL's own discovery scheme, but WPP is the opposite: the head unit sends its
+ * own `{ip_address, port}` in a `WifiStartRequest` over Bluetooth RFCOMM, and the
+ * **phone** then opens the TCP connection to the head unit and wraps it in SSL
+ * (`gearhead:WPP-TCP` — `"Starting attempt %d to create raw socket"` →
+ * `"Creating SSL wrapped socket"`).
+ *
+ * Observed directly (2026-08-06, AA 17.4): gearhead accepted our SDP advert, dialled
+ * our RFCOMM socket, accepted `WifiStartRequest` with `STATUS_SUCCESS`, parsed our
+ * `WifiInfoResponse` and validated the BSSID — then went quiet, because we had
+ * advertised a port with nothing bound to it. `/proc/net/tcp` on the head unit
+ * showed no listener on 5277.
+ *
+ * ## Why this matters beyond fixing the test
+ *
+ * With a listener in place the phone connects **directly to the head unit**. The
+ * companion app is not in the wireless path at all — no mDNS, no UDP probe, no
+ * identity port, no warm proxy. That removes the entire class of companion-side
+ * bridge faults from wireless projection.
+ *
+ * ## Contract
+ *
+ * Deliberately mirrors [TcpConnector]: hand a connected [Socket] to
+ * [onSocketReady] and let the existing aasdk session path take it from there. The
+ * session does not care which side dialled — it needs a connected socket.
+ */
+class WppTcpServer(
+    private val scope: CoroutineScope,
+    private val onSocketReady: (Socket) -> Unit,
+    /** Port to bind. Must match the port advertised in the WifiStartRequest. */
+    private val port: Int = DEFAULT_PORT,
+) {
+    companion object {
+        private const val TAG = "OAL-WppServer"
+
+        /**
+         * Default WPP listen port. Deliberately the same 5277 the companion uses
+         * so existing setup docs and firewall expectations still hold, but note
+         * the roles are inverted here: this binds, the phone connects.
+         */
+        const val DEFAULT_PORT = 5277
+
+        /** Accept backlog. One phone at a time; a small backlog absorbs retries. */
+        private const val BACKLOG = 4
+    }
+
+    private var serverSocket: ServerSocket? = null
+    private var acceptJob: Job? = null
+
+    @Volatile
+    private var isRunning = false
+
+    /** True while a session owns the accepted socket. Guards against duplicates. */
+    private val sessionActive = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    /** The address the phone should be told to connect to, once bound. */
+    @Volatile
+    var boundPort: Int = 0
+        private set
+
+    fun start() {
+        if (isRunning) return
+        isRunning = true
+        acceptJob = scope.launch(Dispatchers.IO) { acceptLoop() }
+    }
+
+    private suspend fun acceptLoop() {
+        try {
+            // Bind on all interfaces: in WPP the phone may reach us over the car's
+            // AP, the phone's own hotspot, or a shared network, and we do not know
+            // which local address it will use until it arrives.
+            serverSocket = ServerSocket().apply {
+                reuseAddress = true
+                bind(InetSocketAddress(port), BACKLOG)
+            }
+            boundPort = serverSocket?.localPort ?: 0
+            OalLog.i(TAG, "WPP TCP server listening on 0.0.0.0:$boundPort — " +
+                    "phone will connect here after the Bluetooth handshake")
+        } catch (e: Exception) {
+            OalLog.e(TAG, "Failed to bind WPP TCP port $port: ${e.message}")
+            isRunning = false
+            return
+        }
+
+        while (isRunning && scope.isActive) {
+            val socket = try {
+                serverSocket?.accept()
+            } catch (e: Exception) {
+                if (isRunning) OalLog.w(TAG, "WPP accept() failed: ${e.message}")
+                null
+            } ?: run {
+                // Socket closed under us — nothing to recover to.
+                if (isRunning && serverSocket == null) return
+                return
+            }
+
+            val remote = runCatching { socket.remoteSocketAddress?.toString() ?: "?" }
+                .getOrDefault("?")
+            OalLog.i(TAG, "Phone connected over WPP from $remote")
+            // Log the peer address explicitly: on a flat /23 an open port attracts
+            // unrelated LAN traffic, and gearhead may reconnect the phone under a
+            // DIFFERENT address than the one adb uses (observed: .1.174 -> .0.35).
+            // Never assume an inbound connection is the phone without checking.
+
+            // Keep listening. An earlier revision stopped accepting after the
+            // first connection to prevent a competing session — but that made the
+            // listener trivially killable: a single stray probe (or gearhead's own
+            // retry, which is routine) consumed the slot and tore the server down,
+            // so the real connection arrived at a closed port. Instead stay bound
+            // and refuse EXTRA connections while one session is live.
+            if (!sessionActive.compareAndSet(false, true)) {
+                OalLog.w(TAG, "Rejecting extra WPP connection from $remote — session already active")
+                runCatching { socket.close() }
+                continue
+            }
+
+            runCatching {
+                socket.tcpNoDelay = true
+                socket.keepAlive = true
+                // Same aggressive dead-peer detection as the dial-out path: the
+                // kernel default (~2h idle) is useless for sleep/wake recovery.
+                setKeepAliveParams(socket, idleSec = 5, intervalSec = 2, count = 3)
+            }.onFailure {
+                OalLog.d(TAG, "TCP tuning unavailable: ${it.message}")
+            }
+
+            onSocketReady(socket)
+        }
+    }
+
+    /**
+     * Release the single-session latch so the next incoming connection is accepted.
+     * Call when the projection session ends; without it, reconnects are refused.
+     */
+    fun onSessionEnded() {
+        if (sessionActive.compareAndSet(true, false)) {
+            OalLog.i(TAG, "WPP session released — ready to accept the next connection")
+        }
+    }
+
+    /**
+     * See TcpConnector.setKeepAliveParams — Java exposes only the on/off switch,
+     * so the timing constants need a native setsockopt via a dup'd FD. No hidden
+     * APIs; options set on the dup apply to the same kernel socket.
+     */
+    private fun setKeepAliveParams(socket: Socket, idleSec: Int, intervalSec: Int, count: Int) {
+        val IPPROTO_TCP = 6
+        val TCP_KEEPIDLE = 4
+        val TCP_KEEPINTVL = 5
+        val TCP_KEEPCNT = 6
+        val pfd = ParcelFileDescriptor.fromSocket(socket)
+        try {
+            val fd = pfd.fileDescriptor
+            Os.setsockoptInt(fd, IPPROTO_TCP, TCP_KEEPIDLE, idleSec)
+            Os.setsockoptInt(fd, IPPROTO_TCP, TCP_KEEPINTVL, intervalSec)
+            Os.setsockoptInt(fd, IPPROTO_TCP, TCP_KEEPCNT, count)
+        } finally {
+            pfd.close()
+        }
+    }
+
+    fun stop() {
+        if (!isRunning && serverSocket == null) return
+        isRunning = false
+        runCatching { serverSocket?.close() }
+        serverSocket = null
+        acceptJob?.cancel()
+        acceptJob = null
+        boundPort = 0
+        sessionActive.set(false)
+        OalLog.i(TAG, "WPP TCP server stopped")
+    }
+}

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -440,8 +440,12 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 var settle = false
                 try {
                     val mode = preferences.connectionMode.first()
-                    val usbMode = preferences.directTransport.first() ==
-                        AppPreferences.DIRECT_TRANSPORT_USB
+                    // Both USB and WPP own their own connection path — neither
+                    // needs the phone chooser, because there is no discovery step
+                    // to disambiguate.
+                    val transport = preferences.directTransport.first()
+                    val usbMode = transport == AppPreferences.DIRECT_TRANSPORT_USB ||
+                        transport == AppPreferences.DIRECT_TRANSPORT_WPP
                     if (!usbMode && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
                         val defaultId = preferences.defaultPhoneId.first()
                         val askMode = preferences.alwaysAskPhone.first()
@@ -571,10 +575,16 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             //      briefly before giving up.
             //   3. Fall back to the persistent manual-IP setting.
             val mode = preferences.connectionMode.first()
-            // USB transport short-circuits wireless resolution entirely: no
-            // mDNS grace, no UDP broadcast, no /24 sweep. The phone is on the
-            // cable and UsbConnectionManager owns the connection.
-            val carHotspotPhone = if (directTransport != AppPreferences.DIRECT_TRANSPORT_USB &&
+            // USB and WPP both short-circuit wireless resolution entirely: no
+            // mDNS grace, no UDP broadcast, no /24 sweep.
+            //   USB — the phone is on the cable and UsbConnectionManager owns it.
+            //   WPP — the phone connects INBOUND to our advertised {ip, port}
+            //         after the Bluetooth handshake, so there is nothing to
+            //         discover and sweeping would just burn 20s before the
+            //         listener is even bound.
+            val skipWirelessResolve = directTransport == AppPreferences.DIRECT_TRANSPORT_USB ||
+                directTransport == AppPreferences.DIRECT_TRANSPORT_WPP
+            val carHotspotPhone = if (!skipWirelessResolve &&
                 overrideIp == null && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
                 // Long budget: with directed probing (no /24 sweep) this is
                 // cheap — just one TCP probe per known IP every
@@ -604,7 +614,11 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 }
             }
             val manualIp = overrideIp ?: carHotspotIp ?: manualIpFromPrefs
-            if (mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
+            // WPP never has an IP to dial — the phone connects to US — so the
+            // Car-Hotspot "couldn't resolve a phone, give up" branch below must
+            // not run, or the session returns before startWpp() can bind the
+            // listener and the advertised port stays dead.
+            if (mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT && !skipWirelessResolve) {
                 OalLog.i(
                     TAG,
                     "Car Hotspot connect: overrideIp=$overrideIp resolved=$carHotspotIp final=$manualIp",
@@ -759,8 +773,19 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      * Wi-Fi connection mode below is ignored" — so every wireless trigger now
      * consults this flow first.
      */
+    /**
+     * True when the active transport owns its own connection path and needs no
+     * wireless discovery — USB (cable) or WPP (phone dials in to us).
+     *
+     * Named for its original USB-only meaning; it now gates every "should we go
+     * looking for a phone" code path, so WPP must be included or the app burns
+     * UDP broadcasts and /24 sweeps while waiting for an inbound connection.
+     */
     val usbTransportActive: StateFlow<Boolean> = preferences.directTransport
-        .map { it == AppPreferences.DIRECT_TRANSPORT_USB }
+        .map {
+            it == AppPreferences.DIRECT_TRANSPORT_USB ||
+                it == AppPreferences.DIRECT_TRANSPORT_WPP
+        }
         .stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5000),
@@ -879,6 +904,30 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                         // nothing to discover. Keep mDNS/sweep off entirely.
                         phoneDiscovery.stop()
                     }
+                }
+        }
+        // WPP: bind the inbound listener as soon as the transport is selected.
+        //
+        // Every other transport has an event that starts the session — discovery
+        // resolving a phone (hotspot) or a cable attach (USB). WPP has neither:
+        // the phone connects INBOUND to the {ip, port} we advertised over
+        // Bluetooth, so the socket must already be listening before there is
+        // anything to react to. Waiting for a trigger here is circular, and is
+        // why an earlier revision advertised a port with nothing bound to it.
+        //
+        // So treat "transport == wpp" itself as the trigger: start the session,
+        // which binds the listener and then idles until the phone arrives.
+        viewModelScope.launch {
+            preferences.directTransport
+                .map { it == AppPreferences.DIRECT_TRANSPORT_WPP }
+                .distinctUntilChanged()
+                .collect { isWpp ->
+                    if (!isWpp) return@collect
+                    if (sessionManager.sessionState.value != SessionState.IDLE) return@collect
+                    if (connectInFlight) return@collect
+                    OalLog.i(TAG, "WPP transport selected — binding inbound listener")
+                    hasConnected = false
+                    connect()
                 }
         }
         // Debug aid for emulator testing: when manualIpEnabled is on, inject

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -76,6 +76,10 @@ import com.openautolink.app.data.AppPreferences
 import com.openautolink.app.ui.components.LocalEchoTextField
 import androidx.compose.material3.FilterChip
 
+// Standard MAC form aa:bb:cc:dd:ee:ff. gearhead rejects anything else
+// (WIFI_INVALID_BSSID) before it will attempt projection.
+private val BSSID_PATTERN = Regex("^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$")
+
 private enum class SettingsTab(
     val title: String,
     val icon: ImageVector,
@@ -297,6 +301,7 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
             listOf(
                 "hotspot" to "Wi-Fi",
                 "usb" to "USB",
+                AppPreferences.DIRECT_TRANSPORT_WPP to "Wireless (WPP)",
             ).forEach { (mode, label) ->
                 FilterChip(
                     selected = uiState.directTransport == mode,
@@ -308,12 +313,71 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
         Text(
             text = when (uiState.directTransport) {
                 "usb" -> "Phone connects to the car over a USB cable using AOA v2. The Wi-Fi connection mode below is ignored. A device picker is shown on the projection screen so the OS only prompts for the phone you select."
+                AppPreferences.DIRECT_TRANSPORT_WPP ->
+                    "The phone connects to the car directly, the way a factory head unit works — no companion app needed. " +
+                        "The car advertises itself over Bluetooth, then hands the phone the Wi-Fi details below. " +
+                        "Pair the phone to this head unit over Bluetooth first, and make sure \"Phone calls\" is enabled for it."
                 else -> "Phone and car talk over the shared Wi-Fi network configured below."
             },
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
         )
+
+        if (uiState.directTransport == AppPreferences.DIRECT_TRANSPORT_WPP) {
+            Spacer(modifier = Modifier.height(8.dp))
+            // These must be entered by hand. An unprivileged app cannot read a
+            // running access point's SSID/passphrase/BSSID on AAOS —
+            // getWifiApConfiguration() is signature-gated — so there is nothing
+            // to auto-fill from. The phone hard-rejects wrong or missing values
+            // (WIFI_INVALID_BSSID / WIFI_SECURITY_NOT_SUPPORTED) before it will
+            // start projection, so the hints below matter.
+            Text(
+                text = "Wi-Fi details sent to the phone",
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            Text(
+                text = "Enter the network the phone should join to reach this head unit — normally the car's own hotspot. " +
+                    "These can't be detected automatically.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            LocalEchoTextField(
+                value = uiState.hotspotSsid,
+                onValueChange = { viewModel.updateHotspotSsid(it) },
+                label = { Text("Network name (SSID)") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            LocalEchoTextField(
+                value = uiState.hotspotPassword,
+                onValueChange = { viewModel.updateHotspotPassword(it) },
+                label = { Text("Password") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                supportingText = { Text("Leave empty only if the network is genuinely open") },
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            LocalEchoTextField(
+                value = uiState.wppBssid,
+                onValueChange = { viewModel.updateWppBssid(it) },
+                label = { Text("Access point BSSID") },
+                singleLine = true,
+                isError = uiState.wppBssid.isNotBlank() && !BSSID_PATTERN.matches(uiState.wppBssid),
+                supportingText = {
+                    Text(
+                        if (uiState.wppBssid.isNotBlank() && !BSSID_PATTERN.matches(uiState.wppBssid)) {
+                            "Must look like aa:bb:cc:dd:ee:ff"
+                        } else {
+                            "The AP's MAC address. Required — the phone rejects the connection without it."
+                        }
+                    )
+                },
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+        }
         Spacer(modifier = Modifier.height(12.dp))
 
         SectionHeader("Connection Mode")

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -19,6 +19,8 @@ data class SettingsUiState(
     val directTransport: String = AppPreferences.DEFAULT_DIRECT_TRANSPORT,
     val hotspotSsid: String = AppPreferences.DEFAULT_HOTSPOT_SSID,
     val hotspotPassword: String = AppPreferences.DEFAULT_HOTSPOT_PASSWORD,
+    /** AP BSSID advertised to the phone in WPP mode. Must be entered by hand. */
+    val wppBssid: String = "",
     val videoAutoNegotiate: Boolean = AppPreferences.DEFAULT_VIDEO_AUTO_NEGOTIATE,
     val videoCodec: String = AppPreferences.DEFAULT_VIDEO_CODEC,
     val videoFps: Int = AppPreferences.DEFAULT_VIDEO_FPS,
@@ -189,6 +191,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val _hotspotSsidOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_SSID)
     private val _hotspotPasswordOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_PASSWORD)
+    private val _wppBssidOverride = MutableStateFlow("")
     private val _directTransportOverride = MutableStateFlow(AppPreferences.DEFAULT_DIRECT_TRANSPORT)
 
     init {
@@ -197,6 +200,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         viewModelScope.launch {
             preferences.hotspotPassword.collect { _hotspotPasswordOverride.value = it }
+        }
+        viewModelScope.launch {
+            preferences.wppBssid.collect { _wppBssidOverride.value = it }
         }
         viewModelScope.launch {
             preferences.directTransport.collect { _directTransportOverride.value = it }
@@ -208,8 +214,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _hotspotSsidOverride,
         _hotspotPasswordOverride,
         _directTransportOverride,
-    ) { state, ssid, psk, transport ->
-        state.copy(hotspotSsid = ssid, hotspotPassword = psk, directTransport = transport)
+        _wppBssidOverride,
+    ) { state, ssid, psk, transport, bssid ->
+        state.copy(
+            hotspotSsid = ssid, hotspotPassword = psk,
+            directTransport = transport, wppBssid = bssid,
+        )
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5000),
@@ -295,6 +305,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         return com.openautolink.app.transport.PhoneDiscovery
             .getInstance(getApplication())
             .listRealInterfaces()
+    }
+
+    fun updateWppBssid(bssid: String) {
+        _wppBssidOverride.value = bssid
+        viewModelScope.launch { preferences.setWppBssid(bssid) }
     }
 
     fun updateDirectTransport(transport: String) {


### PR DESCRIPTION
## Wireless Android Auto works again on 17.4

**Do not merge yet — tablet-verified only, needs a real car run.**

AA 17.4 disabled the entry points every third-party head unit used:

```
WirelessStartupReceiver   android:enabled="false"
WirelessStartupActivity   android:exported="false"
VnLaunchPadActivity       android:enabled="false"   (no launcher icon)
```

None can be re-enabled from app code — hence the current README saying "USB or nothing".

**But that path isn't the only one.** The route real OEM head units use — Bluetooth SDP advert + Google's WiFi Projection Protocol — is completely untouched in 17.4, and everything it needs is exported and enabled:

```
WifiBluetoothReceiver        exported=true enabled=true   (ACL_CONNECTED)
WirelessSetupSharedService   exported=true enabled=true
```

## Verified working end to end

TCL tablet standing in for a head unit, OnePlus 13, gearhead 17.4. Sustained video — 41 bitrate samples at 204–253 kbps:

```
Handshake: sending WifiStartRequest (type 1) -> 192.168.1.100:5277
Handshake: phone replied type=2
Handshake: sending WifiInfoResponse (type 3)
Phone connected over WPP from /192.168.0.35:33766
MediaCodecDecoder: sustained frames
```

## How it works

`AaWirelessBtServer` publishes an RFCOMM record on the AA Wireless UUID `4de17a00-…`. gearhead SDP-queries bonded devices (`CAR.BTCapsStore`), reports `AAW status (SUPPORTED)`, and dials back. We answer a three-message handshake:

```
[2B length][2B type][protobuf]
car   -> type 1  WifiStartRequest  { ip_address, port }
phone -> type 2
car   -> type 3  WifiInfoResponse  { ssid, key, bssid, security, ap_type }
```

`WppTcpServer` is the half OAL never had. **WPP inverts this project's direction** — the phone connects *to* the head unit. OAL only ever dialled out, so the advertised port had nothing bound and the handshake succeeded into silence. The accepted socket goes to `AasdkSession.handleConnection()`, the same path `TcpConnector` uses.

Three guards in `ProjectionViewModel` each assumed *"wireless ⇒ we dial out"*; the last one was a Car-Hotspot early `return` that checked `connectionMode` but never transport, returning before the listener could bind.

## Conditions that are hard failures

- Phone **bonded and BT-connected** — unbonded is never AAW-capable
- **"Phone calls" (HFP)** enabled for the head unit on the phone
- **Real BSSID** — empty/zero/broadcast → `WIFI_INVALID_BSSID`
- **Real credentials** — `OPEN` on a WPA2 network → `WIFI_SECURITY_NOT_SUPPORTED`
- Listener bound **before** the BT handshake completes

## Deliberately not done

- **README unchanged.** "No wireless workaround" should only change once a real car confirms it — the car has an OEM BT stack owning HFP/A2DP and may run its own AP.
- **Opt-in only.** Transport must be `"wpp"` and the advertiser armed via `DEBUG_AAW_BT`. No default behaviour changes.
