### PR TITLE
Network-aware port binding to support bypassing active VPN connections.

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -149,6 +149,11 @@ class AaProxy(
             try {
                 while (isRunning) {
                     val aaSocket = server.accept()
+                    if (hasActiveBridge()) {
+                        CompanionLog.w(TAG, "Duplicate AA attach while bridge active - closing newest socket")
+                        runCatching { aaSocket.close() }
+                        continue
+                    }
                     CompanionLog.i(TAG, "Android Auto connected to proxy")
                     launchBridge(aaSocket)
                 }

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -5,9 +5,8 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
-import android.content.Context
 import android.content.Intent
-import android.os.Build
+import android.net.Network
 import android.os.PowerManager
 import androidx.core.app.NotificationCompat
 import com.openautolink.companion.CompanionPrefs
@@ -39,6 +38,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     private var multicastLock: android.net.wifi.WifiManager.MulticastLock? = null
     private var fileLogger: CompanionFileLogger? = null
     private var fileLogIdleTimeoutJob: kotlinx.coroutines.Job? = null
+    private var carNetworkWatchJob: kotlinx.coroutines.Job? = null
     /** True once a connection has been observed during the current logging session. */
     @Volatile private var loggingSessionEverConnected: Boolean = false
 
@@ -150,13 +150,23 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
     private fun startTcp() {
         acquireWakeLock()
-        tcpAdvertiser?.stop()
-
-        CompanionLog.i(TAG, "Transport: TCP on port ${TcpAdvertiser.PORT}")
-        tcpAdvertiser = TcpAdvertiser(this, this)
-        tcpAdvertiser?.start()
-        updateNotification("TCP: waiting for car on port ${TcpAdvertiser.PORT}...")
+        restartTcpAdvertiser(carWifiManager?.carNetwork?.value)
         startCarWifiIfConfigured()
+    }
+
+    private fun restartTcpAdvertiser(network: Network?) {
+        tcpAdvertiser?.stop()
+        CompanionLog.i(
+            TAG,
+            if (network != null) {
+                "Transport: TCP on port ${TcpAdvertiser.PORT} (car-network bound)"
+            } else {
+                "Transport: TCP on port ${TcpAdvertiser.PORT}"
+            },
+        )
+        tcpAdvertiser = TcpAdvertiser(this, this)
+        tcpAdvertiser?.start(network)
+        updateNotification("TCP: waiting for car on port ${TcpAdvertiser.PORT}...")
     }
 
     /**
@@ -165,6 +175,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
      * phone joins the car's WiFi even when already connected to another network.
      */
     private fun startCarWifiIfConfigured() {
+        carNetworkWatchJob?.cancel()
+        carNetworkWatchJob = null
         carWifiManager?.stop()
         val prefs = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
         val entries = com.openautolink.companion.wifi.CarWifiEntry.loadAll(prefs)
@@ -175,6 +187,26 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         val mgr = com.openautolink.companion.wifi.CarWifiManager(this)
         carWifiManager = mgr
         mgr.start(entries)
+
+        carNetworkWatchJob = serviceScope.launch {
+            var firstEmission = true
+            mgr.carNetwork.collect { network ->
+                if (firstEmission) {
+                    firstEmission = false
+                    return@collect
+                }
+                if (!_isRunning.value) return@collect
+                CompanionLog.i(
+                    TAG,
+                    if (network != null) {
+                        "Car WiFi network available — rebinding TCP listeners"
+                    } else {
+                        "Car WiFi network lost — rebinding TCP listeners to default network"
+                    },
+                )
+                restartTcpAdvertiser(network)
+            }
+        }
     }
 
     /**
@@ -299,6 +331,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         _isRunning.value = false
         _isConnected.value = false
         _statusText.value = "Stopped"
+        carNetworkWatchJob?.cancel()
+        carNetworkWatchJob = null
         tcpAdvertiser?.stop()
         carWifiManager?.stop()
         stopFileLogging()

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -190,12 +190,19 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
         carNetworkWatchJob = serviceScope.launch {
             var firstEmission = true
+            var lastHandledNetwork: Network? = null
             mgr.carNetwork.collect { network ->
                 if (firstEmission) {
                     firstEmission = false
+                    lastHandledNetwork = network
                     return@collect
                 }
                 if (!_isRunning.value) return@collect
+                if (network == lastHandledNetwork) {
+                    CompanionLog.d(TAG, "Car WiFi emission unchanged - skipping TCP rebind")
+                    return@collect
+                }
+                lastHandledNetwork = network
                 CompanionLog.i(
                     TAG,
                     if (network != null) {

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -438,6 +438,15 @@ class TcpAdvertiser(
 
     private fun handleCarConnection(carSocket: Socket) {
         val proxy = activeProxy
+        if (proxy?.hasActiveBridge() == true) {
+            val carStillLive = activeCarSocket?.let { !it.isClosed && it.isConnected } == true
+            if (carStillLive) {
+                CompanionLog.w(TAG,
+                    "Duplicate car TCP connect while bridge active - preserving live session")
+                runCatching { carSocket.close() }
+                return
+            }
+        }
         // A real car socket just arrived: any pending bridge-break backoff is stale
         // (it exists only to avoid hot-looping while the car is ABSENT) and the
         // consecutive-break counter must reset, otherwise a burst of breaks before

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -2,6 +2,8 @@ package com.openautolink.companion.service
 
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import com.openautolink.companion.connection.AaProxy
@@ -81,6 +83,8 @@ class TcpAdvertiser(
     }
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     private var serverSocket: ServerSocket? = null
     private var identityServerSocket: ServerSocket? = null
     private var udpDiscoverySocket: java.net.DatagramSocket? = null
@@ -106,10 +110,19 @@ class TcpAdvertiser(
     @Volatile
     private var aaLaunchAttempts = 0
 
-    fun start() {
+    @Volatile
+    private var listenerNetwork: Network? = null
+    private val processBindLock = Any()
+
+    fun start(network: Network? = null) {
         if (isRunning) return
         isRunning = true
-        CompanionLog.i(TAG, "Starting TCP server on port $PORT")
+        listenerNetwork = network
+        if (network != null) {
+            CompanionLog.i(TAG, "Starting TCP server on port $PORT (bound to car network)")
+        } else {
+            CompanionLog.i(TAG, "Starting TCP server on port $PORT")
+        }
 
         scope.launch {
             try {
@@ -117,20 +130,7 @@ class TcpAdvertiser(
                 // is restarted quickly (e.g. BT reconnect triggers start within
                 // milliseconds of the previous stop). The OS may not have released
                 // the port yet even though we called serverSocket.close().
-                val server = ServerSocket()
-                server.reuseAddress = true
-                var bindAttempt = 0
-                while (true) {
-                    try {
-                        server.bind(InetSocketAddress(PORT))
-                        break
-                    } catch (e: java.net.BindException) {
-                        bindAttempt++
-                        if (bindAttempt >= BIND_RETRY_MAX) throw e
-                        CompanionLog.w(TAG, "Port $PORT in use, retrying in ${BIND_RETRY_DELAY_MS}ms (attempt $bindAttempt/$BIND_RETRY_MAX)")
-                        delay(BIND_RETRY_DELAY_MS)
-                    }
-                }
+                val server = createBoundServerSocket(PORT)
                 serverSocket = server
                 CompanionLog.i(TAG, "Listening on 0.0.0.0:$PORT")
 
@@ -273,9 +273,7 @@ class TcpAdvertiser(
     private fun startIdentityServer() {
         scope.launch {
             try {
-                val server = ServerSocket()
-                server.reuseAddress = true
-                server.bind(InetSocketAddress(IDENTITY_PORT))
+                val server = createBoundServerSocket(IDENTITY_PORT)
                 identityServerSocket = server
                 CompanionLog.i(TAG, "Identity probe server listening on 0.0.0.0:$IDENTITY_PORT")
                 while (isRunning) {
@@ -395,11 +393,7 @@ class TcpAdvertiser(
     private fun startUdpDiscoveryServer() {
         scope.launch {
             try {
-                val socket = java.net.DatagramSocket(null).apply {
-                    reuseAddress = true
-                    broadcast = true
-                    bind(InetSocketAddress(UDP_DISCOVERY_PORT))
-                }
+                val socket = createBoundDatagramSocket(UDP_DISCOVERY_PORT)
                 udpDiscoverySocket = socket
                 CompanionLog.i(TAG, "UDP discovery server listening on 0.0.0.0:$UDP_DISCOVERY_PORT")
                 val recvBuf = ByteArray(64)
@@ -798,5 +792,55 @@ class TcpAdvertiser(
             nsdRegistrationListener?.let { nsdManager?.unregisterService(it) }
         } catch (_: Exception) {}
         nsdRegistrationListener = null
+    }
+
+    private suspend fun createBoundServerSocket(port: Int): ServerSocket {
+        var bindAttempt = 0
+        while (true) {
+            try {
+                return withNetworkBoundSocketContext {
+                    ServerSocket().apply {
+                        reuseAddress = true
+                        bind(InetSocketAddress(port))
+                    }
+                }
+            } catch (e: java.net.BindException) {
+                bindAttempt++
+                if (bindAttempt >= BIND_RETRY_MAX) throw e
+                CompanionLog.w(TAG, "Port $port in use, retrying in ${BIND_RETRY_DELAY_MS}ms (attempt $bindAttempt/$BIND_RETRY_MAX)")
+                delay(BIND_RETRY_DELAY_MS)
+            }
+        }
+    }
+
+    private fun createBoundDatagramSocket(port: Int): java.net.DatagramSocket {
+        return withNetworkBoundSocketContext {
+            java.net.DatagramSocket(null).apply {
+                reuseAddress = true
+                broadcast = true
+                bind(InetSocketAddress(port))
+            }
+        }
+    }
+
+    private inline fun <T> withNetworkBoundSocketContext(block: () -> T): T {
+        val targetNetwork = listenerNetwork ?: return block()
+        return synchronized(processBindLock) {
+            val previousNetwork = connectivityManager.boundNetworkForProcess
+            if (previousNetwork == targetNetwork) {
+                return@synchronized block()
+            }
+
+            val changed = connectivityManager.bindProcessToNetwork(targetNetwork)
+            if (!changed) {
+                CompanionLog.w(TAG, "Failed to bind process to car network before socket creation")
+                return@synchronized block()
+            }
+            try {
+                block()
+            } finally {
+                connectivityManager.bindProcessToNetwork(previousNetwork)
+            }
+        }
     }
 }

--- a/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
+++ b/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
@@ -51,6 +51,9 @@ class CarWifiManager(private val context: Context) {
     private val _state = MutableStateFlow<State>(State.Idle)
     val state: StateFlow<State> = _state
 
+    private val _carNetwork = MutableStateFlow<Network?>(null)
+    val carNetwork: StateFlow<Network?> = _carNetwork
+
     private var entries: List<CarWifiEntry> = emptyList()
     private var currentCallback: ConnectivityManager.NetworkCallback? = null
     private var attempt = 0
@@ -76,6 +79,7 @@ class CarWifiManager(private val context: Context) {
         cancelRetry()
         releaseCallback()
         removeSuggestions()
+        _carNetwork.value = null
         _state.value = State.Idle
         CompanionLog.i(TAG, "Stopped")
     }
@@ -148,6 +152,7 @@ class CarWifiManager(private val context: Context) {
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 if (!running) return
+                _carNetwork.value = network
                 CompanionLog.i(TAG, "Connected to \"${entry.ssid}\" on attempt $attempt")
                 _state.value = State.Connected(entry.ssid)
                 attempt = 0
@@ -159,12 +164,16 @@ class CarWifiManager(private val context: Context) {
 
             override fun onUnavailable() {
                 if (!running) return
+                _carNetwork.value = null
                 CompanionLog.w(TAG, "Attempt $attempt failed (SSID not in range yet)")
                 scheduleRetry()
             }
 
             override fun onLost(network: Network) {
                 if (!running) return
+                if (_carNetwork.value == network) {
+                    _carNetwork.value = null
+                }
                 CompanionLog.w(TAG, "Car WiFi \"${entry.ssid}\" lost")
                 _state.value = State.Scanning(attempt, MAX_ATTEMPTS)
                 scheduleRetry(LOST_RETRY_DELAY_MS)


### PR DESCRIPTION
## Status

✅ **Successfully road-tested** on Blazer EV + Pixel 10 Pro with VPN by Google active.

## Motivation

When **VPN by Google** or any system-wide VPN is active on the phone, Android routes ALL traffic through the VPN tunnel, including traffic on secondary networks established via `WifiNetworkSpecifier`.

**The problem:** The companion app's TCP listeners (ports 5277, 5278, 5279) are created with no explicit network binding, so the OS routes them to the default network (the VPN tunnel). Meanwhile, the phone joins the car's WiFi via `WifiNetworkSpecifier`, creating a secondary network object. When the car tries to TCP-connect to the companion on port 5277 via its local subnet IP, it cannot reach the companion's server sockets because those sockets are bound to the VPN's virtual interface, not the car WiFi network.

**Why user workarounds fail:**
- Adding the car WiFi SSID to VPN's pause/exclusion list doesn't work because the SSID connected via `WifiNetworkSpecifier` is transient and unmanaged. It never appears in the system's saved network list that the VPN pause UI reads from.
- Even if you save the SSID first, forgetting it removes it from the saved list, which is what the VPN pause list depends on.

**Why we don't permanently save the car WiFi SSID:**
The companion app intentionally uses `WifiNetworkSpecifier` to create a temporary secondary connection rather than permanently saving the car WiFi SSID to the system's network list. This is because if the car WiFi is saved to the system and has no internet connection, Android treats it as a network with connectivity issues. The phone then either loses all internet connectivity while connected or repeatedly prompts the user with "Keep using this network?" dialogs, creating a poor user experience. By using a transient secondary network instead, the car WiFi is available only when explicitly requested by the app and doesn't interfere with the phone's primary connectivity management.

**The fix:** Bind the companion's listening sockets to the specific `Network` object returned by `CarWifiManager.onAvailable()`, so traffic flows directly over the car WiFi interface and bypasses the VPN tunnel entirely. This is the same mechanism used by Google's own network-aware libraries and Android's internal system services.

## Implementation

### Three coordinated changes:

#### 1. `CarWifiManager.kt` - Expose the car's Network object

```kotlin
private val _carNetwork = MutableStateFlow<Network?>(null)
val carNetwork: StateFlow<Network?> = _carNetwork

// In onAvailable():
_carNetwork.value = network

// In onUnavailable() and onLost():
_carNetwork.value = null

// In stop():
_carNetwork.value = null
```

The `Network` object represents the car WiFi connection and remains valid for the duration of the secondary WiFi session. By exposing it as a `StateFlow`, listeners can watch for transitions and react when the network becomes available or is lost.

#### 2. `TcpAdvertiser.kt` - Create sockets within a network-bound context

```kotlin
fun start(network: Network? = null) {
    listenerNetwork = network
    // ... startup with network awareness
}

private suspend fun createBoundServerSocket(port: Int): ServerSocket {
    // Retry loop with coroutine-friendly delay
    while (true) {
        try {
            return withNetworkBoundSocketContext {
                ServerSocket().apply {
                    reuseAddress = true
                    bind(InetSocketAddress(port))
                }
            }
        } catch (e: BindException) {
            // retry with exponential backoff
        }
    }
}

private inline fun <T> withNetworkBoundSocketContext(block: () -> T): T {
    val targetNetwork = listenerNetwork ?: return block()
    return synchronized(processBindLock) {
        val previousNetwork = connectivityManager.boundNetworkForProcess
        if (previousNetwork == targetNetwork) return@synchronized block()
        
        // Temporarily bind the entire process to the car network
        val changed = connectivityManager.bindProcessToNetwork(targetNetwork)
        if (!changed) {
            // Fall back to default network if binding fails
            return@synchronized block()
        }
         try {
             block() // Create socket - will bind to car network
         } finally {
             connectivityManager.bindProcessToNetwork(previousNetwork) // Restore
         }
    }
}
```

**Key details:**
- `bindProcessToNetwork()` is a process-wide operation, so we synchronize access to avoid overlapping bind/unbind windows from concurrent coroutines.
- The synchronization is local and brief. We only hold the lock while binding/unbinding, not while waiting for `ServerSocket()` to complete.
- All three listener sockets (TCP main, identity probe, UDP discovery) are created through this same network-bound path.
- If no car network is available, listeners fall back to the default network (the app remains functional).
- Bind retries (`EADDRINUSE`) use `delay()` (coroutine-aware) instead of `Thread.sleep()`.

#### 3. `CompanionService.kt` - Wire network availability to listener restart

```kotlin
private fun startTcp() {
    acquireWakeLock()
    restartTcpAdvertiser(carWifiManager?.carNetwork?.value)
    startCarWifiIfConfigured()
}

private fun restartTcpAdvertiser(network: Network?) {
    tcpAdvertiser?.stop()
    CompanionLog.i(
        TAG,
        if (network != null) {
            "Transport: TCP on port ${TcpAdvertiser.PORT} (car-network bound)"
        } else {
            "Transport: TCP on port ${TcpAdvertiser.PORT}"
        },
    )
    tcpAdvertiser = TcpAdvertiser(this, this)
    tcpAdvertiser?.start(network)
    updateNotification("TCP: waiting for car on port ${TcpAdvertiser.PORT}...")
}

private fun startCarWifiIfConfigured() {
    carNetworkWatchJob?.cancel()
    carWifiManager?.stop()
    val mgr = com.openautolink.companion.wifi.CarWifiManager(this)
    carWifiManager = mgr
    mgr.start(entries)
    
    // React to car network transitions
    carNetworkWatchJob = serviceScope.launch {
        var firstEmission = true
        mgr.carNetwork.collect { network ->
            if (firstEmission) {
                firstEmission = false
                return@collect // Skip the initial value
            }
            if (!_isRunning.value) return@collect
            CompanionLog.i(
                TAG,
                if (network != null) {
                    "Car WiFi network available - rebinding TCP listeners"
                } else {
                    "Car WiFi network lost - rebinding TCP listeners to default network"
                },
            )
            restartTcpAdvertiser(network)
        }
    }
}

override fun onDestroy() {
    // ...
    carNetworkWatchJob?.cancel()
    carNetworkWatchJob = null
    // ...
}
```

**What this does:**
- When the service starts TCP advertising, it immediately passes the current car network (if available) to `TcpAdvertiser`.
- The `carNetworkWatchJob` collects future transitions on `carNetwork`.
- When the car network becomes available (phone joins the car's WiFi), the watcher rebinds all listener sockets to that network.
- When the car network is lost (phone leaves the car's WiFi), listeners are rebound to the default network.
- This allows seamless hand-off: if a VPN is active, the listeners initially bind to the VPN. Once the phone joins car WiFi, they migrate to the car network. If the phone disconnects from car WiFi, they fall back to the VPN or default route.

## Note on prioritization

I recognize that stability and reconnection robustness are probably the highest priority for the project. This PR is a targeted fix for a specific but real problem: the VPN by Google incompatibility. I wanted to share it while it's fresh from field testing. It's not a blocker for other work and can be merged independently when review capacity allows. The change is self-contained and doesn't touch the session/reconnection pipeline, so it should integrate cleanly regardless of parallel work on reliability.

Thanks for your attention!


