### PR TITLE
feat(car): add configurable reconnect overlay

### DIFF
--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -124,6 +124,8 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val ALWAYS_IN_PARK = booleanPreferencesKey("always_in_park")
         val CLUSTER_NAVIGATION = booleanPreferencesKey("cluster_navigation")
         val OVERLAY_STATS_BUTTON = booleanPreferencesKey("overlay_stats_button")
+        val OVERLAY_PHONE_SWITCH_BUTTON = booleanPreferencesKey("overlay_phone_switch_button")
+        val OVERLAY_RECONNECT_BUTTON = booleanPreferencesKey("overlay_reconnect_button")
         val FILE_LOGGING_ENABLED = booleanPreferencesKey("file_logging_enabled")
         val FILE_LOGGING_AUTOSTART_USB = booleanPreferencesKey("file_logging_autostart_usb")
         val LOGCAT_CAPTURE_ENABLED = booleanPreferencesKey("logcat_capture_enabled")
@@ -310,6 +312,8 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_ALWAYS_IN_PARK = false
         const val DEFAULT_CLUSTER_NAVIGATION = true
         const val DEFAULT_OVERLAY_STATS_BUTTON = true
+        const val DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON = true
+        const val DEFAULT_OVERLAY_RECONNECT_BUTTON = false
         const val DEFAULT_FILE_LOGGING_ENABLED = false
         const val DEFAULT_FILE_LOGGING_AUTOSTART_USB = false
         // On by default. There is no adb on the head unit, so this capture is
@@ -528,6 +532,14 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val overlayStatsButton: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[OVERLAY_STATS_BUTTON] ?: DEFAULT_OVERLAY_STATS_BUTTON
+    }
+
+    val overlayPhoneSwitchButton: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[OVERLAY_PHONE_SWITCH_BUTTON] ?: DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON
+    }
+
+    val overlayReconnectButton: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[OVERLAY_RECONNECT_BUTTON] ?: DEFAULT_OVERLAY_RECONNECT_BUTTON
     }
 
     val fileLoggingEnabled: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -770,6 +782,14 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setOverlayStatsButton(visible: Boolean) {
         dataStore.edit { it[OVERLAY_STATS_BUTTON] = visible }
+    }
+
+    suspend fun setOverlayPhoneSwitchButton(visible: Boolean) {
+        dataStore.edit { it[OVERLAY_PHONE_SWITCH_BUTTON] = visible }
+    }
+
+    suspend fun setOverlayReconnectButton(visible: Boolean) {
+        dataStore.edit { it[OVERLAY_RECONNECT_BUTTON] = visible }
     }
 
     suspend fun setFileLoggingEnabled(enabled: Boolean) {

--- a/app/src/main/java/com/openautolink/app/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/openautolink/app/ui/navigation/AppNavHost.kt
@@ -41,6 +41,7 @@ fun AppNavHost(navController: NavHostController = rememberNavController()) {
                 onNavigateToSettings = {
                     // Legacy — no longer used, settings are an overlay now
                 },
+                onReconnect = { settingsViewModel.saveAndReconnect() },
                 settingsOverlay = { onBack, onShowDiagnostics ->
                     SettingsScreen(
                         viewModel = settingsViewModel,

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.CloudUpload
 import androidx.compose.material.icons.filled.PowerSettingsNew
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
@@ -82,6 +83,7 @@ import com.openautolink.app.video.VideoStats
 fun ProjectionScreen(
     viewModel: ProjectionViewModel = viewModel(),
     onNavigateToSettings: () -> Unit = {},
+    onReconnect: () -> Unit = {},
     settingsOverlay: @Composable (onBack: () -> Unit, onShowDiagnostics: () -> Unit) -> Unit = { _, _ -> },
     diagnosticsOverlay: @Composable (onBack: () -> Unit) -> Unit = {},
 ) {
@@ -572,12 +574,12 @@ fun ProjectionScreen(
                     maxBoundsY = maxBoundsY,
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
-
                 // Switch Phone button — Car Hotspot mode only. Tapping opens a
                 // centered chooser overlay; the underlying AA session keeps
                 // streaming until the user explicitly picks a different phone.
-                if (isCarHotspotMode) {
+                if (isCarHotspotMode && uiState.overlayPhoneSwitchButton) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
                     DraggableOverlayButton(
                         icon = Icons.Default.PhoneAndroid,
                         contentDescription = "Switch Phone",
@@ -597,30 +599,49 @@ fun ProjectionScreen(
                         maxBoundsX = maxBoundsX,
                         maxBoundsY = maxBoundsY,
                     )
-
-                    Spacer(modifier = Modifier.height(8.dp))
                 }
 
-                // Stats button — draggable
-                DraggableOverlayButton(
-                    icon = Icons.Default.Info,
-                    contentDescription = "Stats for nerds",
-                    onClick = { viewModel.toggleStats() },
-                    positionKey = "overlay_stats",
-                    containerColor = if (uiState.showStats) {
-                        MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
-                    } else {
-                        MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
-                    },
-                    tint = if (uiState.showStats) {
-                        MaterialTheme.colorScheme.onPrimary
-                    } else {
-                        MaterialTheme.colorScheme.onSurface
-                    },
-                    modifier = Modifier.testTag("statsButton"),
-                    maxBoundsX = maxBoundsX,
-                    maxBoundsY = maxBoundsY,
-                )
+                // Stats button — user-configurable, unlike Settings which always stays visible.
+                if (uiState.overlayStatsButton) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    DraggableOverlayButton(
+                        icon = Icons.Default.Info,
+                        contentDescription = "Stats for nerds",
+                        onClick = { viewModel.toggleStats() },
+                        positionKey = "overlay_stats",
+                        containerColor = if (uiState.showStats) {
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                        } else {
+                            MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+                        },
+                        tint = if (uiState.showStats) {
+                            MaterialTheme.colorScheme.onPrimary
+                        } else {
+                            MaterialTheme.colorScheme.onSurface
+                        },
+                        modifier = Modifier.testTag("statsButton"),
+                        maxBoundsX = maxBoundsX,
+                        maxBoundsY = maxBoundsY,
+                    )
+                }
+
+                // Reconnect button — invokes the exact same callback as Settings'
+                // Save & Reconnect action, so preference reload and session behavior
+                // cannot drift between the two entry points.
+                if (uiState.overlayReconnectButton) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    DraggableOverlayButton(
+                        icon = Icons.Default.Refresh,
+                        contentDescription = "Reconnect",
+                        onClick = onReconnect,
+                        positionKey = "overlay_reconnect",
+                        modifier = Modifier.testTag("reconnectButton"),
+                        maxBoundsX = maxBoundsX,
+                        maxBoundsY = maxBoundsY,
+                    )
+                }
 
                 // File logging button — only shown when enabled in Settings → Diagnostics
                 if (uiState.fileLoggingEnabled) {

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -87,6 +87,10 @@ data class ProjectionUiState(
     val reconnectAttempt: Int = 0,
     /** Shows the floating "simulate ignition cycle" button. Maintainer tool. */
     val simulateIgnitionButton: Boolean = false,
+    /** Visibility of the user-configurable floating controls. */
+    val overlayStatsButton: Boolean = AppPreferences.DEFAULT_OVERLAY_STATS_BUTTON,
+    val overlayPhoneSwitchButton: Boolean = AppPreferences.DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON,
+    val overlayReconnectButton: Boolean = AppPreferences.DEFAULT_OVERLAY_RECONNECT_BUTTON,
 )
 
 /** State of the maintainer log-upload action, drives the floating button color. */
@@ -250,6 +254,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         _uploadState,
         preferences.simulateIgnitionButton,
         sessionManager.reconnectAttempt,
+        preferences.overlayStatsButton,
+        preferences.overlayPhoneSwitchButton,
+        preferences.overlayReconnectButton,
     ) { values ->
         ProjectionUiState(
             sessionState = values[0] as SessionState,
@@ -283,6 +290,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             uploadState = values[28] as LogUploadState,
             simulateIgnitionButton = values[29] as Boolean,
             reconnectAttempt = values[30] as Int,
+            overlayStatsButton = values[31] as Boolean,
+            overlayPhoneSwitchButton = values[32] as Boolean,
+            overlayReconnectButton = values[33] as Boolean,
         )
     }.stateIn(
         viewModelScope,

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -684,6 +684,40 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
 }
 
 @Composable
+private fun OverlayButtonToggle(
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    testTag: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(0.7f)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.testTag(testTag),
+        )
+    }
+}
+
+@Composable
 private fun DisplayTab(
     viewModel: SettingsViewModel,
     uiState: SettingsUiState,
@@ -967,30 +1001,29 @@ private fun DisplayTab(
             modifier = Modifier.padding(bottom = 12.dp)
         )
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(0.7f)
-                .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Stats Button",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = "Floating button to toggle performance stats overlay.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Switch(
-                checked = uiState.overlayStatsButton,
-                onCheckedChange = { viewModel.updateOverlayStatsButton(it) },
-                modifier = Modifier.testTag("overlayStatsToggle"),
-            )
-        }
+        OverlayButtonToggle(
+            title = "Stats Button",
+            description = "Floating button to toggle performance stats overlay.",
+            checked = uiState.overlayStatsButton,
+            onCheckedChange = viewModel::updateOverlayStatsButton,
+            testTag = "overlayStatsToggle",
+        )
+
+        OverlayButtonToggle(
+            title = "Phone Switcher Button",
+            description = "Floating button to choose the active phone in Car Hotspot mode.",
+            checked = uiState.overlayPhoneSwitchButton,
+            onCheckedChange = viewModel::updateOverlayPhoneSwitchButton,
+            testTag = "overlayPhoneSwitchToggle",
+        )
+
+        OverlayButtonToggle(
+            title = "Reconnect Button",
+            description = "Floating button that runs the same action as Save & Reconnect.",
+            checked = uiState.overlayReconnectButton,
+            onCheckedChange = viewModel::updateOverlayReconnectButton,
+            testTag = "overlayReconnectToggle",
+        )
 
         Spacer(modifier = Modifier.height(24.dp))
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -50,6 +50,8 @@ data class SettingsUiState(
     val alwaysInPark: Boolean = AppPreferences.DEFAULT_ALWAYS_IN_PARK,
     val clusterNavigation: Boolean = AppPreferences.DEFAULT_CLUSTER_NAVIGATION,
     val overlayStatsButton: Boolean = AppPreferences.DEFAULT_OVERLAY_STATS_BUTTON,
+    val overlayPhoneSwitchButton: Boolean = AppPreferences.DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON,
+    val overlayReconnectButton: Boolean = AppPreferences.DEFAULT_OVERLAY_RECONNECT_BUTTON,
     val fileLoggingEnabled: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_ENABLED,
     val fileLoggingAutoStartUsb: Boolean = AppPreferences.DEFAULT_FILE_LOGGING_AUTOSTART_USB,
     val logcatCaptureEnabled: Boolean = AppPreferences.DEFAULT_LOGCAT_CAPTURE_ENABLED,
@@ -141,6 +143,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.logPersistEnabled,
         preferences.alwaysInPark,
         preferences.simulateIgnitionButton,
+        preferences.overlayPhoneSwitchButton,
+        preferences.overlayReconnectButton,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -191,6 +195,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             logPersistEnabled = values[45] as Boolean,
             alwaysInPark = values[46] as Boolean,
             simulateIgnitionButton = values[47] as Boolean,
+            overlayPhoneSwitchButton = values[48] as Boolean,
+            overlayReconnectButton = values[49] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -454,6 +460,14 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateOverlayStatsButton(visible: Boolean) {
         viewModelScope.launch { preferences.setOverlayStatsButton(visible) }
+    }
+
+    fun updateOverlayPhoneSwitchButton(visible: Boolean) {
+        viewModelScope.launch { preferences.setOverlayPhoneSwitchButton(visible) }
+    }
+
+    fun updateOverlayReconnectButton(visible: Boolean) {
+        viewModelScope.launch { preferences.setOverlayReconnectButton(visible) }
     }
 
     fun updateFileLoggingEnabled(enabled: Boolean) {

--- a/app/src/test/java/com/openautolink/app/data/OverlayReconnectPreferenceTest.kt
+++ b/app/src/test/java/com/openautolink/app/data/OverlayReconnectPreferenceTest.kt
@@ -1,0 +1,24 @@
+package com.openautolink.app.data
+
+import com.openautolink.app.ui.projection.ProjectionUiState
+import com.openautolink.app.ui.settings.SettingsUiState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OverlayReconnectPreferenceTest {
+
+    @Test
+    fun `floating reconnect button is off by default in preferences and UI state`() {
+        assertFalse(AppPreferences.DEFAULT_OVERLAY_RECONNECT_BUTTON)
+        assertFalse(SettingsUiState().overlayReconnectButton)
+        assertFalse(ProjectionUiState().overlayReconnectButton)
+    }
+
+    @Test
+    fun `floating phone switcher preference is represented in both UI states`() {
+        assertTrue(AppPreferences.DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON)
+        assertTrue(SettingsUiState().overlayPhoneSwitchButton)
+        assertTrue(ProjectionUiState().overlayPhoneSwitchButton)
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in floating Reconnect button on the car projection screen
- route it through the exact Settings Save & Reconnect implementation
- restore functional visibility toggles for Stats and Phone Switcher
- keep Settings permanently visible so the configuration surface cannot be hidden

## Verification
- 209 car unit tests passed with zero failures
- fresh debug APK assembled, including both native ABIs
- compiled APK contains the new preference, control, and callback markers
- git diff --check passed

## Release plan
- GitHub release v0.1.433
- Play automotive:internal versionCode 433, completed
