### PR TITLE
fix(wireless): restart dead Bluetooth advertiser on ignition

### DIFF
--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -264,7 +264,10 @@ object AaWirelessBtControl {
 
     fun ensureAdvertising() {
         val ctx = appContext ?: return
-        if (btServer?.isRunning == true) return
+        if (btServer?.isRunning == true) {
+            OalLog.i(TAG, "Bluetooth advertiser already live — ignition re-arm not needed")
+            return
+        }
         // Single-flight: ignition ON arrives as 4 -> 5 -> 4 within ~350ms, which
         // fired this three times in one cycle. Each one raced the others into a
         // Bluetooth stack that was still down.
@@ -323,37 +326,6 @@ object AaWirelessBtControl {
      * 180s, plus room for the publish itself. Anything past this is a corpse.
      */
     private const val ENSURE_MAX_MS = 240_000L
-
-    fun republishAfterSocketDeath() {
-        val ctx = appContext ?: return
-        scope.launch {
-            // Wait for the adapter to actually come back rather than guessing.
-            //
-            // The previous revision waited a flat 5s and then republished; the
-            // adapter was still disabled 67 SECONDS after the socket died, so
-            // every attempt logged "No BT adapter or adapter disabled" and the
-            // car never advertised again. The head unit's Bluetooth goes down
-            // with the ignition and returns on its own schedule.
-            if (!awaitBluetoothEnabled()) {
-                OalLog.w(TAG, "Bluetooth did not come back — cannot republish the SDP record")
-                return@launch
-            }
-            kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
-              runCatching {
-                btServer?.stop()
-                btServer = null
-                startFromPreferences(ctx)
-                // Deliberately does NOT touch lastReadvertiseAtMs. This republish
-                // is recovery from a dead Bluetooth socket, not a response to a
-                // newly-learned address, and letting it start that cooldown
-                // blocked the discovery-driven re-advertise that follows it.
-                OalLog.i(TAG, "Republished the SDP record after the Bluetooth socket died")
-              }.onFailure {
-                OalLog.w(TAG, "Republish after socket death failed: ${it.message}")
-              }
-            }
-        }
-    }
 
     /**
      * Polls until the Bluetooth adapter is enabled, or the budget runs out.
@@ -1264,7 +1236,16 @@ object AaWirelessBtControl {
                 "transport mode for that port to be bound")
 
         btServer?.stop()
-        val bt = AaWirelessBtServer(context, scope)
+        val bt = AaWirelessBtServer(
+            context = context,
+            parentScope = scope,
+            onUnexpectedAcceptLoopExit = {
+                // Socket-death and ignition recovery share ensureAdvertising's
+                // single-flight guard, so they cannot replace each other's new
+                // SDP listener when Bluetooth returns.
+                ensureAdvertising()
+            },
+        )
         btServer = bt
         // Probe first: if the BT stack refuses to publish the record we want that
         // stated plainly in the log, not inferred later from the phone's silence.

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -88,6 +88,7 @@ import java.util.UUID
 class AaWirelessBtServer(
     private val context: Context,
     parentScope: CoroutineScope,
+    private val onUnexpectedAcceptLoopExit: () -> Unit = {},
 ) {
     // Deliberately does NOT inherit parentScope.coroutineContext.
     //
@@ -112,8 +113,19 @@ class AaWirelessBtServer(
     @Volatile
     private var running = false
 
-    /** True while the SDP record is published and the accept loop is alive. */
-    val isRunning: Boolean get() = running
+    /**
+     * True only while the advertiser was started AND its accept loop is alive.
+     *
+     * Bluetooth going down leaves the server object in memory. The accept loop
+     * exits after ten failures, but [running] historically stayed true, so the
+     * next ignition's ensureAdvertising() silently treated a dead SDP record as
+     * healthy and never told the phone which Wi-Fi to join.
+     */
+    val isRunning: Boolean
+        get() = AdvertiserLiveness.isLive(
+            startRequested = running,
+            acceptLoopActive = acceptJob?.isActive == true,
+        )
 
     @Volatile
     private var credentials: WifiCredentials? = null
@@ -186,7 +198,26 @@ class AaWirelessBtServer(
             return
         }
         running = true
-        acceptJob = scope.launch(CoroutineName("AaWirelessBt-Accept")) { acceptLoop() }
+        acceptJob = scope.launch(CoroutineName("AaWirelessBt-Accept")) {
+            var socketDied = false
+            try {
+                socketDied = acceptLoop()
+            } finally {
+                // This finally belongs to the exact accept Job that stopped. Do
+                // not poll AaWirelessBtControl.btServer: ignition recovery can
+                // replace that global reference while this older Job unwinds.
+                val startWasStillRequested = running
+                running = false
+                if (AdvertiserLiveness.shouldRecoverAfterExit(
+                        startRequested = startWasStillRequested,
+                        socketDied = socketDied,
+                    )
+                ) {
+                    OalLog.i(TAG, "Dead Bluetooth accept loop fully exited — requesting advertiser recovery")
+                    onUnexpectedAcceptLoopExit()
+                }
+            }
+        }
         hfpJob = scope.launch(CoroutineName("AaWirelessBt-Hfp")) { hfpPresenceLoop() }
     }
 
@@ -258,13 +289,13 @@ class AaWirelessBtServer(
     }
 
     @SuppressLint("MissingPermission")
-    private suspend fun acceptLoop() {
+    private suspend fun acceptLoop(): Boolean {
         @Suppress("DEPRECATION")
         val adapter = BluetoothAdapter.getDefaultAdapter()
         if (adapter == null || !adapter.isEnabled) {
             OalLog.w(TAG, "No BT adapter or adapter disabled — AA wireless BT not started")
             running = false
-            return
+            return false
         }
 
         try {
@@ -274,7 +305,7 @@ class AaWirelessBtServer(
         } catch (e: Exception) {
             OalLog.w(TAG, "Failed to publish AA Wireless SDP record: ${e.message}")
             running = false
-            return
+            return false
         }
 
         var consecutiveAcceptFailures = 0
@@ -343,14 +374,17 @@ class AaWirelessBtServer(
                     // car silently stopped advertising for the rest of the
                     // session: no SDP record, so the phone had nothing to dial
                     // back to and was never told which WiFi to join.
-                    AaWirelessBtControl.republishAfterSocketDeath()
-                    break
+                    // Report socket death only after this exact accept Job exits;
+                    // the server-owned finally decides whether recovery is still
+                    // wanted and invokes the callback once.
+                    return true
                 }
                 try { delay(1000) } catch (_: Throwable) { break }
             } else {
                 consecutiveAcceptFailures = 0
             }
         }
+        return false
     }
 
     /**
@@ -654,7 +688,10 @@ class AaWirelessBtServer(
                 PackageManager.PERMISSION_GRANTED
 
     fun stop() {
-        if (!running) return
+        // Cleanup is deliberately idempotent. A dead accept loop clears
+        // `running` before recovery replaces this server; returning early here
+        // would leak its sockets/jobs and let the old HFP listener conflict with
+        // the replacement instance.
         running = false
         runCatching { aaServerSocket?.close() }
         aaServerSocket = null

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AdvertiserLiveness.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AdvertiserLiveness.kt
@@ -1,0 +1,17 @@
+package com.openautolink.app.transport.bluetooth
+
+/**
+ * Defines whether the Bluetooth SDP advertiser can still accept a phone.
+ *
+ * A start flag alone is insufficient: the Bluetooth socket can die while the
+ * object survives across an ignition cycle. In that case the accept-loop job is
+ * complete and the SDP record is no longer live even if teardown never cleared
+ * the old flag.
+ */
+internal object AdvertiserLiveness {
+    fun isLive(startRequested: Boolean, acceptLoopActive: Boolean): Boolean =
+        startRequested && acceptLoopActive
+
+    fun shouldRecoverAfterExit(startRequested: Boolean, socketDied: Boolean): Boolean =
+        startRequested && socketDied
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/AdvertiserLivenessTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/AdvertiserLivenessTest.kt
@@ -1,0 +1,68 @@
+package com.openautolink.app.transport.bluetooth
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdvertiserLivenessTest {
+
+    @Test
+    fun staleRunFlagIsNotLiveAfterAcceptLoopExits() {
+        assertFalse(
+            AdvertiserLiveness.isLive(
+                startRequested = true,
+                acceptLoopActive = false,
+            )
+        )
+    }
+
+    @Test
+    fun activeAcceptLoopIsLiveAfterStart() {
+        assertTrue(
+            AdvertiserLiveness.isLive(
+                startRequested = true,
+                acceptLoopActive = true,
+            )
+        )
+    }
+
+    @Test
+    fun stoppedAdvertiserIsNotLiveEvenIfJobHasNotExitedYet() {
+        assertFalse(
+            AdvertiserLiveness.isLive(
+                startRequested = false,
+                acceptLoopActive = true,
+            )
+        )
+    }
+
+    @Test
+    fun deadSocketExitRequestsRecovery() {
+        assertTrue(
+            AdvertiserLiveness.shouldRecoverAfterExit(
+                startRequested = true,
+                socketDied = true,
+            )
+        )
+    }
+
+    @Test
+    fun intentionalStopNeverRequestsRecovery() {
+        assertFalse(
+            AdvertiserLiveness.shouldRecoverAfterExit(
+                startRequested = false,
+                socketDied = true,
+            )
+        )
+    }
+
+    @Test
+    fun ordinaryLoopCompletionDoesNotRequestRecovery() {
+        assertFalse(
+            AdvertiserLiveness.shouldRecoverAfterExit(
+                startRequested = true,
+                socketDied = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- Treat the Bluetooth SDP advertiser as live only while its accept job is active.
- Recover only after the exact dead accept loop has fully exited.
- Funnel socket-death and ignition recovery through one single-flight restart path.
- Make server cleanup idempotent after a dead-loop exit.
- Add regression tests for stale liveness and recovery gating.

## Runtime evidence

The 2026-08-15 ignition-cycle capture logged `Ignition ON — re-arming the Bluetooth advertiser`, then no advertiser start, refusal, or failure line. The prior accept loop had died while its stale `running` flag remained true, so the phone never received the Wi-Fi startup handshake.

## Verification

- `:app:testDebugUnitTest`
- `:app:compileDebugKotlin`
- Release AAB built and signature verified
- Release DEX contains the new recovery markers
- Play `automotive:internal`: 0.1.434 / versionCode 434 / completed

This is a shipped attempt pending an ignition-cycle road test; it is not claimed verified in-car yet.
