### PR TITLE
diag: trace pre-wake and WPP startup end to end

### DIFF
--- a/app/src/main/java/com/openautolink/app/MainActivity.kt
+++ b/app/src/main/java/com/openautolink/app/MainActivity.kt
@@ -151,6 +151,9 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         com.openautolink.app.diagnostics.DiagnosticLog.i("lifecycle", "MainActivity.onResume")
+        com.openautolink.app.wake.PreWakeMonitor.reportActivity(
+            com.openautolink.app.wake.PreWakeActivityCallback.RESUME
+        )
         publishCurrentUiNightMode("onResume")
         // On AAOS, resume after car sleep leaves TCP sockets dead.
         // SessionManager dedupes against the SCREEN_ON broadcast receiver
@@ -162,6 +165,9 @@ class MainActivity : ComponentActivity() {
     override fun onPause() {
         super.onPause()
         com.openautolink.app.diagnostics.DiagnosticLog.i("lifecycle", "MainActivity.onPause")
+        com.openautolink.app.wake.PreWakeMonitor.reportActivity(
+            com.openautolink.app.wake.PreWakeActivityCallback.PAUSE
+        )
         // Mirror onResume on the sleep side. Lets the next markWake compute
         // gap from "going idle" rather than "last control message", which
         // matters when streaming keeps lastActiveTimestamp fresh right up
@@ -172,11 +178,17 @@ class MainActivity : ComponentActivity() {
     override fun onStart() {
         super.onStart()
         com.openautolink.app.diagnostics.DiagnosticLog.i("lifecycle", "MainActivity.onStart")
+        com.openautolink.app.wake.PreWakeMonitor.reportActivity(
+            com.openautolink.app.wake.PreWakeActivityCallback.START
+        )
     }
 
     override fun onStop() {
         super.onStop()
         com.openautolink.app.diagnostics.DiagnosticLog.i("lifecycle", "MainActivity.onStop")
+        com.openautolink.app.wake.PreWakeMonitor.reportActivity(
+            com.openautolink.app.wake.PreWakeActivityCallback.STOP
+        )
     }
 
     override fun onTopResumedActivityChanged(isTopResumedActivity: Boolean) {

--- a/app/src/main/java/com/openautolink/app/OalApplication.kt
+++ b/app/src/main/java/com/openautolink/app/OalApplication.kt
@@ -43,6 +43,11 @@ class OalApplication : Application() {
         // shutdown burns a 45s timeout into a dead WiFi.
         com.openautolink.app.input.IgnitionMonitor.start(this)
 
+        // Passive, process-scope pre-wake diagnostics. This must be initialized
+        // after the VHAL observer and before Bluetooth advertising so it can
+        // observe (but never cause) the complete pre-ignition sequence.
+        com.openautolink.app.wake.PreWakeMonitor.initialize(this)
+
         // Android Auto Wireless BT advertiser.
         //
         // Must run at PROCESS scope, not session scope: its whole job is to make

--- a/app/src/main/java/com/openautolink/app/diagnostics/DiagnosticLog.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/DiagnosticLog.kt
@@ -18,6 +18,11 @@ data class LocalLogEntry(
     val message: String,
 )
 
+internal const val MAX_LOCAL_DIAGNOSTIC_MESSAGE_LENGTH = 500
+
+internal fun fitLocalDiagnosticMessage(message: String): String =
+    message.take(MAX_LOCAL_DIAGNOSTIC_MESSAGE_LENGTH)
+
 /**
  * Global diagnostic logger — subsystems call this to emit diagnostic log events.
  *
@@ -138,7 +143,7 @@ object DiagnosticLog {
             timestamp = System.currentTimeMillis(),
             level = level,
             tag = tag,
-            message = if (msg.length > 500) msg.take(500) else msg,
+            message = fitLocalDiagnosticMessage(msg),
         )
         synchronized(ring) {
             if (ring.size >= MAX_LOCAL_ENTRIES) ring.pollFirst()

--- a/app/src/main/java/com/openautolink/app/input/IgnitionMonitor.kt
+++ b/app/src/main/java/com/openautolink/app/input/IgnitionMonitor.kt
@@ -190,6 +190,9 @@ object IgnitionMonitor {
                             3 -> "ACC"; 4 -> "ON"; 5 -> "START"; else -> "?"
                         }
                         DiagnosticLog.i(TAG, "IGNITION_STATE → $v ($name) [was ${lastLoggedIgnition ?: "?"}]")
+                        if (v == 2 || v == 4 || v == 5) {
+                            com.openautolink.app.wake.PreWakeMonitor.reportIgnition(v)
+                        }
                         lastLoggedIgnition = v
                     }
                     // Stamp the transition into a non-ON state so callers can

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -212,6 +212,9 @@ class SessionManager(
     /** Called by the UI whenever a surface becomes available or is destroyed. */
     fun publishSurface(surface: android.view.Surface?, width: Int, height: Int) {
         lastKnownSurface = surface?.let { Triple(it, width, height) }
+        if (surface != null && surface.isValid && width > 0 && height > 0) {
+            com.openautolink.app.wake.PreWakeMonitor.reportSurfaceReady(width, height)
+        }
         // attach() configures or swaps the MediaCodec output surface, which
         // blocks on the codec — and this is called from SurfaceView callbacks on
         // the main thread. One archived ANR's last main-thread line is exactly
@@ -1419,6 +1422,9 @@ class SessionManager(
         // handshake completing.
         com.openautolink.app.transport.bluetooth.AaWirelessBtControl.onCompanionSelected =
             { ip -> if (ip.isNotBlank()) session.dialCompanion(ip) }
+        // The new session is now current and its live companion callback is
+        // installed. Report readiness only at this truthful lifecycle point.
+        com.openautolink.app.wake.PreWakeMonitor.reportSessionReady()
         // Answer the phone's SensorStartRequest with current vehicle state.
         // Without this, a parked car never sends driving status and the phone
         // stays FULLY_RESTRICTED (no Maps keyboard). Issue #61.

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -1245,11 +1245,18 @@ object AaWirelessBtControl {
                 // SDP listener when Bluetooth returns.
                 ensureAdvertising()
             },
+            onSdpPublished = { elapsedMs ->
+                com.openautolink.app.wake.PreWakeMonitor.reportSdpPublished(elapsedMs)
+            },
+            onPhoneDialback = { elapsedMs ->
+                com.openautolink.app.wake.PreWakeMonitor.reportPhoneDialback(elapsedMs)
+            },
         )
         btServer = bt
         // Probe first: if the BT stack refuses to publish the record we want that
         // stated plainly in the log, not inferred later from the phone's silence.
-        OalLog.i(TAG, "SDP advertise capability: ${bt.canAdvertise()}")
+        val canAdvertise = bt.canAdvertise()
+        OalLog.i(TAG, "SDP advertise capability: $canAdvertise")
         // Re-resolve the address on every handshake rather than reusing the value
         // captured here: the car's AP is given a new subnet on each ignition
         // cycle, so this snapshot goes stale as soon as the car is restarted.

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothServerSocket
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.SystemClock
 import androidx.core.content.ContextCompat
 import com.openautolink.app.diagnostics.OalLog
 import com.openautolink.app.proto.Wireless
@@ -89,6 +90,8 @@ class AaWirelessBtServer(
     private val context: Context,
     parentScope: CoroutineScope,
     private val onUnexpectedAcceptLoopExit: () -> Unit = {},
+    onSdpPublished: (Long) -> Unit = {},
+    onPhoneDialback: (Long) -> Unit = {},
 ) {
     // Deliberately does NOT inherit parentScope.coroutineContext.
     //
@@ -104,6 +107,16 @@ class AaWirelessBtServer(
     // Only the dispatcher is taken from the parent. Lifecycle is ours, and stop()
     // now affects nothing but this server.
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val outcomeObserver = AsyncBluetoothOutcomeObserver(
+        enqueue = { observation ->
+            scope.launch(CoroutineName("AaWirelessBt-OutcomeObserver")) { observation() }
+        },
+        onSdpPublished = onSdpPublished,
+        onPhoneDialback = onPhoneDialback,
+        onFailure = { error ->
+            OalLog.w(TAG, "Bluetooth outcome observer failed: ${error.message}")
+        },
+    )
 
     private var aaServerSocket: BluetoothServerSocket? = null
     private var hfpServerSocket: BluetoothServerSocket? = null
@@ -300,13 +313,14 @@ class AaWirelessBtServer(
 
         try {
             aaServerSocket = adapter.listenUsingRfcommWithServiceRecord(SDP_NAME, AA_UUID)
-            OalLog.i(TAG, "Listening on Android Auto Wireless UUID $AA_UUID — " +
-                    "phone should now see this head unit as AAW capable")
         } catch (e: Exception) {
             OalLog.w(TAG, "Failed to publish AA Wireless SDP record: ${e.message}")
             running = false
             return false
         }
+        outcomeObserver.sdpPublishedAt(SystemClock.elapsedRealtime())
+        OalLog.i(TAG, "Listening on Android Auto Wireless UUID $AA_UUID — " +
+                "phone should now see this head unit as AAW capable")
 
         var consecutiveAcceptFailures = 0
         while (running && scope.isActive) {
@@ -324,6 +338,7 @@ class AaWirelessBtServer(
             }
 
             if (client != null) {
+                outcomeObserver.phoneDialbackAt(SystemClock.elapsedRealtime())
                 val remote = runCatching { client.remoteDevice?.address ?: "?" }.getOrDefault("?")
                 OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote")
                 // Flag it here rather than inside handleHandshake: the window that

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AsyncBluetoothOutcomeObserver.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AsyncBluetoothOutcomeObserver.kt
@@ -1,0 +1,17 @@
+package com.openautolink.app.transport.bluetooth
+
+/** Dispatches diagnostic observers away from the Bluetooth accept/handshake path. */
+class AsyncBluetoothOutcomeObserver(
+    private val enqueue: (() -> Unit) -> Unit,
+    private val onSdpPublished: (Long) -> Unit,
+    private val onPhoneDialback: (Long) -> Unit,
+    private val onFailure: (Throwable) -> Unit,
+) {
+    fun sdpPublishedAt(elapsedMs: Long) {
+        enqueue { runCatching { onSdpPublished(elapsedMs) }.onFailure(onFailure) }
+    }
+
+    fun phoneDialbackAt(elapsedMs: Long) {
+        enqueue { runCatching { onPhoneDialback(elapsedMs) }.onFailure(onFailure) }
+    }
+}

--- a/app/src/main/java/com/openautolink/app/wake/AttemptSummaryScheduler.kt
+++ b/app/src/main/java/com/openautolink/app/wake/AttemptSummaryScheduler.kt
@@ -1,0 +1,90 @@
+package com.openautolink.app.wake
+
+fun interface AttemptSummaryTimeout {
+    fun cancel()
+}
+
+enum class AttemptSummaryOutcome {
+    READY,
+    TIMEOUT,
+}
+
+/**
+ * Owns one terminal deadline per retained attempt. Attempt IDs, rather than a process-global
+ * sampler, identify every callback so an old timeout can never summarize a newer attempt.
+ */
+class AttemptSummaryScheduler(
+    private val timeoutMs: Long,
+    private val schedule: (Long, Long, () -> Unit) -> AttemptSummaryTimeout,
+    private val emit: (WakeSummary, AttemptSummaryOutcome) -> Unit,
+) {
+    private data class Pending(
+        var summary: WakeSummary,
+        val timeout: AttemptSummaryTimeout,
+    )
+
+    private val lock = Any()
+    private val pendingByAttempt = linkedMapOf<Long, Pending>()
+    private val completedAttemptIds = linkedSetOf<Long>()
+    private var retainedIds = linkedSetOf<Long>()
+
+    val retainedAttemptIds: Set<Long>
+        get() = synchronized(lock) { retainedIds.toSet() }
+
+    val activeTimeoutCount: Int
+        get() = synchronized(lock) { pendingByAttempt.size }
+
+    fun observe(current: WakeSummary, previous: WakeSummary?) {
+        val summaries = listOfNotNull(previous, current).associateBy { it.attemptId }
+        val evicted = mutableListOf<Pending>()
+        synchronized(lock) {
+            retainedIds = summaries.keys.toCollection(linkedSetOf())
+            completedAttemptIds.retainAll(retainedIds)
+
+            val staleIds = pendingByAttempt.keys.filter { it !in retainedIds }
+            staleIds.forEach { staleId ->
+                pendingByAttempt.remove(staleId)?.let { pending ->
+                    completedAttemptIds += staleId
+                    evicted += pending
+                }
+            }
+
+            summaries.forEach { (attemptId, summary) ->
+                val existing = pendingByAttempt[attemptId]
+                if (existing != null) {
+                    existing.summary = summary
+                } else if (attemptId !in completedAttemptIds) {
+                    val timeout = schedule(attemptId, timeoutMs) { timeout(attemptId) }
+                    pendingByAttempt[attemptId] = Pending(summary, timeout)
+                }
+            }
+        }
+        evicted.forEach { pending ->
+            pending.timeout.cancel()
+            emit(pending.summary, AttemptSummaryOutcome.TIMEOUT)
+        }
+    }
+
+    fun ready(summary: WakeSummary): Boolean =
+        resolve(summary.attemptId, summary, AttemptSummaryOutcome.READY)
+
+    private fun timeout(attemptId: Long) {
+        resolve(attemptId, null, AttemptSummaryOutcome.TIMEOUT)
+    }
+
+    private fun resolve(
+        attemptId: Long,
+        suppliedSummary: WakeSummary?,
+        outcome: AttemptSummaryOutcome,
+    ): Boolean {
+        val resolved = synchronized(lock) {
+            val active = pendingByAttempt.remove(attemptId) ?: return false
+            completedAttemptIds += attemptId
+            active to (suppliedSummary ?: active.summary)
+        }
+        val (pending, summary) = resolved
+        pending.timeout.cancel()
+        emit(summary, outcome)
+        return true
+    }
+}

--- a/app/src/main/java/com/openautolink/app/wake/GmBroadcastIngressLimiter.kt
+++ b/app/src/main/java/com/openautolink/app/wake/GmBroadcastIngressLimiter.kt
@@ -1,0 +1,116 @@
+package com.openautolink.app.wake
+
+enum class GmIngressOutcome {
+    ACCEPTED,
+    DUPLICATE,
+    WINDOW_LIMITED,
+    HARD_CAPPED,
+}
+
+data class GmIngressResult(
+    val allowed: Boolean,
+    val outcome: GmIngressOutcome,
+    val shouldLogSuppression: Boolean,
+)
+
+/** Stable, bounded keys for exported broadcasts that do not carry an integer state. */
+object GmIngressDedupeKey {
+    const val ACTION_ONLY = 0
+
+    fun poweroffView(view: Boolean?, mute: Boolean?, fpi: Boolean?): Int =
+        view.asTrit() + (mute.asTrit() * 3) + (fpi.asTrit() * 9)
+
+    private fun Boolean?.asTrit(): Int = when (this) {
+        null -> 0
+        false -> 1
+        true -> 2
+    }
+}
+
+/** Pure, per-action availability guard for exported untrusted GM diagnostics. */
+class GmBroadcastIngressLimiter(
+    private val windowMs: Long = 1_000L,
+    private val maxPerWindow: Int = 8,
+    private val hardCapPerEpoch: Int = 64,
+) {
+    private data class ActionState(
+        var epoch: Long,
+        var acceptedTotal: Int = 0,
+        val acceptedInWindow: ArrayDeque<Long> = ArrayDeque(),
+        var hasLastRaw: Boolean = false,
+        var lastRaw: Int? = null,
+        var lastSeenAtMs: Long = Long.MIN_VALUE,
+        val loggedSuppressions: MutableSet<GmIngressOutcome> = mutableSetOf(),
+    )
+
+    private val states = mutableMapOf<String, ActionState>()
+
+    init {
+        require(windowMs > 0L)
+        require(maxPerWindow > 0)
+        require(hardCapPerEpoch > 0)
+    }
+
+    @Synchronized
+    fun evaluate(action: String, rawValue: Int?, elapsedMs: Long, epoch: Long): GmIngressResult {
+        val state = states.getOrPut(action) { ActionState(epoch) }
+        if (state.epoch != epoch) state.reset(epoch)
+
+        val cutoff = elapsedMs - windowMs
+        while (state.acceptedInWindow.firstOrNull()?.let { it <= cutoff } == true) {
+            state.acceptedInWindow.removeFirst()
+        }
+
+        val duplicate =
+            state.hasLastRaw && state.lastRaw == rawValue &&
+                elapsedMs - state.lastSeenAtMs < windowMs
+        state.hasLastRaw = true
+        state.lastRaw = rawValue
+        state.lastSeenAtMs = elapsedMs
+        if (duplicate) {
+            return state.suppressed(GmIngressOutcome.DUPLICATE)
+        }
+        if (state.acceptedTotal >= hardCapPerEpoch) {
+            return state.suppressed(GmIngressOutcome.HARD_CAPPED)
+        }
+        if (state.acceptedInWindow.size >= maxPerWindow) {
+            return state.suppressed(GmIngressOutcome.WINDOW_LIMITED)
+        }
+
+        state.acceptedTotal++
+        state.acceptedInWindow.addLast(elapsedMs)
+        return GmIngressResult(true, GmIngressOutcome.ACCEPTED, false)
+    }
+
+    fun handle(
+        action: String,
+        rawValue: Int?,
+        elapsedMs: Long,
+        epoch: Long,
+        onAccepted: () -> Unit,
+    ): GmIngressResult {
+        val result = evaluate(action, rawValue, elapsedMs, epoch)
+        if (result.allowed) onAccepted()
+        return result
+    }
+
+    @Synchronized
+    fun acceptedCount(action: String): Int = states[action]?.acceptedTotal ?: 0
+
+    private fun ActionState.reset(newEpoch: Long) {
+        epoch = newEpoch
+        acceptedTotal = 0
+        acceptedInWindow.clear()
+        hasLastRaw = false
+        lastRaw = null
+        lastSeenAtMs = Long.MIN_VALUE
+        loggedSuppressions.clear()
+    }
+
+    private fun ActionState.suppressed(outcome: GmIngressOutcome): GmIngressResult =
+        GmIngressResult(
+            allowed = false,
+            outcome = outcome,
+            shouldLogSuppression = loggedSuppressions.add(outcome),
+        )
+}

--- a/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
+++ b/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
@@ -1,0 +1,652 @@
+package com.openautolink.app.wake
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.hardware.display.DisplayManager
+import android.os.PowerManager
+import android.os.Process
+import android.os.SystemClock
+import android.provider.Settings
+import android.view.Display
+import androidx.core.content.ContextCompat
+import com.openautolink.app.data.AppPreferences
+import com.openautolink.app.diagnostics.DiagnosticLog
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/**
+ * Process-scope, passive observer for the pre-ignition window.
+ *
+ * All access to [reducer], its summaries, sampler generation and summary emission is serialized
+ * through [stateLock]. Task 2's reducer intentionally owns mutable state and is not thread-safe;
+ * receiver, display, VHAL, Activity and session callbacks can arrive on different threads.
+ *
+ * This object only reads framework state and writes diagnostics. It never publishes SDP, starts
+ * projection, dials a peer, requests a network, binds process traffic, or changes transport state.
+ */
+object PreWakeMonitor {
+    private const val TAG = "PreWakeMonitor"
+    private const val GM_SYSTEM_STATE = "gm.intent.action.SYSTEM_STATE_CHANGED"
+    private const val GM_POWER_MODE = "gm.intent.action.POWER_MODE_CHANGED"
+    private const val GM_POWEROFF_VIEW = "gm.intent.ACTION_BROADCAST_POWEROFF_VIEW"
+    private const val GM_HOME_STARTED = "com.gm.HOME_STARTED"
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val stateLock = Any()
+    private val policy = PreWakeSignalPolicy()
+    private val reducer = WakeAttemptReducer { nextAttemptId++ }
+    private val gmDeliveryEvidence = GmDeliveryEvidenceTracker()
+    private val gmIngressLimiter = GmBroadcastIngressLimiter()
+    private val receivers = mutableListOf<BroadcastReceiver>()
+    private val summaryScheduler = AttemptSummaryScheduler(
+        timeoutMs = PreWakeSignalPolicy.DEFAULT_SAMPLING_PLAN.durationMs,
+        schedule = { attemptId, delayMs, callback ->
+            val job = scope.launch {
+                delay(delayMs)
+                callback()
+            }
+            AttemptSummaryTimeout { job.cancel() }
+        },
+        emit = { summary, outcome -> emitSummary(summary, outcome.name.lowercase()) },
+    )
+
+    private var nextAttemptId = 1L
+    private var initialized = false
+    private var applicationContext: Context? = null
+    private var processStartElapsedMs = 0L
+    private var powerEpoch = 0L
+    private var samplerJob: Job? = null
+    private var samplerGeneration = 0L
+    private var configuredApInterface = AppPreferences.DEFAULT_WPP_AP_INTERFACE
+    private var lastApSnapshot: ApSnapshot? = null
+    private var lastDisplayState: Int? = null
+
+    fun initialize(context: Context) {
+        val app = context.applicationContext
+        synchronized(stateLock) {
+            if (initialized) {
+                DiagnosticLog.i(TAG, "WAKE EVENT monitor init outcome=already-initialized")
+                return
+            }
+            initialized = true
+            applicationContext = app
+            processStartElapsedMs = SystemClock.elapsedRealtime()
+        }
+
+        registerGmReceiver(app, "SYSTEM_STATE_CHANGED", GM_SYSTEM_STATE) { intent ->
+            val elapsedMs = SystemClock.elapsedRealtime()
+            val raw = intExtraOrNull(intent, "System_State")
+            if (!allowGmIngress(GM_SYSTEM_STATE, raw, elapsedMs)) return@registerGmReceiver
+            if (raw == null) {
+                recordGmDelivery(GmDeliverySignal.SYSTEM_STATE, elapsedMs)
+                DiagnosticLog.w(TAG, "WAKE EVENT GM System_State outcome=missing-extra")
+            } else {
+                record(
+                    policy.gmSystemState(raw, elapsedMs),
+                    candidateSource = true,
+                    gmDeliverySignal = GmDeliverySignal.SYSTEM_STATE,
+                )
+            }
+            readCapabilities(app, "GM System_State")
+            sampleAp("GM System_State")
+        }
+        registerGmReceiver(app, "POWER_MODE_CHANGED", GM_POWER_MODE) { intent ->
+            val elapsedMs = SystemClock.elapsedRealtime()
+            val raw = intExtraOrNull(intent, "power_mode")
+            if (!allowGmIngress(GM_POWER_MODE, raw, elapsedMs)) return@registerGmReceiver
+            if (raw == null) {
+                recordGmDelivery(GmDeliverySignal.POWER_MODE, elapsedMs)
+                DiagnosticLog.w(TAG, "WAKE EVENT GM power_mode outcome=missing-extra")
+            } else {
+                record(
+                    policy.gmPowerMode(raw, elapsedMs),
+                    candidateSource = true,
+                )
+                recordGmDelivery(GmDeliverySignal.POWER_MODE, elapsedMs)
+            }
+            readCapabilities(app, "GM power_mode")
+            sampleAp("GM power_mode")
+        }
+        registerGmReceiver(app, "POWEROFF_VIEW", GM_POWEROFF_VIEW) { intent ->
+            val elapsedMs = SystemClock.elapsedRealtime()
+            val view = booleanExtra(intent, "gm.poweroff_view_state")
+            val mute = booleanExtra(intent, "gm.poweroff_mute_state")
+            val fpi = booleanExtra(intent, "gm.poweroff_fpi_state")
+            val dedupeKey = GmIngressDedupeKey.poweroffView(view, mute, fpi)
+            if (!allowGmIngress(GM_POWEROFF_VIEW, dedupeKey, elapsedMs)) {
+                return@registerGmReceiver
+            }
+            recordGmDelivery(GmDeliverySignal.POWEROFF_VIEW, elapsedMs)
+            val values = listOf(
+                "view" to view,
+                "mute" to mute,
+                "fpi" to fpi,
+            ).joinToString(",") { (name, value) -> "$name=${value ?: "missing"}" }
+            DiagnosticLog.i(
+                TAG,
+                "WAKE EVENT GM POWEROFF_VIEW detail=$values hintOnly=true outcome=recorded",
+            )
+            readCapabilities(app, "GM POWEROFF_VIEW")
+        }
+        registerGmReceiver(app, "HOME_STARTED(optional)", GM_HOME_STARTED) {
+            val elapsedMs = SystemClock.elapsedRealtime()
+            if (!allowGmIngress(
+                    GM_HOME_STARTED,
+                    GmIngressDedupeKey.ACTION_ONLY,
+                    elapsedMs,
+                )
+            ) {
+                return@registerGmReceiver
+            }
+            recordGmDelivery(GmDeliverySignal.HOME_STARTED, elapsedMs)
+            DiagnosticLog.i(
+                TAG,
+                "WAKE EVENT GM HOME_STARTED hintOnly=true outcome=delivered-recorded",
+            )
+            readCapabilities(app, "GM HOME_STARTED")
+        }
+        registerBluetoothReceiver(app)
+        registerDisplayListener(app)
+
+        recordRaw(WakeEvent(WakeSignal.PROCESS_START, processStartElapsedMs, "pid=${Process.myPid()}"))
+        logEpoch(app, "process-start")
+        readCapabilities(app, "process-start")
+
+        scope.launch {
+            configuredApInterface = runCatching {
+                AppPreferences.getInstance(app).wppApInterface.first()
+            }.getOrElse { error ->
+                DiagnosticLog.w(
+                    TAG,
+                    "WAKE EVENT AP config outcome=read-failed error=${safe(error.javaClass.simpleName)}",
+                )
+                AppPreferences.DEFAULT_WPP_AP_INTERFACE
+            }.ifBlank { AppPreferences.DEFAULT_WPP_AP_INTERFACE }
+            DiagnosticLog.i(
+                TAG,
+                "WAKE EVENT AP config interface=${safe(configuredApInterface)} outcome=available",
+            )
+            sampleApNow("process-start", candidateSource = false)
+        }
+    }
+
+    fun reportIgnition(rawState: Int) {
+        val elapsedMs = SystemClock.elapsedRealtime()
+        if (rawState == 2) synchronized(stateLock) { powerEpoch++ }
+        record(policy.ignitionState(rawState, elapsedMs), candidateSource = true)
+        sampleAp("ignition-$rawState")
+    }
+
+    fun reportActivity(callback: PreWakeActivityCallback) {
+        record(policy.activity(callback, SystemClock.elapsedRealtime()), candidateSource = true)
+    }
+
+    fun reportSessionReady() {
+        record(policy.sessionReady(SystemClock.elapsedRealtime()), candidateSource = false)
+    }
+
+    fun reportSurfaceReady(width: Int, height: Int) {
+        record(policy.surfaceReady(width, height, SystemClock.elapsedRealtime()), candidateSource = false)
+    }
+
+    fun reportSdpPublished(elapsedMs: Long) {
+        record(policy.sdpPublished(elapsedMs), candidateSource = false)
+    }
+
+    fun reportPhoneDialback(elapsedMs: Long) {
+        record(policy.phoneDialback(elapsedMs), candidateSource = false)
+    }
+
+    private fun registerGmReceiver(
+        context: Context,
+        label: String,
+        action: String,
+        onReceive: (Intent) -> Unit,
+    ) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action != action) {
+                    DiagnosticLog.w(TAG, "WAKE EVENT GM $label outcome=ignored-action")
+                    return
+                }
+                runCatching { onReceive(intent) }
+                    .onFailure { error ->
+                        DiagnosticLog.w(
+                            TAG,
+                            "WAKE EVENT GM $label outcome=delivery-failed " +
+                                "error=${safe(error.javaClass.simpleName)}",
+                        )
+                    }
+            }
+        }
+        try {
+            // GM senders are separate UIDs. Export is deliberate; SYSTEM_STATE and POWER_MODE
+            // remain untrusted hints, while protected owner broadcasts still require delivery
+            // across a UID boundary. Each action gets its own receiver and outcome line.
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                IntentFilter(action),
+                ContextCompat.RECEIVER_EXPORTED,
+            )
+            synchronized(stateLock) { receivers += receiver }
+            DiagnosticLog.i(
+                TAG,
+                "WAKE EVENT GM receiver=$label exported=true outcome=registration-succeeded " +
+                    "deliveryProof=false",
+            )
+        } catch (error: Throwable) {
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT GM receiver=$label exported=true outcome=registration-failed " +
+                    "error=${safe(error.javaClass.simpleName)}",
+            )
+        }
+    }
+
+    private fun registerBluetoothReceiver(context: Context) {
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action != BluetoothAdapter.ACTION_STATE_CHANGED) {
+                    DiagnosticLog.w(TAG, "WAKE EVENT Bluetooth outcome=ignored-action")
+                    return
+                }
+                if (!intent.hasExtra(BluetoothAdapter.EXTRA_STATE)) {
+                    DiagnosticLog.w(TAG, "WAKE EVENT Bluetooth outcome=missing-extra")
+                    return
+                }
+                val raw = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, Int.MIN_VALUE)
+                record(policy.bluetoothState(raw, SystemClock.elapsedRealtime()), candidateSource = true)
+                sampleAp("bluetooth-$raw")
+            }
+        }
+        try {
+            ContextCompat.registerReceiver(
+                context,
+                receiver,
+                IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED),
+                ContextCompat.RECEIVER_EXPORTED,
+            )
+            synchronized(stateLock) { receivers += receiver }
+            DiagnosticLog.i(TAG, "WAKE EVENT Bluetooth receiver exported=true outcome=registration-succeeded")
+        } catch (error: Throwable) {
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT Bluetooth receiver exported=true outcome=registration-failed " +
+                    "error=${safe(error.javaClass.simpleName)}",
+            )
+        }
+    }
+
+    private fun registerDisplayListener(context: Context) {
+        val manager = context.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager
+        if (manager == null) {
+            DiagnosticLog.w(TAG, "WAKE EVENT display listener outcome=service-unavailable")
+            return
+        }
+        val listener = object : DisplayManager.DisplayListener {
+            override fun onDisplayAdded(displayId: Int) = recordDisplay(manager, displayId, "added")
+            override fun onDisplayRemoved(displayId: Int) {
+                if (displayId == Display.DEFAULT_DISPLAY) {
+                    DiagnosticLog.i(TAG, "WAKE EVENT display=default state=REMOVED outcome=transition-recorded")
+                }
+            }
+            override fun onDisplayChanged(displayId: Int) = recordDisplay(manager, displayId, "changed")
+        }
+        try {
+            manager.registerDisplayListener(listener, null)
+            DiagnosticLog.i(TAG, "WAKE EVENT display listener outcome=registration-succeeded")
+            recordDisplay(manager, Display.DEFAULT_DISPLAY, "initial")
+        } catch (error: Throwable) {
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT display listener outcome=registration-failed " +
+                    "error=${safe(error.javaClass.simpleName)}",
+            )
+        }
+    }
+
+    private fun recordDisplay(manager: DisplayManager, displayId: Int, source: String) {
+        if (displayId != Display.DEFAULT_DISPLAY) return
+        val state = manager.getDisplay(displayId)?.state
+        if (state == null) {
+            DiagnosticLog.w(TAG, "WAKE EVENT display=default source=$source outcome=not-available")
+            return
+        }
+        val changed = synchronized(stateLock) {
+            if (lastDisplayState == state) false else {
+                lastDisplayState = state
+                true
+            }
+        }
+        if (changed) {
+            DiagnosticLog.i(
+                TAG,
+                "WAKE EVENT display=default state=${displayStateName(state)} source=$source " +
+                    "evidence=screen-only outcome=transition-recorded",
+            )
+        }
+    }
+
+    private fun record(
+        decision: PreWakePolicyDecision,
+        candidateSource: Boolean,
+        gmDeliverySignal: GmDeliverySignal? = null,
+    ) {
+        val event = decision.event
+        val outcome = if (event == null) "auxiliary-recorded" else "recorded"
+        DiagnosticLog.i(
+            TAG,
+            "WAKE EVENT kind=${decision.observation.kind} detail=${decision.observation.detail} " +
+                "hintOnly=${decision.observation.hintOnly} readiness=${decision.impliesSessionReadiness} " +
+                "authorization=${decision.authorizesBehavior} outcome=$outcome",
+        )
+        if (event != null) {
+            recordRaw(event, gmDeliverySignal)
+        }
+
+        if (candidateSource && decision.sampling != null) {
+            applicationContext?.let { logEpoch(it, decision.observation.kind.name) }
+            startSampler(decision.sampling, decision.observation.kind.name)
+        }
+    }
+
+    private fun recordRaw(event: WakeEvent, gmDeliverySignal: GmDeliverySignal? = null) {
+        val summary = synchronized(stateLock) {
+            val current = reducer.record(event)
+            gmDeliveryEvidence.retain(reducer.retainedAttemptWindows())
+            if (gmDeliverySignal != null) {
+                gmDeliveryEvidence.observeAt(event.elapsedMs, gmDeliverySignal)
+            }
+            summaryScheduler.observe(current, reducer.previousSummary)
+            current
+        }
+        if (summary.sessionReadyAtMs != null && summary.surfaceReadyAtMs != null) {
+            finishSampler("ready")
+            summaryScheduler.ready(summary)
+        }
+    }
+
+    private fun recordGmDelivery(signal: GmDeliverySignal, elapsedMs: Long) {
+        synchronized(stateLock) {
+            gmDeliveryEvidence.retain(reducer.retainedAttemptWindows())
+            gmDeliveryEvidence.observeAt(elapsedMs, signal)
+        }
+    }
+
+    private fun allowGmIngress(action: String, rawValue: Int?, elapsedMs: Long): Boolean {
+        val epoch = synchronized(stateLock) { powerEpoch }
+        val result = gmIngressLimiter.evaluate(action, rawValue, elapsedMs, epoch)
+        if (!result.allowed && result.shouldLogSuppression) {
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT GM ingress action=${safe(action)} outcome=" +
+                    result.outcome.name.lowercase(),
+            )
+        }
+        return result.allowed
+    }
+
+    private fun startSampler(plan: PreWakeSamplingPlan, source: String) {
+        synchronized(stateLock) {
+            if (samplerJob?.isActive == true) {
+                DiagnosticLog.i(
+                    TAG,
+                    "WAKE EVENT sampler source=$source outcome=coalesced generation=$samplerGeneration",
+                )
+                return
+            }
+            samplerGeneration += 1L
+            val generation = samplerGeneration
+            samplerJob = scope.launch {
+                val startedAt = SystemClock.elapsedRealtime()
+                val deadline = startedAt + plan.durationMs
+                DiagnosticLog.i(
+                    TAG,
+                    "WAKE EVENT sampler source=$source intervalMs=${plan.intervalMs} " +
+                        "durationMs=${plan.durationMs} generation=$generation outcome=started",
+                )
+                while (isActive && SystemClock.elapsedRealtime() < deadline) {
+                    sampleApNow("sampler-$generation", candidateSource = false)
+                    delay(plan.intervalMs)
+                }
+                if (isActive) {
+                    DiagnosticLog.i(
+                        TAG,
+                        "WAKE EVENT sampler generation=$generation elapsedMs=" +
+                            "${SystemClock.elapsedRealtime() - startedAt} outcome=timeout-finished",
+                    )
+                    synchronized(stateLock) {
+                        if (samplerGeneration == generation) samplerJob = null
+                    }
+                }
+            }
+        }
+    }
+
+    private fun finishSampler(outcome: String) {
+        val job = synchronized(stateLock) {
+            samplerGeneration += 1L
+            samplerJob.also { samplerJob = null }
+        }
+        if (job != null) {
+            job.cancel()
+            DiagnosticLog.i(TAG, "WAKE EVENT sampler outcome=${safe(outcome)}-finished")
+        }
+    }
+
+    private fun emitSummary(summary: WakeSummary, outcome: String) {
+        val gmEvidenceFields = synchronized(stateLock) {
+            gmDeliveryEvidence.format(summary.attemptId)
+        }
+        val missing = buildList {
+            if (summary.btReadyAtMs == null) add("BLUETOOTH_ON")
+            if (summary.apReadyAtMs == null) add("AP_PRESENT")
+            if (summary.ignitionOnAtMs == null) add("IGNITION_ON")
+            if (summary.activityStartedAtMs == null) add("ACTIVITY_START")
+            if (summary.sessionReadyAtMs == null) add("SESSION_READY")
+            if (summary.surfaceReadyAtMs == null) add("SURFACE_READY")
+        }.joinToString(",").ifEmpty { "none" }
+        val line = WakeSummaryFormatter.formatForDiagnosticLog(
+            summary = summary,
+            gmEvidenceFields = gmEvidenceFields,
+            outcome = safe(outcome),
+            missing = missing,
+        )
+        if (outcome == "timeout") DiagnosticLog.w(TAG, line) else DiagnosticLog.i(TAG, line)
+    }
+
+    private fun sampleAp(reason: String) {
+        scope.launch { sampleApNow(reason, candidateSource = false) }
+    }
+
+    private fun sampleApNow(reason: String, candidateSource: Boolean) {
+        val interfaceName = configuredApInterface
+        val snapshot = try {
+            val networkInterface = NetworkInterface.getByName(interfaceName)
+            val ip = networkInterface
+                ?.takeIf { it.isUp }
+                ?.inetAddresses
+                ?.toList()
+                ?.filterIsInstance<Inet4Address>()
+                ?.firstOrNull { !it.isLoopbackAddress && !it.isLinkLocalAddress }
+                ?.hostAddress
+            ApSnapshot(ip = ip, error = null)
+        } catch (error: Throwable) {
+            ApSnapshot(ip = null, error = error.javaClass.simpleName)
+        }
+        val previous = synchronized(stateLock) {
+            val old = lastApSnapshot
+            lastApSnapshot = snapshot
+            old
+        }
+        if (previous != snapshot) {
+            val decision = policy.accessPoint(interfaceName, snapshot.ip, SystemClock.elapsedRealtime())
+            DiagnosticLog.i(
+                TAG,
+                "AP interface transition interface=${safe(interfaceName)} " +
+                    "from=${safe(previous?.ip ?: "absent")} to=${safe(snapshot.ip ?: "absent")} " +
+                    "reason=${safe(reason)} error=${safe(snapshot.error ?: "-")} outcome=recorded",
+            )
+            record(decision, candidateSource)
+        }
+    }
+
+    private fun readCapabilities(context: Context, reason: String) {
+        CAPABILITY_KEYS.forEach { key ->
+            try {
+                val value = Settings.Global.getString(context.contentResolver, key)
+                DiagnosticLog.i(
+                    TAG,
+                    "WAKE EVENT setting=$key reason=${safe(reason)} available=${value != null} " +
+                        "value=${safe(value ?: "-")} error=- outcome=read-complete",
+                )
+            } catch (error: Throwable) {
+                DiagnosticLog.w(
+                    TAG,
+                    "WAKE EVENT setting=$key reason=${safe(reason)} available=false value=- " +
+                        "error=${safe(error.javaClass.simpleName)} outcome=read-failed",
+                )
+            }
+        }
+    }
+
+    private fun logEpoch(context: Context, reason: String) {
+        val bootCount = try {
+            "value=${Settings.Global.getInt(context.contentResolver, Settings.Global.BOOT_COUNT)}"
+        } catch (error: Throwable) {
+            "error=${safe(error.javaClass.simpleName)}"
+        }
+        val interactive = runCatching {
+            (context.getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
+        }.fold(onSuccess = { it.toString() }, onFailure = { "error:${safe(it.javaClass.simpleName)}" })
+        val displayState = runCatching {
+            val manager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
+            manager.getDisplay(Display.DEFAULT_DISPLAY)?.state?.let(::displayStateName) ?: "unavailable"
+        }.getOrElse { "error:${safe(it.javaClass.simpleName)}" }
+        DiagnosticLog.i(
+            TAG,
+            "WAKE EVENT epoch reason=${safe(reason)} pid=${Process.myPid()} " +
+                "processStartElapsedMs=$processStartElapsedMs nowElapsedMs=${SystemClock.elapsedRealtime()} " +
+                "wallTimeMs=${System.currentTimeMillis()} bootCount=$bootCount " +
+                "interactive=$interactive display=$displayState outcome=recorded",
+        )
+    }
+
+    private fun intExtraOrNull(intent: Intent, name: String): Int? =
+        if (intent.hasExtra(name)) intent.getIntExtra(name, Int.MIN_VALUE) else null
+
+    private fun booleanExtra(intent: Intent, name: String): Boolean? =
+        if (intent.hasExtra(name)) intent.getBooleanExtra(name, false) else null
+
+    private fun displayStateName(state: Int): String = when (state) {
+        Display.STATE_OFF -> "OFF"
+        Display.STATE_ON -> "ON"
+        Display.STATE_DOZE -> "DOZE"
+        Display.STATE_DOZE_SUSPEND -> "DOZE_SUSPEND"
+        Display.STATE_VR -> "VR"
+        Display.STATE_ON_SUSPEND -> "ON_SUSPEND"
+        else -> "RAW_$state"
+    }
+
+    private fun safe(value: String): String = value
+        .replace(Regex("[\\p{Cc}>(),=]"), "_")
+        .take(96)
+
+    private data class ApSnapshot(val ip: String?, val error: String?)
+
+    private val CAPABILITY_KEYS = listOf(
+        "fid_wifi_disable_status",
+        "fid_hotspot_disable_status",
+        "hmi_hotspot_disable_status",
+        "share_hotspot_data_status",
+        "car_data_subscription_status",
+        "cellular_network_available_status",
+        "data_services_enabled",
+    )
+}
+
+enum class GmDeliverySignal(val summaryField: String) {
+    SYSTEM_STATE("gmSystemState"),
+    POWER_MODE("gmPowerMode"),
+    POWEROFF_VIEW("gmPoweroffView"),
+    HOME_STARTED("gmHomeStarted"),
+}
+
+/** Keeps explicit GM-delivery evidence only for the reducer's current and previous attempt. */
+class GmDeliveryEvidenceTracker {
+    private val observationsByAttempt = mutableMapOf<Long, MutableSet<GmDeliverySignal>>()
+    private val pendingBySignal = mutableMapOf<GmDeliverySignal, Long>()
+    private var windows: List<WakeAttemptWindow> = emptyList()
+
+    var retainedAttemptIds: Set<Long> = emptySet()
+        private set
+
+    fun retain(currentAttemptId: Long, previousAttemptId: Long?) {
+        windows = emptyList()
+        retainedAttemptIds = buildSet {
+            previousAttemptId?.let(::add)
+            add(currentAttemptId)
+        }
+        observationsByAttempt.keys.retainAll(retainedAttemptIds)
+    }
+
+    fun retain(windows: List<WakeAttemptWindow>) {
+        this.windows = windows.takeLast(2)
+        retainedAttemptIds = this.windows.mapTo(linkedSetOf()) { it.attemptId }
+        observationsByAttempt.keys.retainAll(retainedAttemptIds)
+        val pending = pendingBySignal.toMap()
+        pendingBySignal.clear()
+        pending.forEach { (signal, elapsedMs) ->
+            val attemptId = attemptIdFor(elapsedMs)
+            when {
+                attemptId != null -> observe(attemptId, signal)
+                shouldKeepPending(elapsedMs) -> pendingBySignal[signal] = elapsedMs
+            }
+        }
+    }
+
+    fun observeAt(elapsedMs: Long, signal: GmDeliverySignal) {
+        val attemptId = attemptIdFor(elapsedMs)
+        if (attemptId == null) {
+            pendingBySignal[signal] = elapsedMs
+        } else {
+            observe(attemptId, signal)
+        }
+    }
+
+    fun observe(attemptId: Long, signal: GmDeliverySignal) {
+        if (attemptId !in retainedAttemptIds) return
+        observationsByAttempt.getOrPut(attemptId) { mutableSetOf() } += signal
+    }
+
+    fun format(attemptId: Long): String {
+        val observed = observationsByAttempt[attemptId].orEmpty()
+        return GmDeliverySignal.entries.joinToString(" ") { signal ->
+            "${signal.summaryField}=${if (signal in observed) "observed" else "not_observed"}"
+        }
+    }
+
+    private fun attemptIdFor(elapsedMs: Long): Long? = windows
+        .lastOrNull { window ->
+            (window.startsAfterMs == null || elapsedMs > window.startsAfterMs) &&
+                (window.endsAtMs == null || elapsedMs <= window.endsAtMs)
+        }
+        ?.attemptId
+
+    private fun shouldKeepPending(elapsedMs: Long): Boolean {
+        val newest = windows.lastOrNull() ?: return true
+        return newest.endsAtMs != null && elapsedMs > newest.endsAtMs
+    }
+}

--- a/app/src/main/java/com/openautolink/app/wake/PreWakeSignalPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/wake/PreWakeSignalPolicy.kt
@@ -1,0 +1,227 @@
+package com.openautolink.app.wake
+
+/** A typed, privacy-safe observation produced by [PreWakeSignalPolicy]. */
+data class PreWakeObservation(
+    val kind: PreWakeObservationKind,
+    val detail: String,
+    /** GM broadcasts are evidence for diagnostics only, never authorization. */
+    val hintOnly: Boolean = false,
+)
+
+enum class PreWakeObservationKind {
+    GM_SYSTEM_STATE,
+    GM_POWER_MODE,
+    BLUETOOTH_STATE,
+    ACCESS_POINT,
+    IGNITION,
+    ACTIVITY,
+    SESSION,
+    SURFACE,
+    SDP,
+    PHONE_DIALBACK,
+}
+
+enum class PreWakeActivityCallback { START, RESUME, PAUSE, STOP }
+
+data class PreWakeSamplingPlan(
+    val intervalMs: Long,
+    val durationMs: Long,
+) {
+    init {
+        require(intervalMs > 0L)
+        require(durationMs >= intervalMs)
+    }
+
+    val maximumSamples: Int = ((durationMs + intervalMs - 1L) / intervalMs).toInt()
+    val isBounded: Boolean = maximumSamples > 0
+}
+
+data class PreWakePolicyDecision(
+    val observation: PreWakeObservation,
+    val event: WakeEvent?,
+    val sampling: PreWakeSamplingPlan? = null,
+    /** True only for the truthful SESSION_READY callback, never for environmental hints. */
+    val impliesSessionReadiness: Boolean = false,
+    /** This policy is diagnostic-only. No input authorizes projection behavior. */
+    val authorizesBehavior: Boolean = false,
+)
+
+/**
+ * Pure mapping from framework observations to the Task 2 wake vocabulary.
+ *
+ * This class deliberately owns no threads and performs no I/O. It cannot publish SDP, dial,
+ * launch projection, request a network, or otherwise authorize behavior. The process monitor
+ * serializes calls into the mutable [WakeAttemptReducer].
+ */
+class PreWakeSignalPolicy {
+
+    fun gmSystemState(rawState: Int, elapsedMs: Long): PreWakePolicyDecision {
+        val name = GM_SYSTEM_STATES[rawState] ?: "UNKNOWN"
+        return decision(
+            kind = PreWakeObservationKind.GM_SYSTEM_STATE,
+            detail = "raw=$rawState,name=$name",
+            event = WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs,
+                detail = "raw=$rawState,name=$name",
+            ),
+            wakeCandidate = rawState in GM_SYSTEM_STATES,
+            hintOnly = true,
+        )
+    }
+
+    fun gmPowerMode(rawMode: Int, elapsedMs: Long): PreWakePolicyDecision = decision(
+        kind = PreWakeObservationKind.GM_POWER_MODE,
+        detail = "raw=$rawMode",
+        // Task 2 intentionally has no readiness field for this spoofable broadcast.
+        event = null,
+        wakeCandidate = rawMode in GM_WAKE_POWER_MODES,
+        hintOnly = true,
+    )
+
+    fun bluetoothState(rawState: Int, elapsedMs: Long): PreWakePolicyDecision {
+        val signal = when (rawState) {
+            BLUETOOTH_STATE_ON -> WakeSignal.BLUETOOTH_ON
+            BLUETOOTH_STATE_OFF -> WakeSignal.BLUETOOTH_OFF
+            else -> null
+        }
+        return decision(
+            kind = PreWakeObservationKind.BLUETOOTH_STATE,
+            detail = "raw=$rawState",
+            event = signal?.let { WakeEvent(it, elapsedMs, "raw=$rawState") },
+            wakeCandidate = rawState == BLUETOOTH_STATE_ON,
+        )
+    }
+
+    fun accessPoint(
+        interfaceName: String,
+        localIpv4: String?,
+        elapsedMs: Long,
+    ): PreWakePolicyDecision {
+        val safeInterface = safeField(interfaceName)
+        val safeIp = localIpv4?.let(::safeField)?.takeIf { it.isNotBlank() }
+        val detail = if (safeIp == null) {
+            "interface=$safeInterface,ip=-"
+        } else {
+            "interface=$safeInterface,ip=$safeIp"
+        }
+        return decision(
+            kind = PreWakeObservationKind.ACCESS_POINT,
+            detail = detail,
+            event = WakeEvent(
+                if (safeIp == null) WakeSignal.AP_ABSENT else WakeSignal.AP_PRESENT,
+                elapsedMs,
+                detail,
+            ),
+            wakeCandidate = safeIp != null,
+        )
+    }
+
+    fun ignitionState(rawState: Int, elapsedMs: Long): PreWakePolicyDecision {
+        val signal = when (rawState) {
+            2 -> WakeSignal.IGNITION_OFF
+            4 -> WakeSignal.IGNITION_ON
+            5 -> WakeSignal.IGNITION_START
+            else -> null
+        }
+        return decision(
+            kind = PreWakeObservationKind.IGNITION,
+            detail = "raw=$rawState",
+            event = signal?.let { WakeEvent(it, elapsedMs, "raw=$rawState") },
+            wakeCandidate = rawState == 4 || rawState == 5,
+        )
+    }
+
+    fun activity(
+        callback: PreWakeActivityCallback,
+        elapsedMs: Long,
+    ): PreWakePolicyDecision {
+        val signal = when (callback) {
+            PreWakeActivityCallback.START -> WakeSignal.ACTIVITY_START
+            PreWakeActivityCallback.RESUME -> WakeSignal.ACTIVITY_RESUME
+            PreWakeActivityCallback.PAUSE,
+            PreWakeActivityCallback.STOP -> null
+        }
+        return decision(
+            kind = PreWakeObservationKind.ACTIVITY,
+            detail = "callback=${callback.name}",
+            event = signal?.let { WakeEvent(it, elapsedMs, callback.name) },
+            wakeCandidate = signal != null,
+        )
+    }
+
+    fun sessionReady(elapsedMs: Long): PreWakePolicyDecision = decision(
+        kind = PreWakeObservationKind.SESSION,
+        detail = "ready=true",
+        event = WakeEvent(WakeSignal.SESSION_READY, elapsedMs),
+        impliesSessionReadiness = true,
+    )
+
+    fun surfaceReady(width: Int, height: Int, elapsedMs: Long): PreWakePolicyDecision = decision(
+        kind = PreWakeObservationKind.SURFACE,
+        detail = "valid=true,size=${width}x$height",
+        event = WakeEvent(WakeSignal.SURFACE_READY, elapsedMs, "${width}x$height"),
+    )
+
+    fun sdpPublished(elapsedMs: Long): PreWakePolicyDecision = decision(
+        kind = PreWakeObservationKind.SDP,
+        detail = "published=true",
+        event = WakeEvent(WakeSignal.SDP_PUBLISHED, elapsedMs),
+    )
+
+    fun phoneDialback(elapsedMs: Long): PreWakePolicyDecision = decision(
+        kind = PreWakeObservationKind.PHONE_DIALBACK,
+        detail = "accepted=true",
+        event = WakeEvent(WakeSignal.PHONE_DIALBACK, elapsedMs),
+    )
+
+    private fun decision(
+        kind: PreWakeObservationKind,
+        detail: String,
+        event: WakeEvent?,
+        wakeCandidate: Boolean = false,
+        hintOnly: Boolean = false,
+        impliesSessionReadiness: Boolean = false,
+    ) = PreWakePolicyDecision(
+        observation = PreWakeObservation(kind, safeDetail(detail), hintOnly),
+        event = event?.copy(detail = safeDetail(event.detail)),
+        sampling = if (wakeCandidate) DEFAULT_SAMPLING_PLAN else null,
+        impliesSessionReadiness = impliesSessionReadiness,
+        authorizesBehavior = false,
+    )
+
+    private fun safeDetail(value: String): String = value
+        .replace(UNSAFE_DETAIL_CHARS, "_")
+        .take(MAX_DETAIL_LENGTH)
+
+    private fun safeField(value: String): String = value
+        .trim()
+        .replace(UNSAFE_FIELD_CHARS, "_")
+        .take(MAX_FIELD_LENGTH)
+
+    companion object {
+        const val BLUETOOTH_STATE_OFF = 10
+        const val BLUETOOTH_STATE_ON = 12
+        private const val MAX_FIELD_LENGTH = 64
+        private const val MAX_DETAIL_LENGTH = 160
+        private val UNSAFE_FIELD_CHARS = Regex("[^A-Za-z0-9._:-]")
+        private val UNSAFE_DETAIL_CHARS = Regex("[\\p{Cc}>()]")
+
+        val DEFAULT_SAMPLING_PLAN = PreWakeSamplingPlan(
+            intervalMs = 250L,
+            durationMs = 15_000L,
+        )
+
+        private val GM_SYSTEM_STATES = mapOf(
+            1 to "ANIMATION_INIT",
+            2 to "HMI_INIT",
+            3 to "HMI_INACTIVE",
+            4 to "START",
+            5 to "RUN",
+            6 to "PROPULSION",
+            7 to "ACCESSORY",
+            8 to "LOCAL_INFOTAINMENT",
+        )
+        private val GM_WAKE_POWER_MODES = setOf(2, 5) // ON/STARTUP and legacy RESUME
+    }
+}

--- a/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
+++ b/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
@@ -24,6 +24,12 @@ data class WakeEvent(
     val detail: String = "",
 )
 
+data class WakeAttemptWindow(
+    val attemptId: Long,
+    val startsAfterMs: Long?,
+    val endsAtMs: Long?,
+)
+
 data class WakeSummary(
     val attemptId: Long,
     val trigger: WakeSignal,
@@ -59,6 +65,15 @@ class WakeAttemptReducer(
     val currentSummary: WakeSummary?
         get() = currentAttempt?.toSummary()
 
+    fun retainedAttemptWindows(): List<WakeAttemptWindow> = listOfNotNull(
+        previousAttempt?.let { previous ->
+            WakeAttemptWindow(previous.id, previous.startsAfterMs, currentAttempt?.startsAfterMs)
+        },
+        currentAttempt?.let { current ->
+            WakeAttemptWindow(current.id, current.startsAfterMs, current.lastIgnitionOffMs())
+        },
+    )
+
     fun record(event: WakeEvent): WakeSummary {
         val existing = currentAttempt
         if (existing == null) {
@@ -67,7 +82,7 @@ class WakeAttemptReducer(
             previousAttempt
                 ?.takeIf { it.startsAfterMs == null || event.elapsedMs > it.startsAfterMs }
                 ?.let { previous ->
-                    previous.events += event
+                    previous.add(event)
                     previousSummary = previous.toSummary()
                 }
             return existing.toSummary()
@@ -87,7 +102,7 @@ class WakeAttemptReducer(
         }
 
         return currentAttempt!!.run {
-            events += event
+            add(event)
             toSummary()
         }
     }
@@ -102,10 +117,28 @@ class WakeAttemptReducer(
         .filter { it.signal == WakeSignal.IGNITION_OFF }
         .maxOfOrNull { it.elapsedMs }
 
+    private fun Attempt.add(event: WakeEvent) {
+        events += event
+        if (events.size <= MAX_TIMELINE_EVENTS) return
+
+        val ordered = events.sortedWith(EVENT_ORDER)
+        val protected = linkedSetOf<WakeEvent>()
+        WakeSignal.entries.forEach { signal ->
+            ordered.firstOrNull { it.signal == signal }?.let(protected::add)
+        }
+        ordered.firstTrueApEdge()?.let(protected::add)
+        LATEST_EDGE_SIGNALS.forEach { signal ->
+            ordered.lastOrNull { it.signal == signal }?.let(protected::add)
+        }
+        ordered.asReversed().forEach { candidate ->
+            if (protected.size < MAX_TIMELINE_EVENTS) protected += candidate
+        }
+        events.clear()
+        events += protected.sortedWith(EVENT_ORDER)
+    }
+
     private fun Attempt.toSummary(): WakeSummary {
-        val timeline = events.sortedWith(
-            compareBy<WakeEvent>({ it.elapsedMs }, { it.signal.ordinal }, { it.detail })
-        )
+        val timeline = events.sortedWith(EVENT_ORDER)
         var apAbsent = false
         var apEdgeAtMs: Long? = null
         timeline.forEach { event ->
@@ -139,7 +172,7 @@ class WakeAttemptReducer(
     private fun List<WakeEvent>.trigger(): WakeSignal {
         firstOrNull {
             it.signal == WakeSignal.GM_SYSTEM_STATE &&
-                it.detail in OBSERVATIONAL_GM_STATES
+                it.detail in OBSERVATIONAL_GM_DETAILS
         }?.let { return it.signal }
         firstOrNull { it.signal == WakeSignal.IGNITION_ON }?.let { return it.signal }
         firstOrNull { it.signal == WakeSignal.PROCESS_START }?.let { return it.signal }
@@ -149,13 +182,50 @@ class WakeAttemptReducer(
     private fun List<WakeEvent>.firstTime(signal: WakeSignal): Long? =
         firstOrNull { it.signal == signal }?.elapsedMs
 
+    private fun List<WakeEvent>.firstTrueApEdge(): WakeEvent? {
+        var apAbsent = false
+        for (event in this) {
+            when (event.signal) {
+                WakeSignal.AP_ABSENT -> apAbsent = true
+                WakeSignal.AP_PRESENT -> {
+                    if (apAbsent) return event
+                    apAbsent = false
+                }
+                else -> Unit
+            }
+        }
+        return null
+    }
+
     private fun List<WakeEvent>.firstDetail(signal: WakeSignal): String? =
         firstOrNull { it.signal == signal }?.detail?.takeIf { it.isNotBlank() }
 
-    private companion object {
-        val OBSERVATIONAL_GM_STATES = setOf("ANIMATION_INIT", "HMI_INIT")
+    companion object {
+        const val MAX_TIMELINE_EVENTS = 64
 
-        val ATTEMPT_START_SIGNALS = WakeSignal.entries.toSet() - setOf(
+        private val EVENT_ORDER = compareBy<WakeEvent>(
+            { it.elapsedMs },
+            { it.signal.ordinal },
+            { it.detail },
+        )
+
+        private val LATEST_EDGE_SIGNALS = setOf(
+            WakeSignal.GM_SYSTEM_STATE,
+            WakeSignal.BLUETOOTH_OFF,
+            WakeSignal.BLUETOOTH_ON,
+            WakeSignal.AP_ABSENT,
+            WakeSignal.AP_PRESENT,
+            WakeSignal.IGNITION_OFF,
+            WakeSignal.IGNITION_ON,
+            WakeSignal.IGNITION_START,
+        )
+
+        private val OBSERVATIONAL_GM_DETAILS = setOf(
+            "raw=1,name=ANIMATION_INIT",
+            "raw=2,name=HMI_INIT",
+        )
+
+        private val ATTEMPT_START_SIGNALS = WakeSignal.entries.toSet() - setOf(
             WakeSignal.BLUETOOTH_OFF,
             WakeSignal.AP_ABSENT,
             WakeSignal.IGNITION_OFF,
@@ -164,27 +234,64 @@ class WakeAttemptReducer(
 }
 
 object WakeSummaryFormatter {
-    fun format(summary: WakeSummary): String = buildString {
-        append("WAKE SUMMARY")
-        append(" attempt=").append(summary.attemptId)
-        append(" trigger=").append(summary.trigger.name)
-        append(" gm=").append(summary.gmState.asField())
-        append(" bt=").append(summary.btReadyAtMs.asField())
-        append(" ap=").append(summary.apReadyAtMs.asField())
-        append(" apEdge=").append(summary.apAbsentToPresentAtMs.asField())
-        append(" ignition=").append(summary.ignitionOnAtMs.asField())
-        append(" activity=").append(summary.activityStartedAtMs.asField())
-        append(" session=").append(summary.sessionReadyAtMs.asField())
-        append(" surface=").append(summary.surfaceReadyAtMs.asField())
-        append(" timeline=")
-        append(summary.timeline.joinToString(">") { event ->
+    const val MAX_DIAGNOSTIC_LINE_LENGTH = 480
+
+    fun format(summary: WakeSummary): String =
+        formatFixedFields(summary) + " timeline=" + formatTimeline(summary)
+
+    fun formatForDiagnosticLog(
+        summary: WakeSummary,
+        gmEvidenceFields: String,
+        outcome: String,
+        missing: String,
+    ): String {
+        val terminalFields =
+            " ${gmEvidenceFields.singleLine().take(128)}" +
+                " outcome=${outcome.singleLine().take(32)}" +
+                " missing=${missing.singleLine().take(96)}"
+        var prefix = formatFixedFields(summary) + terminalFields + " timeline="
+        if (prefix.length > MAX_DIAGNOSTIC_LINE_LENGTH) {
+            prefix = formatFixedFields(summary, compact = true) + terminalFields + " timeline="
+        }
+        val timelineBudget = (MAX_DIAGNOSTIC_LINE_LENGTH - prefix.length).coerceAtLeast(0)
+        val timeline = formatTimeline(summary)
+        val boundedTimeline = when {
+            timeline.length <= timelineBudget -> timeline
+            timelineBudget == 0 -> ""
+            else -> timeline.take(timelineBudget - 1) + "~"
+        }
+        return (prefix + boundedTimeline).take(MAX_DIAGNOSTIC_LINE_LENGTH)
+    }
+
+    private fun formatFixedFields(summary: WakeSummary, compact: Boolean = false): String =
+        buildString {
+            append("WAKE SUMMARY")
+            append(" attempt=").append(summary.attemptId)
+            append(" trigger=").append(summary.trigger.name)
+            append(" gm=").append(summary.gmState.asField().let { if (compact) it.take(32) else it })
+            append(" bt=").append(summary.btReadyAtMs.stageField(compact))
+            append(" ap=").append(summary.apReadyAtMs.stageField(compact))
+            append(" apEdge=").append(summary.apAbsentToPresentAtMs.stageField(compact))
+            append(" ignition=").append(summary.ignitionOnAtMs.stageField(compact))
+            append(" activity=").append(summary.activityStartedAtMs.stageField(compact))
+            append(" session=").append(summary.sessionReadyAtMs.stageField(compact))
+            append(" surface=").append(summary.surfaceReadyAtMs.stageField(compact))
+        }
+
+    private fun formatTimeline(summary: WakeSummary): String =
+        summary.timeline.joinToString(">") { event ->
             buildString {
                 append(event.signal.name).append('@').append(event.elapsedMs)
                 if (event.detail.isNotBlank()) {
                     append('(').append(event.detail.singleLine()).append(')')
                 }
             }
-        })
+        }
+
+    private fun Long?.stageField(compact: Boolean): String = when {
+        this == null -> "-"
+        compact -> "+"
+        else -> toString()
     }
 
     private fun Any?.asField(): String = this?.toString()?.singleLine() ?: "-"

--- a/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
+++ b/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
@@ -1,0 +1,193 @@
+package com.openautolink.app.wake
+
+enum class WakeSignal {
+    PROCESS_START,
+    GM_SYSTEM_STATE,
+    BLUETOOTH_OFF,
+    BLUETOOTH_ON,
+    AP_ABSENT,
+    AP_PRESENT,
+    IGNITION_OFF,
+    IGNITION_ON,
+    IGNITION_START,
+    ACTIVITY_START,
+    ACTIVITY_RESUME,
+    SESSION_READY,
+    SURFACE_READY,
+    SDP_PUBLISHED,
+    PHONE_DIALBACK,
+}
+
+data class WakeEvent(
+    val signal: WakeSignal,
+    val elapsedMs: Long,
+    val detail: String = "",
+)
+
+data class WakeSummary(
+    val attemptId: Long,
+    val trigger: WakeSignal,
+    val gmState: String?,
+    val btReadyAtMs: Long?,
+    val apReadyAtMs: Long?,
+    val ignitionOnAtMs: Long?,
+    val activityStartedAtMs: Long?,
+    val sessionReadyAtMs: Long?,
+    val surfaceReadyAtMs: Long?,
+    val apAbsentToPresentAtMs: Long?,
+    val timeline: List<WakeEvent>,
+)
+
+/**
+ * Reduces logging signals into one bounded wake timeline. It intentionally has no behavior hooks.
+ */
+class WakeAttemptReducer(
+    private val nextAttemptId: () -> Long,
+) {
+    private data class Attempt(
+        val id: Long,
+        val startsAfterMs: Long? = null,
+        val events: MutableList<WakeEvent> = mutableListOf(),
+    )
+
+    private var currentAttempt: Attempt? = null
+    private var previousAttempt: Attempt? = null
+
+    var previousSummary: WakeSummary? = null
+        private set
+
+    val currentSummary: WakeSummary?
+        get() = currentAttempt?.toSummary()
+
+    fun record(event: WakeEvent): WakeSummary {
+        val existing = currentAttempt
+        if (existing == null) {
+            currentAttempt = Attempt(nextAttemptId())
+        } else if (existing.startsAfterMs != null && event.elapsedMs <= existing.startsAfterMs) {
+            previousAttempt
+                ?.takeIf { it.startsAfterMs == null || event.elapsedMs > it.startsAfterMs }
+                ?.let { previous ->
+                    previous.events += event
+                    previousSummary = previous.toSummary()
+                }
+            return existing.toSummary()
+        } else if (existing.shouldRollOverFor(event)) {
+            val boundaryMs = existing.lastIgnitionOffMs()!!
+            previousAttempt = Attempt(
+                id = existing.id,
+                startsAfterMs = existing.startsAfterMs,
+                events = existing.events.filterTo(mutableListOf()) { it.elapsedMs <= boundaryMs },
+            )
+            previousSummary = previousAttempt!!.toSummary()
+            currentAttempt = Attempt(
+                id = nextAttemptId(),
+                startsAfterMs = boundaryMs,
+                events = existing.events.filterTo(mutableListOf()) { it.elapsedMs > boundaryMs },
+            )
+        }
+
+        return currentAttempt!!.run {
+            events += event
+            toSummary()
+        }
+    }
+
+    private fun Attempt.shouldRollOverFor(event: WakeEvent): Boolean {
+        val lastIgnitionOff = lastIgnitionOffMs() ?: return false
+        return event.elapsedMs > lastIgnitionOff && event.signal in ATTEMPT_START_SIGNALS
+    }
+
+    private fun Attempt.lastIgnitionOffMs(): Long? = events
+        .asSequence()
+        .filter { it.signal == WakeSignal.IGNITION_OFF }
+        .maxOfOrNull { it.elapsedMs }
+
+    private fun Attempt.toSummary(): WakeSummary {
+        val timeline = events.sortedWith(
+            compareBy<WakeEvent>({ it.elapsedMs }, { it.signal.ordinal }, { it.detail })
+        )
+        var apAbsent = false
+        var apEdgeAtMs: Long? = null
+        timeline.forEach { event ->
+            when (event.signal) {
+                WakeSignal.AP_ABSENT -> apAbsent = true
+                WakeSignal.AP_PRESENT -> {
+                    if (apAbsent && apEdgeAtMs == null) {
+                        apEdgeAtMs = event.elapsedMs
+                    }
+                    apAbsent = false
+                }
+                else -> Unit
+            }
+        }
+
+        return WakeSummary(
+            attemptId = id,
+            trigger = timeline.trigger(),
+            gmState = timeline.firstDetail(WakeSignal.GM_SYSTEM_STATE),
+            btReadyAtMs = timeline.firstTime(WakeSignal.BLUETOOTH_ON),
+            apReadyAtMs = timeline.firstTime(WakeSignal.AP_PRESENT),
+            ignitionOnAtMs = timeline.firstTime(WakeSignal.IGNITION_ON),
+            activityStartedAtMs = timeline.firstTime(WakeSignal.ACTIVITY_START),
+            sessionReadyAtMs = timeline.firstTime(WakeSignal.SESSION_READY),
+            surfaceReadyAtMs = timeline.firstTime(WakeSignal.SURFACE_READY),
+            apAbsentToPresentAtMs = apEdgeAtMs,
+            timeline = timeline,
+        )
+    }
+
+    private fun List<WakeEvent>.trigger(): WakeSignal {
+        firstOrNull {
+            it.signal == WakeSignal.GM_SYSTEM_STATE &&
+                it.detail in OBSERVATIONAL_GM_STATES
+        }?.let { return it.signal }
+        firstOrNull { it.signal == WakeSignal.IGNITION_ON }?.let { return it.signal }
+        firstOrNull { it.signal == WakeSignal.PROCESS_START }?.let { return it.signal }
+        return first().signal
+    }
+
+    private fun List<WakeEvent>.firstTime(signal: WakeSignal): Long? =
+        firstOrNull { it.signal == signal }?.elapsedMs
+
+    private fun List<WakeEvent>.firstDetail(signal: WakeSignal): String? =
+        firstOrNull { it.signal == signal }?.detail?.takeIf { it.isNotBlank() }
+
+    private companion object {
+        val OBSERVATIONAL_GM_STATES = setOf("ANIMATION_INIT", "HMI_INIT")
+
+        val ATTEMPT_START_SIGNALS = WakeSignal.entries.toSet() - setOf(
+            WakeSignal.BLUETOOTH_OFF,
+            WakeSignal.AP_ABSENT,
+            WakeSignal.IGNITION_OFF,
+        )
+    }
+}
+
+object WakeSummaryFormatter {
+    fun format(summary: WakeSummary): String = buildString {
+        append("WAKE SUMMARY")
+        append(" attempt=").append(summary.attemptId)
+        append(" trigger=").append(summary.trigger.name)
+        append(" gm=").append(summary.gmState.asField())
+        append(" bt=").append(summary.btReadyAtMs.asField())
+        append(" ap=").append(summary.apReadyAtMs.asField())
+        append(" apEdge=").append(summary.apAbsentToPresentAtMs.asField())
+        append(" ignition=").append(summary.ignitionOnAtMs.asField())
+        append(" activity=").append(summary.activityStartedAtMs.asField())
+        append(" session=").append(summary.sessionReadyAtMs.asField())
+        append(" surface=").append(summary.surfaceReadyAtMs.asField())
+        append(" timeline=")
+        append(summary.timeline.joinToString(">") { event ->
+            buildString {
+                append(event.signal.name).append('@').append(event.elapsedMs)
+                if (event.detail.isNotBlank()) {
+                    append('(').append(event.detail.singleLine()).append(')')
+                }
+            }
+        })
+    }
+
+    private fun Any?.asField(): String = this?.toString()?.singleLine() ?: "-"
+
+    private fun String.singleLine(): String = trim().replace(Regex("\\s+"), "_")
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/AsyncBluetoothOutcomeObserverTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/AsyncBluetoothOutcomeObserverTest.kt
@@ -1,0 +1,70 @@
+package com.openautolink.app.transport.bluetooth
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AsyncBluetoothOutcomeObserverTest {
+
+    @Test
+    fun `SDP outcome is timestamped after listener creation and observer runs asynchronously`() {
+        val queued = ArrayDeque<() -> Unit>()
+        val events = mutableListOf<String>()
+        val observer = AsyncBluetoothOutcomeObserver(
+            enqueue = queued::addLast,
+            onSdpPublished = { elapsedMs -> events += "observer-sdp@$elapsedMs" },
+            onPhoneDialback = {},
+            onFailure = { throw AssertionError(it) },
+        )
+
+        events += "listener-created"
+        observer.sdpPublishedAt(100L)
+        events += "accept-entered"
+
+        assertEquals(listOf("listener-created", "accept-entered"), events)
+        queued.removeFirst().invoke()
+        assertEquals(
+            listOf("listener-created", "accept-entered", "observer-sdp@100"),
+            events,
+        )
+    }
+
+    @Test
+    fun `dialback outcome returns to handshake path before slow observer runs`() {
+        val queued = ArrayDeque<() -> Unit>()
+        val events = mutableListOf<String>()
+        val observer = AsyncBluetoothOutcomeObserver(
+            enqueue = queued::addLast,
+            onSdpPublished = {},
+            onPhoneDialback = { elapsedMs -> events += "observer-dialback@$elapsedMs" },
+            onFailure = { throw AssertionError(it) },
+        )
+
+        events += "accept-returned-client"
+        observer.phoneDialbackAt(200L)
+        events += "handshake-dispatched"
+
+        assertEquals(listOf("accept-returned-client", "handshake-dispatched"), events)
+        queued.removeFirst().invoke()
+        assertEquals(
+            listOf("accept-returned-client", "handshake-dispatched", "observer-dialback@200"),
+            events,
+        )
+    }
+
+    @Test
+    fun `observer exception is isolated inside queued diagnostic work`() {
+        val queued = ArrayDeque<() -> Unit>()
+        val failures = mutableListOf<String>()
+        val observer = AsyncBluetoothOutcomeObserver(
+            enqueue = queued::addLast,
+            onSdpPublished = { error("boom") },
+            onPhoneDialback = {},
+            onFailure = { failures += it.javaClass.simpleName },
+        )
+
+        observer.sdpPublishedAt(300L)
+        queued.removeFirst().invoke()
+
+        assertEquals(listOf("IllegalStateException"), failures)
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
@@ -1,0 +1,101 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttemptSummarySchedulerTest {
+
+    @Test
+    fun `process start without wake candidate still times out with one summary`() {
+        val harness = Harness()
+        val summary = summary(attemptId = 1L, WakeSignal.PROCESS_START)
+
+        harness.scheduler.observe(current = summary, previous = null)
+        harness.fire(1L)
+
+        assertEquals(listOf(1L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+    }
+
+    @Test
+    fun `old attempt timer resolves old summary after rollover`() {
+        val harness = Harness()
+        val old = summary(attemptId = 10L, WakeSignal.PROCESS_START)
+        val current = summary(attemptId = 11L, WakeSignal.IGNITION_ON)
+
+        harness.scheduler.observe(current = old, previous = null)
+        harness.scheduler.observe(current = current, previous = old)
+        harness.fire(10L)
+
+        assertEquals(listOf(10L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+        assertEquals(setOf(10L, 11L), harness.scheduler.retainedAttemptIds)
+        assertEquals(1, harness.scheduler.activeTimeoutCount)
+    }
+
+    @Test
+    fun `ready racing timeout emits exactly once and cancels that attempt timer`() {
+        val harness = Harness()
+        val summary = summary(attemptId = 20L, WakeSignal.IGNITION_ON)
+
+        harness.scheduler.observe(current = summary, previous = null)
+        val staleTimeout = harness.callback(20L)
+        assertTrue(harness.scheduler.ready(summary))
+        staleTimeout()
+
+        assertEquals(listOf(20L to AttemptSummaryOutcome.READY), harness.emitted)
+        assertTrue(harness.cancelled.getValue(20L))
+        assertEquals(0, harness.scheduler.activeTimeoutCount)
+    }
+
+    @Test
+    fun `timeout emits the newest snapshot observed for its exact attempt`() {
+        val harness = Harness()
+        val initial = summary(attemptId = 30L, WakeSignal.PROCESS_START)
+        val updated = initial.copy(surfaceReadyAtMs = 500L)
+
+        harness.scheduler.observe(current = initial, previous = null)
+        harness.scheduler.observe(current = updated, previous = null)
+        harness.fire(30L)
+
+        assertEquals(500L, harness.emittedSummaries.single().surfaceReadyAtMs)
+        assertEquals(listOf(30L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+    }
+
+    private class Harness {
+        val callbacks = mutableMapOf<Long, () -> Unit>()
+        val cancelled = mutableMapOf<Long, Boolean>()
+        val emitted = mutableListOf<Pair<Long, AttemptSummaryOutcome>>()
+        val emittedSummaries = mutableListOf<WakeSummary>()
+        val scheduler = AttemptSummaryScheduler(
+            timeoutMs = 15_000L,
+            schedule = { attemptId, delayMs, callback ->
+                assertEquals(15_000L, delayMs)
+                callbacks[attemptId] = callback
+                cancelled[attemptId] = false
+                AttemptSummaryTimeout { cancelled[attemptId] = true }
+            },
+            emit = { summary, outcome ->
+                emittedSummaries += summary
+                emitted += summary.attemptId to outcome
+            },
+        )
+
+        fun callback(attemptId: Long): () -> Unit = callbacks.getValue(attemptId)
+
+        fun fire(attemptId: Long) = callback(attemptId).invoke()
+    }
+
+    private fun summary(attemptId: Long, trigger: WakeSignal): WakeSummary = WakeSummary(
+        attemptId = attemptId,
+        trigger = trigger,
+        gmState = null,
+        btReadyAtMs = null,
+        apReadyAtMs = null,
+        ignitionOnAtMs = null,
+        activityStartedAtMs = null,
+        sessionReadyAtMs = null,
+        surfaceReadyAtMs = null,
+        apAbsentToPresentAtMs = null,
+        timeline = listOf(WakeEvent(trigger, attemptId)),
+    )
+}

--- a/app/src/test/java/com/openautolink/app/wake/GmBroadcastIngressLimiterTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/GmBroadcastIngressLimiterTest.kt
@@ -1,0 +1,128 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GmBroadcastIngressLimiterTest {
+
+    @Test
+    fun `alternating raw values cannot bypass per action window limit`() {
+        val limiter = GmBroadcastIngressLimiter(maxPerWindow = 4, hardCapPerEpoch = 20)
+        val outcomes = (0 until 6).map { index ->
+            limiter.evaluate("SYSTEM_STATE_CHANGED", index % 2, elapsedMs = index.toLong(), epoch = 1L)
+        }
+
+        assertEquals(4, outcomes.count { it.allowed })
+        assertEquals(2, outcomes.count { it.outcome == GmIngressOutcome.WINDOW_LIMITED })
+        assertEquals(1, outcomes.count { it.shouldLogSuppression })
+    }
+
+    @Test
+    fun `repeated duplicate is denied before accepted callback`() {
+        val limiter = GmBroadcastIngressLimiter(maxPerWindow = 4, hardCapPerEpoch = 20)
+        var expensiveCallbacks = 0
+
+        val first = limiter.handle("POWER_MODE_CHANGED", 7, 100L, epoch = 1L) {
+            expensiveCallbacks++
+        }
+        val duplicate = limiter.handle("POWER_MODE_CHANGED", 7, 101L, epoch = 1L) {
+            expensiveCallbacks++
+        }
+
+        assertTrue(first.allowed)
+        assertEquals(GmIngressOutcome.DUPLICATE, duplicate.outcome)
+        assertFalse(duplicate.allowed)
+        assertEquals(1, expensiveCallbacks)
+    }
+
+    @Test
+    fun `ignition power epoch resets dedupe and limits`() {
+        val limiter = GmBroadcastIngressLimiter(maxPerWindow = 1, hardCapPerEpoch = 1)
+
+        assertTrue(limiter.evaluate("SYSTEM_STATE_CHANGED", 4, 100L, epoch = 1L).allowed)
+        assertFalse(limiter.evaluate("SYSTEM_STATE_CHANGED", 5, 101L, epoch = 1L).allowed)
+        assertTrue(limiter.evaluate("SYSTEM_STATE_CHANGED", 4, 102L, epoch = 2L).allowed)
+    }
+
+    @Test
+    fun `POWEROFF callbacks are deduped and window limited before expensive work`() {
+        val limiter = GmBroadcastIngressLimiter(maxPerWindow = 2, hardCapPerEpoch = 8)
+        var expensiveCallbacks = 0
+        val states = listOf(
+            Triple(true, false, null),
+            Triple(true, false, null),
+            Triple(false, false, null),
+            Triple(null, true, false),
+            Triple(true, true, true),
+        )
+
+        val results = states.mapIndexed { index, (view, mute, fpi) ->
+            limiter.handle(
+                action = "POWEROFF_VIEW",
+                rawValue = GmIngressDedupeKey.poweroffView(view, mute, fpi),
+                elapsedMs = 100L + index,
+                epoch = 1L,
+            ) { expensiveCallbacks++ }
+        }
+
+        assertEquals(2, expensiveCallbacks)
+        assertEquals(GmIngressOutcome.DUPLICATE, results[1].outcome)
+        assertEquals(2, results.count { it.outcome == GmIngressOutcome.WINDOW_LIMITED })
+        limiter.handle(
+            "POWEROFF_VIEW",
+            GmIngressDedupeKey.poweroffView(true, false, null),
+            200L,
+            epoch = 2L,
+        ) { expensiveCallbacks++ }
+        assertEquals(3, expensiveCallbacks)
+    }
+
+    @Test
+    fun `HOME callback floods are gated before expensive work and reset by epoch`() {
+        val limiter = GmBroadcastIngressLimiter(maxPerWindow = 2, hardCapPerEpoch = 8)
+        var expensiveCallbacks = 0
+
+        repeat(20) { index ->
+            limiter.handle(
+                action = "HOME_STARTED",
+                rawValue = GmIngressDedupeKey.ACTION_ONLY,
+                elapsedMs = 300L + index,
+                epoch = 5L,
+            ) { expensiveCallbacks++ }
+        }
+        assertEquals(1, expensiveCallbacks)
+
+        limiter.handle(
+            action = "HOME_STARTED",
+            rawValue = GmIngressDedupeKey.ACTION_ONLY,
+            elapsedMs = 400L,
+            epoch = 6L,
+        ) { expensiveCallbacks++ }
+        assertEquals(2, expensiveCallbacks)
+    }
+
+    @Test
+    fun `hard cap bounds accepted events even outside rate window`() {
+        val limiter = GmBroadcastIngressLimiter(
+            windowMs = 10L,
+            maxPerWindow = 4,
+            hardCapPerEpoch = 3,
+        )
+
+        val outcomes = (0 until 5).map { index ->
+            limiter.evaluate(
+                action = "SYSTEM_STATE_CHANGED",
+                rawValue = index,
+                elapsedMs = index * 20L,
+                epoch = 9L,
+            )
+        }
+
+        assertEquals(3, outcomes.count { it.allowed })
+        assertEquals(2, outcomes.count { it.outcome == GmIngressOutcome.HARD_CAPPED })
+        assertEquals(1, outcomes.count { it.shouldLogSuppression })
+        assertEquals(3, limiter.acceptedCount("SYSTEM_STATE_CHANGED"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/GmDeliveryEvidenceTrackerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/GmDeliveryEvidenceTrackerTest.kt
@@ -1,0 +1,91 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GmDeliveryEvidenceTrackerTest {
+
+    @Test
+    fun `all four absent signals are explicitly not observed`() {
+        val tracker = GmDeliveryEvidenceTracker()
+        tracker.retain(currentAttemptId = 10L, previousAttemptId = null)
+
+        assertEquals(
+            "gmSystemState=not_observed gmPowerMode=not_observed " +
+                "gmPoweroffView=not_observed gmHomeStarted=not_observed",
+            tracker.format(10L),
+        )
+    }
+
+    @Test
+    fun `observations attach only to the supplied attempt id`() {
+        val tracker = GmDeliveryEvidenceTracker()
+        tracker.retain(currentAttemptId = 11L, previousAttemptId = 10L)
+
+        tracker.observe(10L, GmDeliverySignal.SYSTEM_STATE)
+        tracker.observe(11L, GmDeliverySignal.POWER_MODE)
+
+        assertEquals(
+            "gmSystemState=observed gmPowerMode=not_observed " +
+                "gmPoweroffView=not_observed gmHomeStarted=not_observed",
+            tracker.format(10L),
+        )
+        assertEquals(
+            "gmSystemState=not_observed gmPowerMode=observed " +
+                "gmPoweroffView=not_observed gmHomeStarted=not_observed",
+            tracker.format(11L),
+        )
+    }
+
+    @Test
+    fun `retention is bounded to current and previous attempt without leakage`() {
+        val tracker = GmDeliveryEvidenceTracker()
+        tracker.retain(currentAttemptId = 20L, previousAttemptId = null)
+        tracker.observe(20L, GmDeliverySignal.HOME_STARTED)
+
+        tracker.retain(currentAttemptId = 21L, previousAttemptId = 20L)
+        tracker.observe(21L, GmDeliverySignal.POWEROFF_VIEW)
+        tracker.retain(currentAttemptId = 22L, previousAttemptId = 21L)
+
+        assertEquals(setOf(21L, 22L), tracker.retainedAttemptIds)
+        assertFalse(tracker.format(22L).contains("=observed"))
+        assertTrue(tracker.format(21L).contains("gmPoweroffView=observed"))
+        assertFalse(tracker.format(21L).contains("gmHomeStarted=observed"))
+        assertFalse(tracker.format(20L).contains("=observed"))
+    }
+
+    @Test
+    fun `partial observations leave every other signal explicitly not observed`() {
+        val tracker = GmDeliveryEvidenceTracker()
+        tracker.retain(currentAttemptId = 30L, previousAttemptId = null)
+
+        tracker.observe(30L, GmDeliverySignal.SYSTEM_STATE)
+        tracker.observe(30L, GmDeliverySignal.HOME_STARTED)
+
+        assertEquals(
+            "gmSystemState=observed gmPowerMode=not_observed " +
+                "gmPoweroffView=not_observed gmHomeStarted=observed",
+            tracker.format(30L),
+        )
+    }
+
+    @Test
+    fun `auxiliary GM evidence after ignition off follows elapsed boundary into next attempt`() {
+        var nextId = 40L
+        val reducer = WakeAttemptReducer { nextId++ }
+        val tracker = GmDeliveryEvidenceTracker()
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        tracker.retain(reducer.retainedAttemptWindows())
+        tracker.observeAt(elapsedMs = 250L, GmDeliverySignal.POWER_MODE)
+
+        val next = reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 300L))
+        tracker.retain(reducer.retainedAttemptWindows())
+
+        assertFalse(tracker.format(reducer.previousSummary!!.attemptId).contains("=observed"))
+        assertTrue(tracker.format(next.attemptId).contains("gmPowerMode=observed"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/PreWakeSignalPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/PreWakeSignalPolicyTest.kt
@@ -1,0 +1,156 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreWakeSignalPolicyTest {
+
+    private val policy = PreWakeSignalPolicy()
+
+    @Test
+    fun `GM states one through eight are recorded with their raw values`() {
+        val expectedNames = listOf(
+            "ANIMATION_INIT",
+            "HMI_INIT",
+            "HMI_INACTIVE",
+            "START",
+            "RUN",
+            "PROPULSION",
+            "ACCESSORY",
+            "LOCAL_INFOTAINMENT",
+        )
+
+        expectedNames.forEachIndexed { index, expectedName ->
+            val raw = index + 1
+            val decision = policy.gmSystemState(raw, elapsedMs = raw.toLong())
+
+            assertEquals(PreWakeObservationKind.GM_SYSTEM_STATE, decision.observation.kind)
+            assertTrue(decision.observation.detail.contains("raw=$raw"))
+            assertTrue(decision.observation.detail.contains("name=$expectedName"))
+            assertEquals(WakeSignal.GM_SYSTEM_STATE, decision.event?.signal)
+            assertFalse(decision.impliesSessionReadiness)
+            assertFalse(decision.authorizesBehavior)
+        }
+    }
+
+    @Test
+    fun `unknown GM raw values are recorded but imply no readiness`() {
+        listOf(0, 9, 20, 37).forEach { raw ->
+            val decision = policy.gmSystemState(raw, elapsedMs = 100L + raw)
+
+            assertEquals(PreWakeObservationKind.GM_SYSTEM_STATE, decision.observation.kind)
+            assertTrue(decision.observation.detail.contains("raw=$raw"))
+            assertTrue(decision.observation.detail.contains("name=UNKNOWN"))
+            assertEquals(WakeSignal.GM_SYSTEM_STATE, decision.event?.signal)
+            assertFalse(decision.impliesSessionReadiness)
+            assertFalse(decision.authorizesBehavior)
+        }
+    }
+
+    @Test
+    fun `Bluetooth STATE_ON is recorded without implying session readiness`() {
+        val decision = policy.bluetoothState(
+            rawState = PreWakeSignalPolicy.BLUETOOTH_STATE_ON,
+            elapsedMs = 200L,
+        )
+
+        assertEquals(PreWakeObservationKind.BLUETOOTH_STATE, decision.observation.kind)
+        assertEquals(WakeSignal.BLUETOOTH_ON, decision.event?.signal)
+        assertTrue(decision.observation.detail.contains("raw=12"))
+        assertFalse(decision.impliesSessionReadiness)
+        assertFalse(decision.authorizesBehavior)
+    }
+
+    @Test
+    fun `configured AP observation records only interface and local IP`() {
+        val decision = policy.accessPoint(
+            interfaceName = "ap_br_swlan0",
+            localIpv4 = "10.2.110.1",
+            elapsedMs = 300L,
+        )
+
+        assertEquals(WakeSignal.AP_PRESENT, decision.event?.signal)
+        assertEquals("interface=ap_br_swlan0,ip=10.2.110.1", decision.event?.detail)
+        val rendered = decision.observation.detail.lowercase()
+        assertFalse(rendered.contains("ssid"))
+        assertFalse(rendered.contains("psk"))
+        assertFalse(rendered.contains("password"))
+        assertFalse(rendered.contains("credential"))
+        assertFalse(decision.impliesSessionReadiness)
+    }
+
+    @Test
+    fun `wake candidate starts a bounded non-hot sampling policy`() {
+        val decision = policy.gmSystemState(rawState = 1, elapsedMs = 400L)
+        val sampling = decision.sampling
+
+        assertNotNull(sampling)
+        sampling!!
+        assertEquals(250L, sampling.intervalMs)
+        assertEquals(15_000L, sampling.durationMs)
+        assertTrue(sampling.durationMs > sampling.intervalMs)
+        assertTrue(sampling.maximumSamples in 1..100)
+        assertFalse(sampling.intervalMs == 100L)
+        assertTrue(sampling.isBounded)
+    }
+
+    @Test
+    fun `power mode sampling is limited to wake and resume values`() {
+        assertNotNull(policy.gmPowerMode(rawMode = 2, elapsedMs = 450L).sampling)
+        assertNotNull(policy.gmPowerMode(rawMode = 5, elapsedMs = 451L).sampling)
+
+        listOf(-1, 0, 1, 3, 4, 99).forEach { rawMode ->
+            assertNull(policy.gmPowerMode(rawMode, elapsedMs = 500L + rawMode).sampling)
+        }
+    }
+
+    @Test
+    fun `ignition callbacks remain valid without any GM observation`() {
+        assertEquals(
+            WakeSignal.IGNITION_OFF,
+            policy.ignitionState(rawState = 2, elapsedMs = 500L).event?.signal,
+        )
+        assertEquals(
+            WakeSignal.IGNITION_ON,
+            policy.ignitionState(rawState = 4, elapsedMs = 600L).event?.signal,
+        )
+        assertEquals(
+            WakeSignal.IGNITION_START,
+            policy.ignitionState(rawState = 5, elapsedMs = 700L).event?.signal,
+        )
+    }
+
+    @Test
+    fun `Activity callbacks remain valid without any GM observation`() {
+        assertEquals(
+            WakeSignal.ACTIVITY_START,
+            policy.activity(PreWakeActivityCallback.START, elapsedMs = 800L).event?.signal,
+        )
+        assertEquals(
+            WakeSignal.ACTIVITY_RESUME,
+            policy.activity(PreWakeActivityCallback.RESUME, elapsedMs = 900L).event?.signal,
+        )
+        assertNull(policy.activity(PreWakeActivityCallback.PAUSE, elapsedMs = 1_000L).event)
+        assertNull(policy.activity(PreWakeActivityCallback.STOP, elapsedMs = 1_100L).event)
+    }
+
+    @Test
+    fun `spoofable GM broadcasts are hints only and never authorize behavior`() {
+        val hints = listOf(
+            policy.gmSystemState(rawState = 5, elapsedMs = 1_200L),
+            policy.gmPowerMode(rawMode = 99, elapsedMs = 1_300L),
+        )
+
+        hints.forEach { decision ->
+            assertTrue(decision.observation.hintOnly)
+            assertFalse(decision.impliesSessionReadiness)
+            assertFalse(decision.authorizesBehavior)
+        }
+        assertEquals(PreWakeObservationKind.GM_POWER_MODE, hints[1].observation.kind)
+        assertTrue(hints[1].observation.detail.contains("raw=99"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
@@ -1,0 +1,186 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WakeAttemptReducerTest {
+
+    @Test
+    fun `AP present before ignition is retained in the same attempt`() {
+        var nextId = 40L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, elapsedMs = 90L))
+        val beforeIgnition = reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 100L))
+        val afterIgnition = reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 200L))
+
+        assertEquals(beforeIgnition.attemptId, afterIgnition.attemptId)
+        assertEquals(40L, afterIgnition.attemptId)
+        assertEquals(WakeSignal.IGNITION_ON, afterIgnition.trigger)
+        assertEquals(100L, afterIgnition.apReadyAtMs)
+        assertEquals(100L, afterIgnition.apAbsentToPresentAtMs)
+        assertEquals(200L, afterIgnition.ignitionOnAtMs)
+        assertEquals(41L, nextId)
+    }
+
+    @Test
+    fun `AP present without an observed absent level does not claim an edge`() {
+        val reducer = WakeAttemptReducer { 7L }
+
+        val summary = reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 100L))
+
+        assertEquals(100L, summary.apReadyAtMs)
+        assertNull(summary.apAbsentToPresentAtMs)
+    }
+
+    @Test
+    fun `ignition on anchors a drive attempt without a GM broadcast`() {
+        val reducer = WakeAttemptReducer { 81L }
+
+        val summary = reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 1_000L))
+
+        assertEquals(81L, summary.attemptId)
+        assertEquals(WakeSignal.IGNITION_ON, summary.trigger)
+        assertNull(summary.gmState)
+        assertEquals(1_000L, summary.ignitionOnAtMs)
+    }
+
+    @Test
+    fun `GM init states begin observational attempts without implying readiness`() {
+        listOf("ANIMATION_INIT", "HMI_INIT").forEachIndexed { index, gmState ->
+            val reducer = WakeAttemptReducer { 90L + index }
+
+            val summary = reducer.record(
+                WakeEvent(WakeSignal.GM_SYSTEM_STATE, elapsedMs = 10L, detail = gmState)
+            )
+
+            assertEquals(WakeSignal.GM_SYSTEM_STATE, summary.trigger)
+            assertEquals(gmState, summary.gmState)
+            assertNull(summary.sessionReadyAtMs)
+            assertNull(summary.surfaceReadyAtMs)
+            assertNull(summary.activityStartedAtMs)
+        }
+    }
+
+    @Test
+    fun `timeline ordering uses elapsed realtime instead of input order`() {
+        val reducer = WakeAttemptReducer { 101L }
+
+        reducer.record(WakeEvent(WakeSignal.ACTIVITY_START, elapsedMs = 300L))
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 200L))
+        val summary = reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+
+        assertEquals(
+            listOf(WakeSignal.IGNITION_ON, WakeSignal.AP_PRESENT, WakeSignal.ACTIVITY_START),
+            summary.timeline.map { it.signal }
+        )
+        assertEquals(listOf(100L, 200L, 300L), summary.timeline.map { it.elapsedMs })
+    }
+
+    @Test
+    fun `missing stages remain explicit and are never inferred`() {
+        val reducer = WakeAttemptReducer { 102L }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.ACTIVITY_RESUME, elapsedMs = 200L))
+        val summary = reducer.record(WakeEvent(WakeSignal.SURFACE_READY, elapsedMs = 300L))
+
+        assertNull(summary.btReadyAtMs)
+        assertNull(summary.apReadyAtMs)
+        assertNull(summary.activityStartedAtMs)
+        assertNull(summary.sessionReadyAtMs)
+        assertEquals(300L, summary.surfaceReadyAtMs)
+    }
+
+    @Test
+    fun `AP absent after shutdown rolls into the next wake attempt`() {
+        var nextId = 200L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, elapsedMs = 250L))
+        val summary = reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 300L))
+
+        assertEquals(201L, summary.attemptId)
+        assertEquals(300L, summary.apAbsentToPresentAtMs)
+        assertEquals(
+            listOf(WakeSignal.AP_ABSENT, WakeSignal.AP_PRESENT),
+            summary.timeline.map { it.signal }
+        )
+        assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.AP_ABSENT })
+    }
+
+    @Test
+    fun `late event from the previous attempt cannot corrupt the current attempt`() {
+        var nextId = 210L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 300L))
+        val summary = reducer.record(WakeEvent(WakeSignal.SESSION_READY, elapsedMs = 150L))
+
+        assertEquals(211L, summary.attemptId)
+        assertNull(summary.sessionReadyAtMs)
+        assertEquals(listOf(WakeSignal.IGNITION_ON), summary.timeline.map { it.signal })
+        assertEquals(150L, reducer.previousSummary!!.sessionReadyAtMs)
+    }
+
+    @Test
+    fun `Bluetooth off after shutdown rolls into the next wake attempt`() {
+        var nextId = 220L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        reducer.record(WakeEvent(WakeSignal.BLUETOOTH_OFF, elapsedMs = 250L))
+        val summary = reducer.record(WakeEvent(WakeSignal.BLUETOOTH_ON, elapsedMs = 300L))
+
+        assertEquals(221L, summary.attemptId)
+        assertEquals(
+            listOf(WakeSignal.BLUETOOTH_OFF, WakeSignal.BLUETOOTH_ON),
+            summary.timeline.map { it.signal }
+        )
+        assertFalse(
+            reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.BLUETOOTH_OFF }
+        )
+    }
+
+    @Test
+    fun `history is bounded to the current attempt and previous summary`() {
+        var nextId = 200L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 300L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 400L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 500L))
+
+        assertEquals(202L, reducer.currentSummary!!.attemptId)
+        assertEquals(201L, reducer.previousSummary!!.attemptId)
+        assertFalse(reducer.previousSummary!!.timeline.any { it.elapsedMs < 300L })
+    }
+
+    @Test
+    fun `formatter emits one stable WAKE SUMMARY line with explicit missing values`() {
+        val reducer = WakeAttemptReducer { 9L }
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 120L))
+        val summary = reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 200L))
+
+        val line = WakeSummaryFormatter.format(summary)
+
+        assertEquals(
+            "WAKE SUMMARY attempt=9 trigger=IGNITION_ON gm=- bt=- ap=120 " +
+                "apEdge=- ignition=200 activity=- session=- surface=- " +
+                "timeline=AP_PRESENT@120>IGNITION_ON@200",
+            line
+        )
+        assertFalse(line.contains('\n'))
+        assertTrue(line.startsWith("WAKE SUMMARY "))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
@@ -1,5 +1,6 @@
 package com.openautolink.app.wake
 
+import com.openautolink.app.diagnostics.fitLocalDiagnosticMessage
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -49,19 +50,40 @@ class WakeAttemptReducerTest {
     }
 
     @Test
-    fun `GM init states begin observational attempts without implying readiness`() {
-        listOf("ANIMATION_INIT", "HMI_INIT").forEachIndexed { index, gmState ->
+    fun `policy GM init states begin observational attempts without implying readiness`() {
+        val policy = PreWakeSignalPolicy()
+        listOf(1 to "ANIMATION_INIT", 2 to "HMI_INIT").forEachIndexed { index, (raw, name) ->
             val reducer = WakeAttemptReducer { 90L + index }
+            reducer.record(WakeEvent(WakeSignal.PROCESS_START, elapsedMs = 1L))
 
-            val summary = reducer.record(
-                WakeEvent(WakeSignal.GM_SYSTEM_STATE, elapsedMs = 10L, detail = gmState)
-            )
+            val producedEvent = policy.gmSystemState(raw, elapsedMs = 10L).event!!
+            val summary = reducer.record(producedEvent)
 
             assertEquals(WakeSignal.GM_SYSTEM_STATE, summary.trigger)
-            assertEquals(gmState, summary.gmState)
+            assertEquals("raw=$raw,name=$name", summary.gmState)
             assertNull(summary.sessionReadyAtMs)
             assertNull(summary.surfaceReadyAtMs)
             assertNull(summary.activityStartedAtMs)
+        }
+    }
+
+    @Test
+    fun `GM detail matching rejects bare and substring lookalikes`() {
+        listOf(
+            "ANIMATION_INIT",
+            "HMI_INIT",
+            "raw=11,name=ANIMATION_INIT",
+            "raw=1,name=ANIMATION_INIT_EXTRA",
+            "prefix=HMI_INIT,raw=2",
+        ).forEachIndexed { index, detail ->
+            val reducer = WakeAttemptReducer { 95L + index }
+            reducer.record(WakeEvent(WakeSignal.PROCESS_START, elapsedMs = 1L))
+
+            val summary = reducer.record(
+                WakeEvent(WakeSignal.GM_SYSTEM_STATE, elapsedMs = 2L, detail = detail)
+            )
+
+            assertEquals("detail=$detail", WakeSignal.PROCESS_START, summary.trigger)
         }
     }
 
@@ -167,6 +189,108 @@ class WakeAttemptReducerTest {
     }
 
     @Test
+    fun `hundreds of GM observations keep bounded critical timeline and correct rollover`() {
+        var nextId = 300L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, 100L))
+        reducer.record(WakeEvent(WakeSignal.BLUETOOTH_ON, 110L))
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 120L))
+        reducer.record(WakeEvent(WakeSignal.ACTIVITY_START, 130L))
+        reducer.record(WakeEvent(WakeSignal.SESSION_READY, 140L))
+        reducer.record(WakeEvent(WakeSignal.SURFACE_READY, 150L))
+        repeat(500) { index ->
+            reducer.record(
+                WakeEvent(
+                    WakeSignal.GM_SYSTEM_STATE,
+                    elapsedMs = 200L + index,
+                    detail = "raw=${index % 9},name=NOISE_$index",
+                )
+            )
+        }
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, 800L))
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, 850L))
+        reducer.record(WakeEvent(WakeSignal.BLUETOOTH_OFF, 860L))
+        val current = reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 900L))
+        val completed = reducer.previousSummary!!
+
+        assertTrue(completed.timeline.size <= WakeAttemptReducer.MAX_TIMELINE_EVENTS)
+        assertEquals(110L, completed.btReadyAtMs)
+        assertEquals(120L, completed.apReadyAtMs)
+        assertEquals(130L, completed.activityStartedAtMs)
+        assertEquals(140L, completed.sessionReadyAtMs)
+        assertEquals(150L, completed.surfaceReadyAtMs)
+        assertTrue(completed.timeline.any { it.signal == WakeSignal.IGNITION_OFF && it.elapsedMs == 800L })
+        assertEquals(301L, current.attemptId)
+        assertEquals(900L, current.apAbsentToPresentAtMs)
+        assertTrue(current.timeline.any { it.signal == WakeSignal.BLUETOOTH_OFF })
+    }
+
+    @Test
+    fun `compaction does not synthesize an AP edge from present only`() {
+        val reducer = WakeAttemptReducer { 401L }
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 10L))
+        addCompactionNoise(reducer, startingAtMs = 100L)
+
+        val summary = reducer.currentSummary!!
+        assertEquals(10L, summary.apReadyAtMs)
+        assertNull(summary.apAbsentToPresentAtMs)
+    }
+
+    @Test
+    fun `compaction does not synthesize an AP edge when absent has no later present`() {
+        val reducer = WakeAttemptReducer { 402L }
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 10L))
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, 20L))
+        addCompactionNoise(reducer, startingAtMs = 100L)
+
+        val summary = reducer.currentSummary!!
+        assertEquals(10L, summary.apReadyAtMs)
+        assertNull(summary.apAbsentToPresentAtMs)
+    }
+
+    @Test
+    fun `compaction retains a true absent to present edge`() {
+        val reducer = WakeAttemptReducer { 403L }
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, 10L))
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 20L))
+        addCompactionNoise(reducer, startingAtMs = 100L)
+
+        assertEquals(20L, reducer.currentSummary!!.apAbsentToPresentAtMs)
+    }
+
+    @Test
+    fun `compaction retains the first true AP edge across multiple transitions`() {
+        val reducer = WakeAttemptReducer { 404L }
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 5L))
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, 10L))
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 20L))
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, 30L))
+        reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 40L))
+        addCompactionNoise(reducer, startingAtMs = 100L)
+
+        assertEquals(20L, reducer.currentSummary!!.apAbsentToPresentAtMs)
+    }
+
+    @Test
+    fun `compaction preserves AP precursor across an ignition rollover boundary`() {
+        var nextId = 405L
+        val reducer = WakeAttemptReducer { nextId++ }
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, 10L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, 50L))
+        repeat(WakeAttemptReducer.MAX_TIMELINE_EVENTS + 20) { index ->
+            val signal = if (index % 2 == 0) WakeSignal.AP_ABSENT else WakeSignal.BLUETOOTH_OFF
+            reducer.record(WakeEvent(signal, 60L + index))
+        }
+
+        val summary = reducer.record(WakeEvent(WakeSignal.AP_PRESENT, 200L))
+
+        assertEquals(406L, summary.attemptId)
+        assertEquals(200L, summary.apAbsentToPresentAtMs)
+        assertFalse(reducer.previousSummary!!.timeline.any { it.elapsedMs > 50L })
+    }
+
+    @Test
     fun `formatter emits one stable WAKE SUMMARY line with explicit missing values`() {
         val reducer = WakeAttemptReducer { 9L }
         reducer.record(WakeEvent(WakeSignal.AP_PRESENT, elapsedMs = 120L))
@@ -182,5 +306,73 @@ class WakeAttemptReducerTest {
         )
         assertFalse(line.contains('\n'))
         assertTrue(line.startsWith("WAKE SUMMARY "))
+    }
+
+    @Test
+    fun `diagnostic summary bounds timeline before the sink can erase terminal evidence`() {
+        val summary = WakeSummary(
+            attemptId = 12L,
+            trigger = WakeSignal.GM_SYSTEM_STATE,
+            gmState = "raw=1,name=ANIMATION_INIT",
+            btReadyAtMs = 20L,
+            apReadyAtMs = 30L,
+            ignitionOnAtMs = 40L,
+            activityStartedAtMs = 50L,
+            sessionReadyAtMs = 60L,
+            surfaceReadyAtMs = 70L,
+            apAbsentToPresentAtMs = 30L,
+            timeline = List(WakeAttemptReducer.MAX_TIMELINE_EVENTS) { index ->
+                WakeEvent(
+                    WakeSignal.GM_SYSTEM_STATE,
+                    elapsedMs = 100L + index,
+                    detail = "raw=$index,name=${"X".repeat(140)}",
+                )
+            },
+        )
+        val gmEvidence =
+            "gmSystemState=observed gmPowerMode=not_observed " +
+                "gmPoweroffView=observed gmHomeStarted=not_observed"
+
+        val line = WakeSummaryFormatter.formatForDiagnosticLog(
+            summary = summary,
+            gmEvidenceFields = gmEvidence,
+            outcome = "timeout",
+            missing = "none",
+        )
+        val stored = fitLocalDiagnosticMessage(line)
+
+        assertTrue("summary length=${line.length}", line.length <= 480)
+        assertEquals(line, stored)
+        listOf(
+            "attempt=12",
+            "trigger=GM_SYSTEM_STATE",
+            "gm=raw=1,name=ANIMATION_INIT",
+            "bt=20",
+            "ap=30",
+            "apEdge=30",
+            "ignition=40",
+            "activity=50",
+            "session=60",
+            "surface=70",
+            "gmSystemState=observed",
+            "gmPowerMode=not_observed",
+            "gmPoweroffView=observed",
+            "gmHomeStarted=not_observed",
+            "outcome=timeout",
+            "missing=none",
+        ).forEach { required -> assertTrue("missing $required", stored.contains(required)) }
+        assertTrue(stored.indexOf("missing=none") < stored.indexOf("timeline="))
+    }
+
+    private fun addCompactionNoise(reducer: WakeAttemptReducer, startingAtMs: Long) {
+        repeat(WakeAttemptReducer.MAX_TIMELINE_EVENTS + 20) { index ->
+            reducer.record(
+                WakeEvent(
+                    signal = WakeSignal.GM_SYSTEM_STATE,
+                    elapsedMs = startingAtMs + index,
+                    detail = "raw=9,name=NOISE_$index",
+                )
+            )
+        }
     }
 }

--- a/companion/src/main/java/com/openautolink/companion/autostart/AutoStartReceiver.kt
+++ b/companion/src/main/java/com/openautolink/companion/autostart/AutoStartReceiver.kt
@@ -10,6 +10,7 @@ import android.os.Looper
 import androidx.core.content.ContextCompat
 import com.openautolink.companion.CompanionPrefs
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.service.CompanionService
 
 /**
@@ -39,6 +40,9 @@ class AutoStartReceiver : BroadcastReceiver() {
 
         when (intent.action) {
             BluetoothDevice.ACTION_ACL_CONNECTED -> {
+                val wppAttemptId = PhoneWppDiagnostics.selectedTargetConnected(
+                    existingBridgeActive = CompanionService.isConnected.value,
+                )
                 CompanionLog.i(TAG, "Target BT connected: $deviceAddress")
 
                 // Check if device is fully connected (not just ACL)
@@ -61,6 +65,7 @@ class AutoStartReceiver : BroadcastReceiver() {
 
                 val serviceIntent = Intent(context, CompanionService::class.java).apply {
                     action = CompanionService.ACTION_START
+                    putExtra(CompanionService.EXTRA_WPP_ATTEMPT_ID, wppAttemptId)
                 }
                 try {
                     ContextCompat.startForegroundService(context, serviceIntent)
@@ -74,6 +79,7 @@ class AutoStartReceiver : BroadcastReceiver() {
                 // the proxy bridge lights up in milliseconds.
                 val prewarmIntent = Intent(context, CompanionService::class.java).apply {
                     action = CompanionService.ACTION_PREWARM
+                    putExtra(CompanionService.EXTRA_WPP_ATTEMPT_ID, wppAttemptId)
                 }
                 try {
                     ContextCompat.startForegroundService(context, prewarmIntent)
@@ -84,6 +90,9 @@ class AutoStartReceiver : BroadcastReceiver() {
             }
 
             BluetoothDevice.ACTION_ACL_DISCONNECTED -> {
+                PhoneWppDiagnostics.record(
+                    com.openautolink.companion.diagnostics.PhoneWppStage.TARGET_BT_DISCONNECTED,
+                )
                 CompanionLog.i(TAG, "Target BT disconnected: $deviceAddress")
                 val stopOnDisconnect = prefs.getBoolean(CompanionPrefs.BT_DISCONNECT_STOP, false)
                 if (stopOnDisconnect) {

--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -1,6 +1,8 @@
 package com.openautolink.companion.connection
 
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
+import com.openautolink.companion.diagnostics.PhoneWppStage
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -149,6 +151,7 @@ class AaProxy(
             try {
                 while (isRunning) {
                     val aaSocket = server.accept()
+                    PhoneWppDiagnostics.record(PhoneWppStage.AA_SOCKET)
                     CompanionLog.i(TAG, "Android Auto connected to proxy")
                     launchBridge(aaSocket)
                 }
@@ -166,6 +169,7 @@ class AaProxy(
         scope.launch {
             var carSocket: Socket? = null
             var counted = false
+            var bridgeAttemptId: Long? = null
             try {
                 activeBridges.incrementAndGet()
                 listener?.onConnected()
@@ -194,6 +198,7 @@ class AaProxy(
                 counted = true
 
                 CompanionLog.i(TAG, "Bridge established: AA <-> Car")
+                bridgeAttemptId = PhoneWppDiagnostics.bridgeEstablished()
 
                 val aaIn = aaSocket.getInputStream()
                 val aaOut = aaSocket.getOutputStream()
@@ -214,7 +219,10 @@ class AaProxy(
                 val unexpected = isRunning
                 CompanionLog.i(TAG, "Bridge closed (unexpected=$unexpected)")
                 activeCarSocket = null
-                if (counted) pumpingBridges.decrementAndGet()
+                if (counted) {
+                    PhoneWppDiagnostics.bridgeClosed(bridgeAttemptId)
+                    pumpingBridges.decrementAndGet()
+                }
                 runCatching { aaSocket.close() }
                 // Don't close carSocket here — let the TcpAdvertiser manage it via cleanup()
                 //

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/PhoneWppDiagnostics.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/PhoneWppDiagnostics.kt
@@ -1,0 +1,141 @@
+package com.openautolink.companion.diagnostics
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+
+/** Android runtime facade for the pure, logging-only WPP diagnostics coordinator. */
+object PhoneWppDiagnostics {
+    const val MAX_ATTEMPT_DURATION_MS = 120_000L
+
+    private val handler by lazy { Handler(Looper.getMainLooper()) }
+    private var timeoutRunnable: Runnable? = null
+    private var timeoutAttemptId: Long? = null
+    private var attemptFinishedListener: (() -> Unit)? = null
+    private val lifecycleGuard = WppAttemptLifecycleGuard()
+    private val coordinator = WppDiagnosticsCoordinator(
+        elapsedRealtimeMs = SystemClock::elapsedRealtime,
+        eventSink = { CompanionLog.i(TAG, it) },
+        summarySink = { summary ->
+            CompanionLog.i(TAG, PhoneWppSummaryFormatter.format(summary))
+            finishAttemptLifecycle(summary.attemptId)
+        },
+    )
+
+    @Synchronized
+    fun selectedTargetConnected(existingBridgeActive: Boolean = false): Long {
+        return try {
+            val wasActive = coordinator.isActive
+            val id = coordinator.selectedTargetConnected(existingBridgeActive) ?: return 0L
+            if (!wasActive) armTimeout(id)
+            id
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP diagnostics unavailable: ${e.message}")
+            0L
+        }
+    }
+
+    @Synchronized
+    fun startOrJoin(trigger: WppIntegrationTrigger): Long {
+        return try {
+            val wasActive = coordinator.isActive
+            val id = coordinator.startOrJoin(trigger)
+            if (!wasActive) armTimeout(id)
+            id
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP diagnostics unavailable: ${e.message}")
+            0L
+        }
+    }
+
+    @Synchronized
+    fun record(stage: PhoneWppStage) {
+        try {
+            coordinator.record(stage)
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP event dropped: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun bridgeEstablished(): Long? {
+        return try {
+            coordinator.bridgeEstablished()
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP bridge event dropped: ${e.message}")
+            null
+        }
+    }
+
+    @Synchronized
+    fun bridgeClosed(establishedAttemptId: Long?) {
+        try {
+            coordinator.bridgeClosed(establishedAttemptId)
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP bridge-close event dropped: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun associationOwner(owner: WppAssociationOwner) {
+        try {
+            coordinator.associationOwner(owner)
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP association event dropped: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun timeout() {
+        try {
+            coordinator.attemptId?.let(::timeout)
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WPP timeout event dropped: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun setAttemptFinishedListener(listener: (() -> Unit)?) {
+        attemptFinishedListener = listener
+    }
+
+    @get:Synchronized
+    val isActive: Boolean
+        get() = coordinator.isActive
+
+    private fun armTimeout(attemptId: Long) {
+        lifecycleGuard.started(attemptId)
+        timeoutRunnable?.let(handler::removeCallbacks)
+        val timeout = Runnable { timeout(attemptId) }
+        timeoutRunnable = timeout
+        timeoutAttemptId = attemptId
+        handler.postDelayed(timeout, MAX_ATTEMPT_DURATION_MS)
+    }
+
+    @Synchronized
+    private fun timeout(attemptId: Long) {
+        if (!lifecycleGuard.ownsActiveAttempt(attemptId) || coordinator.attemptId != attemptId) return
+        coordinator.timeout()
+    }
+
+    @Synchronized
+    private fun finishAttemptLifecycle(attemptId: Long) {
+        lifecycleGuard.completed(attemptId)
+        if (timeoutAttemptId == attemptId) {
+            timeoutRunnable?.let(handler::removeCallbacks)
+            timeoutRunnable = null
+            timeoutAttemptId = null
+        }
+        handler.post { notifyAttemptFinished(attemptId) }
+    }
+
+    private fun notifyAttemptFinished(attemptId: Long) {
+        val listener = synchronized(this) {
+            if (!lifecycleGuard.takeCleanup(attemptId)) return
+            attemptFinishedListener
+        }
+        listener?.invoke()
+    }
+
+    private const val TAG = "OAL_WppStartup"
+}

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/WppNetworkObserver.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/WppNetworkObserver.kt
@@ -1,0 +1,75 @@
+package com.openautolink.companion.diagnostics
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+
+/** Passive Wi-Fi presence observer for the active diagnostic attempt. */
+class WppNetworkObserver(
+    context: Context,
+    private val onStage: (PhoneWppStage) -> Unit,
+) {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val addressedNetworks = WppObservedNetworkSet<Network>()
+    private var callback: ConnectivityManager.NetworkCallback? = null
+
+    @Synchronized
+    fun start() {
+        if (callback != null) return
+        val networkCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                connectivityManager.getLinkProperties(network)?.let { properties ->
+                    observeAddressedWifi(network, properties)
+                }
+            }
+
+            override fun onLinkPropertiesChanged(network: Network, properties: LinkProperties) {
+                observeAddressedWifi(network, properties)
+            }
+
+            override fun onLost(network: Network) {
+                val wasAddressed = synchronized(this@WppNetworkObserver) {
+                    addressedNetworks.lost(network)
+                }
+                if (wasAddressed) onStage(PhoneWppStage.NETWORK_LOST)
+            }
+        }
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+        try {
+            connectivityManager.registerNetworkCallback(request, networkCallback)
+            callback = networkCallback
+            CompanionLog.d(TAG, "Passive WiFi network observer registered")
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Passive WiFi network observer unavailable: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun stop() {
+        callback?.let { networkCallback ->
+            try {
+                connectivityManager.unregisterNetworkCallback(networkCallback)
+            } catch (_: Exception) {
+            }
+        }
+        callback = null
+        addressedNetworks.clear()
+        CompanionLog.d(TAG, "Passive WiFi network observer stopped")
+    }
+
+    private fun observeAddressedWifi(network: Network, properties: LinkProperties) {
+        if (properties.interfaceName.isNullOrBlank() || properties.linkAddresses.isEmpty()) return
+        val firstAddressedObservation = synchronized(this) { addressedNetworks.accept(network) }
+        if (firstAddressedObservation) onStage(PhoneWppStage.NETWORK_AVAILABLE)
+    }
+
+    companion object {
+        private const val TAG = "OAL_WppNetwork"
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicy.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicy.kt
@@ -1,0 +1,197 @@
+package com.openautolink.companion.diagnostics
+
+enum class WppIntegrationTrigger {
+    SELECTED_BT,
+    START,
+    PREWARM,
+}
+
+enum class WppNetworkObservationMode {
+    PASSIVE,
+}
+
+enum class WppAssociationOwner(val logValue: String) {
+    COMPANION_ASSIST("companion_assist"),
+    WPP("wpp"),
+}
+
+/** Pure routing rules shared by the passive Android integration and host tests. */
+object WppStartupIntegrationPolicy {
+    fun routeAttempt(
+        @Suppress("UNUSED_PARAMETER") trigger: WppIntegrationTrigger,
+        activeAttemptId: Long?,
+        candidateAttemptId: Long,
+    ): Long {
+        require(candidateAttemptId > 0L) { "WPP candidate attempt ID must be positive" }
+        return activeAttemptId ?: candidateAttemptId
+    }
+
+    fun permitsActiveNetworkRequest(mode: WppNetworkObservationMode): Boolean = when (mode) {
+        WppNetworkObservationMode.PASSIVE -> false
+    }
+
+    /** Null means a caller without a diagnostic handoff; zero means diagnostics skipped it. */
+    fun shouldJoinDispatchedAttempt(dispatchedAttemptId: Long?): Boolean =
+        dispatchedAttemptId == null || dispatchedAttemptId > 0L
+
+    fun isBridgeEstablished(stage: PhoneWppStage): Boolean =
+        stage == PhoneWppStage.BRIDGE_ESTABLISHED
+}
+
+/** Tracks only networks that produced an accepted addressed-Wi-Fi observation. */
+internal class WppObservedNetworkSet<T> {
+    private val acceptedNetworks = mutableSetOf<T>()
+
+    fun accept(network: T): Boolean = acceptedNetworks.add(network)
+
+    fun lost(network: T): Boolean = acceptedNetworks.remove(network)
+
+    fun clear() {
+        acceptedNetworks.clear()
+    }
+}
+
+/** Owns timeout and posted-cleanup work for one monotonic diagnostic attempt ID. */
+internal class WppAttemptLifecycleGuard {
+    private var activeAttemptId: Long? = null
+    private var cleanupPendingAttemptId: Long? = null
+
+    fun started(attemptId: Long) {
+        require(attemptId > 0L) { "WPP attempt ID must be positive" }
+        activeAttemptId = attemptId
+    }
+
+    fun completed(attemptId: Long) {
+        if (activeAttemptId != attemptId) return
+        activeAttemptId = null
+        cleanupPendingAttemptId = attemptId
+    }
+
+    fun ownsActiveAttempt(attemptId: Long): Boolean = activeAttemptId == attemptId
+
+    fun takeCleanup(attemptId: Long): Boolean {
+        if (activeAttemptId != null || cleanupPendingAttemptId != attemptId) return false
+        cleanupPendingAttemptId = null
+        return true
+    }
+}
+
+/**
+ * Synchronized logging-only coordinator. It never controls startup behavior; it only routes
+ * observations into one bounded [WppStartupTracker] attempt and emits one terminal summary.
+ */
+class WppDiagnosticsCoordinator(
+    private val elapsedRealtimeMs: () -> Long,
+    private val eventSink: (String) -> Unit,
+    private val summarySink: (PhoneWppSummary) -> Unit,
+    private val tracker: WppStartupTracker = WppStartupTracker(),
+) {
+    private var activeAttemptId: Long? = null
+
+    @get:Synchronized
+    val isActive: Boolean
+        get() = activeAttemptId != null
+
+    @get:Synchronized
+    val attemptId: Long?
+        get() = activeAttemptId
+
+    @Synchronized
+    fun selectedTargetConnected(existingBridgeActive: Boolean = false): Long? {
+        val now = elapsedRealtimeMs()
+        if (existingBridgeActive) {
+            eventSink(
+                "PHONE WPP EVENT attempt=none stage=${PhoneWppStage.TARGET_BT_CONNECTED.name} " +
+                    "disposition=existing_bridge elapsed=$now",
+            )
+            return null
+        }
+        val wasActive = tracker.isActive
+        val id = tracker.selectedCarConnected(now)
+        activeAttemptId = id
+        if (!wasActive) logEvent(id, "ATTEMPT_START", now)
+        logEvent(id, PhoneWppStage.TARGET_BT_CONNECTED.name, now)
+        return id
+    }
+
+    @Synchronized
+    fun startOrJoin(trigger: WppIntegrationTrigger): Long {
+        val input = when (trigger) {
+            WppIntegrationTrigger.START -> WppStartInput.START
+            WppIntegrationTrigger.PREWARM -> WppStartInput.PREWARM
+            WppIntegrationTrigger.SELECTED_BT ->
+                error("SELECTED_BT must use selectedTargetConnected()")
+        }
+        val now = elapsedRealtimeMs()
+        val wasActive = tracker.isActive
+        val id = tracker.startOrJoin(input, now)
+        activeAttemptId = id
+        if (!wasActive) logEvent(id, "ATTEMPT_START", now)
+        eventSink("PHONE WPP EVENT attempt=$id stage=START_INPUT input=${input.name} elapsed=$now")
+        return id
+    }
+
+    @Synchronized
+    fun record(stage: PhoneWppStage) {
+        if (stage == PhoneWppStage.BRIDGE_ESTABLISHED) {
+            bridgeEstablished()
+            return
+        }
+        if (stage == PhoneWppStage.BRIDGE_CLOSED) {
+            // Close is post-startup and must arrive through bridgeClosed() with the
+            // generation captured when that bridge was established.
+            return
+        }
+        val id = activeAttemptId ?: return
+        val now = elapsedRealtimeMs()
+        tracker.record(stage, now)
+        logEvent(id, stage.name, now)
+    }
+
+    /** Completes startup and returns the generation later close diagnostics must retain. */
+    @Synchronized
+    fun bridgeEstablished(): Long? {
+        val id = activeAttemptId ?: return null
+        val now = elapsedRealtimeMs()
+        tracker.record(PhoneWppStage.BRIDGE_ESTABLISHED, now)
+        logEvent(id, PhoneWppStage.BRIDGE_ESTABLISHED.name, now)
+        finish(tracker.complete(now))
+        return id
+    }
+
+    /** A bridge close is post-startup evidence and must never mutate the current attempt. */
+    @Synchronized
+    fun bridgeClosed(establishedAttemptId: Long?) {
+        val now = elapsedRealtimeMs()
+        val id = establishedAttemptId?.takeIf { it > 0L }?.toString() ?: "none"
+        eventSink(
+            "PHONE WPP EVENT attempt=$id stage=${PhoneWppStage.BRIDGE_CLOSED.name} " +
+                "phase=post_startup elapsed=$now",
+        )
+    }
+
+    @Synchronized
+    fun associationOwner(owner: WppAssociationOwner) {
+        val id = activeAttemptId ?: return
+        val now = elapsedRealtimeMs()
+        eventSink(
+            "PHONE WPP EVENT attempt=$id stage=ASSOCIATION_OWNER " +
+                "association_owner=${owner.logValue} elapsed=$now",
+        )
+    }
+
+    @Synchronized
+    fun timeout() {
+        if (activeAttemptId == null) return
+        finish(tracker.timeout(elapsedRealtimeMs()))
+    }
+
+    private fun finish(summary: PhoneWppSummary) {
+        activeAttemptId = null
+        summarySink(summary)
+    }
+
+    private fun logEvent(attemptId: Long, stage: String, elapsedMs: Long) {
+        eventSink("PHONE WPP EVENT attempt=$attemptId stage=$stage elapsed=$elapsedMs")
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupTracker.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupTracker.kt
@@ -8,7 +8,9 @@ enum class WppStartInput {
 enum class PhoneWppStage {
     TARGET_BT_CONNECTED,
     SERVICE_READY,
+    TCP_START_INTENT,
     TCP_LISTENING,
+    TCP_LISTEN_FAILED,
     WARM_PROXY_READY,
     NETWORK_AVAILABLE,
     NETWORK_LOST,

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupTracker.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/WppStartupTracker.kt
@@ -1,0 +1,202 @@
+package com.openautolink.companion.diagnostics
+
+enum class WppStartInput {
+    START,
+    PREWARM,
+}
+
+enum class PhoneWppStage {
+    TARGET_BT_CONNECTED,
+    SERVICE_READY,
+    TCP_LISTENING,
+    WARM_PROXY_READY,
+    NETWORK_AVAILABLE,
+    NETWORK_LOST,
+    CAR_PROBE,
+    CAR_SOCKET,
+    AA_SOCKET,
+    BRIDGE_ESTABLISHED,
+    BRIDGE_CLOSED,
+    TARGET_BT_DISCONNECTED,
+    STOPPED,
+}
+
+data class PhoneWppEvent(
+    val stage: PhoneWppStage,
+    val elapsedMs: Long,
+    val detail: String = "",
+)
+
+data class PhoneWppSummary(
+    val attemptId: Long,
+    val startedAtMs: Long,
+    val endedAtMs: Long,
+    val startInputs: Set<WppStartInput>,
+    val outcome: String,
+    val missingStage: PhoneWppStage?,
+    val timeline: List<PhoneWppEvent>,
+)
+
+/** Pure logging model for one phone-side WPP startup attempt. */
+class WppStartupTracker(
+    private val nextAttemptId: () -> Long = { DefaultAttemptIds.next() },
+) {
+    private var activeAttemptId: Long? = null
+    private var lastAttemptId: Long? = null
+    private var startedAtMs = 0L
+    private val startInputs = linkedSetOf<WppStartInput>()
+    private val events = mutableListOf<PhoneWppEvent>()
+    private val observedStages = mutableSetOf<PhoneWppStage>()
+
+    val isActive: Boolean
+        get() = activeAttemptId != null
+
+    fun startOrJoin(input: WppStartInput, elapsedMs: Long): Long {
+        val id = ensureActiveAttempt(elapsedMs)
+        startInputs += input
+        return id
+    }
+
+    fun selectedCarConnected(elapsedMs: Long, detail: String = ""): Long {
+        val id = ensureActiveAttempt(elapsedMs)
+        record(PhoneWppStage.TARGET_BT_CONNECTED, elapsedMs, detail)
+        return id
+    }
+
+    fun record(
+        stage: PhoneWppStage,
+        elapsedMs: Long,
+        detail: String = "",
+    ): PhoneWppSummary {
+        ensureActiveAttempt(elapsedMs)
+        observedStages += stage
+        events += PhoneWppEvent(stage, elapsedMs, sanitizeDetail(detail))
+        if (events.size > MAX_EVENTS) events.removeAt(0)
+        return snapshot(endedAtMs = elapsedMs)
+    }
+
+    fun complete(elapsedMs: Long): PhoneWppSummary {
+        val summary = snapshot(
+            endedAtMs = elapsedMs,
+            outcomeOverride = if (hasStage(PhoneWppStage.BRIDGE_ESTABLISHED)) {
+                "connected"
+            } else {
+                "incomplete"
+            },
+        )
+        activeAttemptId = null
+        return summary
+    }
+
+    fun timeout(elapsedMs: Long): PhoneWppSummary {
+        val summary = snapshot(endedAtMs = elapsedMs, outcomeOverride = "timeout")
+        activeAttemptId = null
+        return summary
+    }
+
+    private fun snapshot(
+        endedAtMs: Long,
+        outcomeOverride: String? = null,
+    ): PhoneWppSummary = PhoneWppSummary(
+        attemptId = checkNotNull(activeAttemptId) { "No WPP startup attempt is active" },
+        startedAtMs = startedAtMs,
+        endedAtMs = endedAtMs,
+        startInputs = startInputs.toSet(),
+        outcome = outcomeOverride ?: outcome(),
+        missingStage = REQUIRED_STARTUP_STAGES.firstOrNull { !hasStage(it) },
+        timeline = events.sortedBy { it.elapsedMs },
+    )
+
+    private fun outcome(): String = when {
+        hasStage(PhoneWppStage.BRIDGE_ESTABLISHED) -> "connected"
+        hasStage(PhoneWppStage.AA_SOCKET) && !hasStage(PhoneWppStage.CAR_SOCKET) -> "waiting_for_car"
+        hasStage(PhoneWppStage.CAR_SOCKET) && !hasStage(PhoneWppStage.AA_SOCKET) ->
+            "waiting_for_android_auto"
+        else -> "starting"
+    }
+
+    private fun hasStage(stage: PhoneWppStage): Boolean = stage in observedStages
+
+    // Detail is intentionally fail-closed: stage and elapsed time are sufficient diagnostics,
+    // while arbitrary producer text can contain identifiers, addresses, or credentials.
+    private fun sanitizeDetail(@Suppress("UNUSED_PARAMETER") detail: String): String = ""
+
+    private fun ensureActiveAttempt(elapsedMs: Long): Long {
+        activeAttemptId?.let { return it }
+        val supplied = nextAttemptId()
+        require(supplied > 0L) { "WPP attempt ID must be positive: $supplied" }
+        lastAttemptId?.let { previous ->
+            require(supplied > previous) {
+                "WPP attempt ID must increase: supplied=$supplied previous=$previous"
+            }
+        }
+        events.clear()
+        observedStages.clear()
+        startInputs.clear()
+        startedAtMs = elapsedMs
+        val id = supplied
+        lastAttemptId = id
+        activeAttemptId = id
+        return id
+    }
+
+    private object DefaultAttemptIds {
+        private val counter = MonotonicAttemptIdCounter()
+
+        fun next(): Long = counter.next()
+    }
+
+    companion object {
+        const val MAX_EVENTS = 64
+        const val MAX_DETAIL_LENGTH = 96
+
+        private val REQUIRED_STARTUP_STAGES = listOf(
+            PhoneWppStage.TARGET_BT_CONNECTED,
+            PhoneWppStage.SERVICE_READY,
+            PhoneWppStage.TCP_LISTENING,
+            PhoneWppStage.WARM_PROXY_READY,
+            PhoneWppStage.NETWORK_AVAILABLE,
+            PhoneWppStage.CAR_PROBE,
+            PhoneWppStage.CAR_SOCKET,
+            PhoneWppStage.AA_SOCKET,
+            PhoneWppStage.BRIDGE_ESTABLISHED,
+        )
+    }
+}
+
+internal class MonotonicAttemptIdCounter(initialValue: Long = 0L) {
+    private var value = initialValue
+
+    @Synchronized
+    fun next(): Long {
+        check(value < Long.MAX_VALUE) { "WPP attempt ID counter exhausted" }
+        value += 1L
+        return value
+    }
+}
+
+object PhoneWppSummaryFormatter {
+    const val MAX_LINE_LENGTH = 480
+
+    fun format(summary: PhoneWppSummary): String {
+        val prefix = buildString {
+            append("PHONE WPP SUMMARY attempt=").append(summary.attemptId)
+            append(" outcome=").append(summary.outcome)
+            append(" missing=").append(summary.missingStage?.name ?: "none")
+            append(" timeline=")
+        }
+        val timeline = summary.timeline.joinToString(">") { event ->
+            buildString {
+                append(event.stage.name).append('@').append(event.elapsedMs)
+                if (event.detail.isNotBlank()) append('(').append(event.detail).append(')')
+            }
+        }
+        val budget = (MAX_LINE_LENGTH - prefix.length).coerceAtLeast(0)
+        val boundedTimeline = when {
+            timeline.length <= budget -> timeline
+            budget <= 1 -> "~".take(budget)
+            else -> timeline.take(budget - 1) + "~"
+        }
+        return prefix + boundedTimeline
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -15,6 +15,12 @@ import com.openautolink.companion.MainActivity
 import com.openautolink.companion.R
 import com.openautolink.companion.diagnostics.CompanionFileLogger
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
+import com.openautolink.companion.diagnostics.PhoneWppStage
+import com.openautolink.companion.diagnostics.WppAssociationOwner
+import com.openautolink.companion.diagnostics.WppIntegrationTrigger
+import com.openautolink.companion.diagnostics.WppNetworkObserver
+import com.openautolink.companion.diagnostics.WppStartupIntegrationPolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -39,6 +45,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     private var multicastLock: android.net.wifi.WifiManager.MulticastLock? = null
     private var fileLogger: CompanionFileLogger? = null
     private var fileLogIdleTimeoutJob: kotlinx.coroutines.Job? = null
+    private var wppNetworkObserver: WppNetworkObserver? = null
     /** True once a connection has been observed during the current logging session. */
     @Volatile private var loggingSessionEverConnected: Boolean = false
 
@@ -48,6 +55,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         CompanionLog.init(com.openautolink.companion.BuildConfig.VERSION_NAME)
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, createNotification("Starting..."))
+        PhoneWppDiagnostics.setAttemptFinishedListener(::stopWppNetworkObserver)
         // Hold multicast lock for mDNS discovery (some OEMs filter multicast when screen off)
         try {
             val wm = applicationContext.getSystemService(WIFI_SERVICE) as? android.net.wifi.WifiManager
@@ -88,6 +96,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             }
 
             ACTION_START -> {
+                joinWppAttempt(WppIntegrationTrigger.START, intent)
                 // If already connected (AA bridge active), ignore duplicate starts
                 // (e.g. BT auto-start firing a few hundred ms after the car already
                 // TCP-connected and we fired the AA trigger). Restarting here would
@@ -110,6 +119,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             }
 
             ACTION_PREWARM -> {
+                joinWppAttempt(WppIntegrationTrigger.PREWARM, intent)
                 // Pre-warm path: car-presence signal (BT, scripted, etc.) tells
                 // us a car connection is imminent. Start the AA pipeline now so
                 // by the time the car's TCP arrives ~3–10s later, AA is warm
@@ -149,6 +159,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     }
 
     private fun startTcp() {
+        PhoneWppDiagnostics.record(PhoneWppStage.TCP_START_INTENT)
         acquireWakeLock()
         tcpAdvertiser?.stop()
 
@@ -169,6 +180,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         val prefs = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
         val entries = com.openautolink.companion.wifi.CarWifiEntry.loadAll(prefs)
         if (entries.isEmpty()) {
+            PhoneWppDiagnostics.associationOwner(WppAssociationOwner.WPP)
             CompanionLog.d(TAG, "No car WiFi entries configured, skipping CarWifiManager")
             return
         }
@@ -296,10 +308,14 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     // ── Lifecycle ──────────────────────────────────────────────────────
 
     override fun onDestroy() {
+        PhoneWppDiagnostics.record(PhoneWppStage.STOPPED)
         _isRunning.value = false
         _isConnected.value = false
         _statusText.value = "Stopped"
         tcpAdvertiser?.stop()
+        PhoneWppDiagnostics.timeout()
+        PhoneWppDiagnostics.setAttemptFinishedListener(null)
+        stopWppNetworkObserver()
         carWifiManager?.stop()
         stopFileLogging()
         releaseWakeLock()
@@ -310,6 +326,36 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         serviceScope.cancel()
         _instance = null
         super.onDestroy()
+    }
+
+    private fun joinWppAttempt(trigger: WppIntegrationTrigger, intent: Intent) {
+        val dispatchedAttemptId = intent.takeIf { it.hasExtra(EXTRA_WPP_ATTEMPT_ID) }
+            ?.getLongExtra(EXTRA_WPP_ATTEMPT_ID, 0L)
+        if (!WppStartupIntegrationPolicy.shouldJoinDispatchedAttempt(dispatchedAttemptId)) return
+
+        val attemptId = PhoneWppDiagnostics.startOrJoin(trigger)
+        if (dispatchedAttemptId != null &&
+            dispatchedAttemptId > 0L &&
+            dispatchedAttemptId != attemptId
+        ) {
+            CompanionLog.w(TAG, "WPP attempt handoff changed before service delivery")
+        }
+        if (attemptId > 0L && wppNetworkObserver == null) {
+            try {
+                wppNetworkObserver = WppNetworkObserver(
+                    applicationContext,
+                    PhoneWppDiagnostics::record,
+                ).also { it.start() }
+            } catch (e: Exception) {
+                CompanionLog.w(TAG, "Passive WPP network observation unavailable: ${e.message}")
+            }
+        }
+        PhoneWppDiagnostics.record(PhoneWppStage.SERVICE_READY)
+    }
+
+    private fun stopWppNetworkObserver() {
+        wppNetworkObserver?.stop()
+        wppNetworkObserver = null
     }
 
     override fun onBind(intent: Intent?) = null
@@ -413,6 +459,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         const val ACTION_UPLOAD_LOGS = "com.openautolink.companion.ACTION_UPLOAD_LOGS"
         /** Optional extra on ACTION_START: also start file logging once the service is up. */
         const val EXTRA_START_LOGGING = "com.openautolink.companion.EXTRA_START_LOGGING"
+        /** Diagnostic-only handoff for a selected-car WPP startup attempt. */
+        const val EXTRA_WPP_ATTEMPT_ID = "com.openautolink.companion.EXTRA_WPP_ATTEMPT_ID"
 
         /** Observable service state for UI. */
         private val _isRunning = MutableStateFlow(false)

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -6,6 +6,8 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import com.openautolink.companion.connection.AaProxy
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
+import com.openautolink.companion.diagnostics.PhoneWppStage
 import com.openautolink.companion.trigger.TransparentTriggerActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -112,6 +114,7 @@ class TcpAdvertiser(
         CompanionLog.i(TAG, "Starting TCP server on port $PORT")
 
         scope.launch {
+            var listenerBound = false
             try {
                 // Retry bind briefly to handle EADDRINUSE race when the service
                 // is restarted quickly (e.g. BT reconnect triggers start within
@@ -131,8 +134,10 @@ class TcpAdvertiser(
                         delay(BIND_RETRY_DELAY_MS)
                     }
                 }
+                listenerBound = true
                 serverSocket = server
                 CompanionLog.i(TAG, "Listening on 0.0.0.0:$PORT")
+                PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTENING)
 
                 registerNsd()
                 startIdentityServer()
@@ -140,6 +145,7 @@ class TcpAdvertiser(
 
                 while (isRunning) {
                     val carSocket = server.accept()
+                    PhoneWppDiagnostics.record(PhoneWppStage.CAR_SOCKET)
                     val remoteIp = carSocket.inetAddress?.hostAddress ?: "unknown"
                     CompanionLog.i(TAG, "Car connected from $remoteIp")
                     stateListener.onConnecting()
@@ -147,6 +153,9 @@ class TcpAdvertiser(
                 }
             } catch (e: Exception) {
                 if (isRunning) {
+                    if (!listenerBound) {
+                        PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)
+                    }
                     CompanionLog.e(TAG, "TCP server error: ${e.message}")
                 }
             }
@@ -194,6 +203,7 @@ class TcpAdvertiser(
             )
             activeProxy = proxy
             val port = proxy.start()
+            if (port > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
             CompanionLog.i(TAG, "Started proxy for WPP on localhost:$port")
             port
         } catch (e: Exception) {
@@ -241,6 +251,7 @@ class TcpAdvertiser(
                 activeProxy = proxy
                 isLaunching = true
                 val localPort = proxy.start()
+                if (localPort > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
                 // Do NOT tell Android Auto to connect yet.
                 //
                 // Bluetooth connecting means "a car is nearby", not "the car can
@@ -339,6 +350,7 @@ class TcpAdvertiser(
                 CompanionLog.d(TAG, "Identity probe from $remoteIp: bad/empty request ($read bytes)")
                 return
             }
+            PhoneWppDiagnostics.record(PhoneWppStage.CAR_PROBE)
             val prefs = context.getSharedPreferences(
                 com.openautolink.companion.CompanionPrefs.NAME,
                 Context.MODE_PRIVATE,
@@ -419,6 +431,7 @@ class TcpAdvertiser(
                         CompanionLog.d(TAG, "UDP probe from $remoteIp: bad payload '$text'")
                         continue
                     }
+                    PhoneWppDiagnostics.record(PhoneWppStage.CAR_PROBE)
                     val prefs = context.getSharedPreferences(
                         com.openautolink.companion.CompanionPrefs.NAME,
                         Context.MODE_PRIVATE,
@@ -570,6 +583,7 @@ class TcpAdvertiser(
                 )
                 activeProxy = proxy
                 val localPort = proxy.start()
+                if (localPort > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
 
                 fireAaLaunchIntent(localPort)
                 startAaConnectWatchdog(carSocket)

--- a/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
+++ b/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
@@ -13,6 +13,8 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
+import com.openautolink.companion.diagnostics.WppAssociationOwner
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -66,6 +68,7 @@ class CarWifiManager(private val context: Context) {
         entries = carWifiEntries
         running = true
         attempt = 0
+        PhoneWppDiagnostics.associationOwner(WppAssociationOwner.COMPANION_ASSIST)
         CompanionLog.i(TAG, "Starting car WiFi manager for ${entries.size} SSID(s)")
         registerSuggestions()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) tryConnect()

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
@@ -1,0 +1,274 @@
+package com.openautolink.companion.diagnostics
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppStartupIntegrationPolicyTest {
+
+    @Test
+    fun `selected BT and service start join one attempt`() {
+        val coordinator = coordinatorWithFirstAttempt(71L)
+        val selectedByCoordinator = coordinator.selectedTargetConnected()
+        val joinedByCoordinator = coordinator.startOrJoin(WppIntegrationTrigger.START)
+        val selectedAttempt = WppStartupIntegrationPolicy.routeAttempt(
+            trigger = WppIntegrationTrigger.SELECTED_BT,
+            activeAttemptId = null,
+            candidateAttemptId = 71L,
+        )
+        val serviceAttempt = WppStartupIntegrationPolicy.routeAttempt(
+            trigger = WppIntegrationTrigger.START,
+            activeAttemptId = selectedAttempt,
+            candidateAttemptId = 72L,
+        )
+
+        assertEquals(71L, selectedAttempt)
+        assertEquals(selectedAttempt, serviceAttempt)
+        assertEquals(selectedByCoordinator, joinedByCoordinator)
+    }
+
+    @Test
+    fun `start and prewarm join the same active attempt`() {
+        val coordinator = coordinatorWithFirstAttempt(81L)
+        val startedByCoordinator = coordinator.startOrJoin(WppIntegrationTrigger.START)
+        val prewarmedByCoordinator = coordinator.startOrJoin(WppIntegrationTrigger.PREWARM)
+        val started = WppStartupIntegrationPolicy.routeAttempt(
+            trigger = WppIntegrationTrigger.START,
+            activeAttemptId = null,
+            candidateAttemptId = 81L,
+        )
+        val prewarmed = WppStartupIntegrationPolicy.routeAttempt(
+            trigger = WppIntegrationTrigger.PREWARM,
+            activeAttemptId = started,
+            candidateAttemptId = 82L,
+        )
+
+        assertEquals(started, prewarmed)
+        assertEquals(startedByCoordinator, prewarmedByCoordinator)
+    }
+
+    @Test
+    fun `selected BT with an existing bridge logs standalone and skips attempt creation`() {
+        val events = mutableListOf<String>()
+        val coordinator = WppDiagnosticsCoordinator(
+            elapsedRealtimeMs = { 100L },
+            eventSink = events::add,
+            summarySink = {},
+            tracker = WppStartupTracker { 91L },
+        )
+
+        val selectedAttempt = coordinator.selectedTargetConnected(existingBridgeActive = true)
+
+        assertEquals(null, selectedAttempt)
+        assertFalse(coordinator.isActive)
+        assertEquals(
+            listOf(
+                "PHONE WPP EVENT attempt=none stage=TARGET_BT_CONNECTED " +
+                    "disposition=existing_bridge elapsed=100",
+            ),
+            events,
+        )
+
+        val started = coordinator.startOrJoin(WppIntegrationTrigger.START)
+        val prewarmed = coordinator.startOrJoin(WppIntegrationTrigger.PREWARM)
+        assertEquals(91L, started)
+        assertEquals(started, prewarmed)
+    }
+
+    @Test
+    fun `diagnostic-only skipped handoff suppresses service attempt joining`() {
+        assertFalse(WppStartupIntegrationPolicy.shouldJoinDispatchedAttempt(0L))
+        assertTrue(WppStartupIntegrationPolicy.shouldJoinDispatchedAttempt(null))
+        assertTrue(WppStartupIntegrationPolicy.shouldJoinDispatchedAttempt(91L))
+    }
+
+    @Test
+    fun `passive observation never permits requestNetwork`() {
+        assertFalse(
+            WppStartupIntegrationPolicy.permitsActiveNetworkRequest(
+                WppNetworkObservationMode.PASSIVE,
+            ),
+        )
+    }
+
+    @Test
+    fun `probes and sockets are evidence but not an established bridge`() {
+        listOf(
+            PhoneWppStage.CAR_PROBE,
+            PhoneWppStage.CAR_SOCKET,
+            PhoneWppStage.AA_SOCKET,
+        ).forEach { stage ->
+            assertFalse(WppStartupIntegrationPolicy.isBridgeEstablished(stage))
+        }
+    }
+
+    @Test
+    fun `connected outcome is reserved for bridge establishment`() {
+        PhoneWppStage.entries.forEach { stage ->
+            assertEquals(
+                stage == PhoneWppStage.BRIDGE_ESTABLISHED,
+                WppStartupIntegrationPolicy.isBridgeEstablished(stage),
+            )
+        }
+    }
+
+    @Test
+    fun `bridge establishment completes once before the startup deadline`() {
+        var now = 100L
+        val summaries = mutableListOf<PhoneWppSummary>()
+        val coordinator = WppDiagnosticsCoordinator(
+            elapsedRealtimeMs = { now },
+            eventSink = {},
+            summarySink = summaries::add,
+        )
+        coordinator.startOrJoin(WppIntegrationTrigger.START)
+        coordinator.record(PhoneWppStage.BRIDGE_ESTABLISHED)
+        now += 120_001L
+
+        coordinator.timeout()
+        coordinator.record(PhoneWppStage.BRIDGE_CLOSED)
+
+        assertEquals(1, summaries.size)
+        assertEquals("connected", summaries.single().outcome)
+        assertEquals(100L, summaries.single().endedAtMs)
+    }
+
+    @Test
+    fun `old bridge close cannot alter a newer startup attempt`() {
+        var now = 100L
+        var nextId = 201L
+        val events = mutableListOf<String>()
+        val summaries = mutableListOf<PhoneWppSummary>()
+        val coordinator = WppDiagnosticsCoordinator(
+            elapsedRealtimeMs = { now },
+            eventSink = events::add,
+            summarySink = summaries::add,
+            tracker = WppStartupTracker { nextId++ },
+        )
+        coordinator.startOrJoin(WppIntegrationTrigger.START)
+        val establishedAttemptId = coordinator.bridgeEstablished()
+
+        now = 200L
+        val newerAttemptId = coordinator.startOrJoin(WppIntegrationTrigger.START)
+        coordinator.record(PhoneWppStage.SERVICE_READY)
+        now = 300L
+        coordinator.bridgeClosed(establishedAttemptId)
+        coordinator.timeout()
+
+        assertEquals(201L, establishedAttemptId)
+        assertEquals(202L, newerAttemptId)
+        assertEquals(2, summaries.size)
+        assertFalse(summaries.last().timeline.any { it.stage == PhoneWppStage.BRIDGE_CLOSED })
+        assertTrue(
+            events.contains(
+                "PHONE WPP EVENT attempt=201 stage=BRIDGE_CLOSED phase=post_startup elapsed=300",
+            ),
+        )
+    }
+
+    @Test
+    fun `coordinator timeout reports the first missing stage once`() {
+        val summaries = mutableListOf<PhoneWppSummary>()
+        val coordinator = WppDiagnosticsCoordinator(
+            elapsedRealtimeMs = { 500L },
+            eventSink = {},
+            summarySink = summaries::add,
+        )
+        coordinator.selectedTargetConnected()
+        coordinator.record(PhoneWppStage.SERVICE_READY)
+
+        coordinator.timeout()
+        coordinator.timeout()
+
+        assertEquals(1, summaries.size)
+        assertEquals("timeout", summaries.single().outcome)
+        assertEquals(PhoneWppStage.TCP_LISTENING, summaries.single().missingStage)
+    }
+
+    @Test
+    fun `stale completed attempt cleanup cannot claim a newer attempt`() {
+        val lifecycle = WppAttemptLifecycleGuard()
+        lifecycle.started(101L)
+        lifecycle.completed(101L)
+
+        lifecycle.started(102L)
+
+        assertFalse(lifecycle.takeCleanup(101L))
+        assertTrue(lifecycle.ownsActiveAttempt(102L))
+        lifecycle.completed(102L)
+        assertFalse(lifecycle.takeCleanup(101L))
+        assertTrue(lifecycle.takeCleanup(102L))
+        assertFalse(lifecycle.takeCleanup(102L))
+    }
+
+    @Test
+    fun `network loss is emitted only for previously accepted networks`() {
+        val networks = WppObservedNetworkSet<String>()
+
+        assertFalse(networks.lost("unrelated"))
+        assertTrue(networks.accept("wpp"))
+        assertFalse(networks.accept("wpp"))
+        assertTrue(networks.lost("wpp"))
+        assertFalse(networks.lost("wpp"))
+    }
+
+    @Test
+    fun `bridge close keeps the generation captured at establishment`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt",
+        ).readText()
+
+        assertTrue(
+            source.contains(
+                "bridgeAttemptId = PhoneWppDiagnostics.bridgeEstablished()",
+            ),
+        )
+        assertTrue(source.contains("PhoneWppDiagnostics.bridgeClosed(bridgeAttemptId)"))
+        assertFalse(source.contains("record(PhoneWppStage.BRIDGE_CLOSED)"))
+    }
+
+    @Test
+    fun `tcp listen failure is reported only before the listener binds`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+
+        assertTrue(source.contains("var listenerBound = false"))
+        assertTrue(source.contains("listenerBound = true"))
+        assertTrue(
+            source.contains(
+                "if (!listenerBound) {\n" +
+                    "                        PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)",
+            ),
+        )
+    }
+
+    @Test
+    fun `network observer source is passive only`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/diagnostics/WppNetworkObserver.kt",
+        ).readText()
+
+        assertTrue(source.contains("registerNetworkCallback("))
+        assertFalse(source.contains("requestNetwork("))
+        assertFalse(source.contains("bindProcessTraffic"))
+        assertFalse(source.contains("bindProcessToNetwork("))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+
+    private fun coordinatorWithFirstAttempt(attemptId: Long) = WppDiagnosticsCoordinator(
+        elapsedRealtimeMs = { 100L },
+        eventSink = {},
+        summarySink = {},
+        tracker = WppStartupTracker { attemptId },
+    )
+}

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupTrackerTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupTrackerTest.kt
@@ -1,0 +1,286 @@
+package com.openautolink.companion.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppStartupTrackerTest {
+
+    @Test
+    fun `start and prewarm inputs join one active attempt`() {
+        var nextId = 41L
+        val tracker = WppStartupTracker { nextId++ }
+
+        val started = tracker.startOrJoin(WppStartInput.START, elapsedMs = 100L)
+        val prewarmed = tracker.startOrJoin(WppStartInput.PREWARM, elapsedMs = 110L)
+        val duplicateStart = tracker.startOrJoin(WppStartInput.START, elapsedMs = 120L)
+
+        assertEquals(41L, started)
+        assertEquals(started, prewarmed)
+        assertEquals(started, duplicateStart)
+        assertEquals(42L, nextId)
+    }
+
+    @Test
+    fun `BT disconnect during handoff does not terminate an attempt that bridges`() {
+        val tracker = WppStartupTracker { 8L }
+        tracker.selectedCarConnected(elapsedMs = 1_000L)
+
+        tracker.record(PhoneWppStage.TARGET_BT_DISCONNECTED, elapsedMs = 1_200L)
+        val bridged = tracker.record(PhoneWppStage.BRIDGE_ESTABLISHED, elapsedMs = 1_500L)
+
+        assertTrue(tracker.isActive)
+        assertEquals(8L, bridged.attemptId)
+        assertEquals("connected", bridged.outcome)
+        assertEquals(
+            listOf(
+                PhoneWppStage.TARGET_BT_CONNECTED,
+                PhoneWppStage.TARGET_BT_DISCONNECTED,
+                PhoneWppStage.BRIDGE_ESTABLISHED,
+            ),
+            bridged.timeline.map { it.stage },
+        )
+    }
+
+    @Test
+    fun `connected outcome and missing stage survive bridge eviction from bounded history`() {
+        val tracker = WppStartupTracker { 9L }
+        tracker.selectedCarConnected(elapsedMs = 1L)
+        listOf(
+            PhoneWppStage.SERVICE_READY,
+            PhoneWppStage.TCP_LISTENING,
+            PhoneWppStage.WARM_PROXY_READY,
+            PhoneWppStage.NETWORK_AVAILABLE,
+            PhoneWppStage.CAR_PROBE,
+            PhoneWppStage.CAR_SOCKET,
+            PhoneWppStage.AA_SOCKET,
+            PhoneWppStage.BRIDGE_ESTABLISHED,
+        ).forEachIndexed { index, stage ->
+            tracker.record(stage, elapsedMs = 10L + index)
+        }
+        repeat(WppStartupTracker.MAX_EVENTS + 1) { index ->
+            tracker.record(PhoneWppStage.NETWORK_LOST, elapsedMs = 100L + index)
+        }
+
+        val summary = tracker.record(PhoneWppStage.STOPPED, elapsedMs = 1_000L)
+
+        assertFalse(summary.timeline.any { it.stage == PhoneWppStage.BRIDGE_ESTABLISHED })
+        assertEquals("connected", summary.outcome)
+        assertEquals(null, summary.missingStage)
+    }
+
+    @Test
+    fun `AA socket without car socket waits for car and is never connected`() {
+        val tracker = WppStartupTracker { 10L }
+        tracker.startOrJoin(WppStartInput.PREWARM, elapsedMs = 100L)
+
+        val summary = tracker.record(PhoneWppStage.AA_SOCKET, elapsedMs = 200L)
+
+        assertEquals("waiting_for_car", summary.outcome)
+        assertTrue(summary.outcome != "connected")
+    }
+
+    @Test
+    fun `waiting outcome and missing stage survive AA socket eviction from bounded history`() {
+        val tracker = WppStartupTracker { 11L }
+        tracker.selectedCarConnected(elapsedMs = 1L)
+        listOf(
+            PhoneWppStage.SERVICE_READY,
+            PhoneWppStage.TCP_LISTENING,
+            PhoneWppStage.WARM_PROXY_READY,
+            PhoneWppStage.NETWORK_AVAILABLE,
+            PhoneWppStage.CAR_PROBE,
+            PhoneWppStage.AA_SOCKET,
+        ).forEachIndexed { index, stage ->
+            tracker.record(stage, elapsedMs = 10L + index)
+        }
+        repeat(WppStartupTracker.MAX_EVENTS + 1) { index ->
+            tracker.record(PhoneWppStage.NETWORK_LOST, elapsedMs = 100L + index)
+        }
+
+        val summary = tracker.record(PhoneWppStage.STOPPED, elapsedMs = 1_000L)
+
+        assertFalse(summary.timeline.any { it.stage == PhoneWppStage.AA_SOCKET })
+        assertEquals("waiting_for_car", summary.outcome)
+        assertEquals(PhoneWppStage.CAR_SOCKET, summary.missingStage)
+    }
+
+    @Test
+    fun `car socket without AA socket waits for Android Auto`() {
+        val tracker = WppStartupTracker { 10L }
+        tracker.selectedCarConnected(elapsedMs = 100L)
+
+        val summary = tracker.record(PhoneWppStage.CAR_SOCKET, elapsedMs = 200L)
+
+        assertEquals("waiting_for_android_auto", summary.outcome)
+    }
+
+    @Test
+    fun `only bridge establishment completes with a positive connected outcome`() {
+        val socketsOnly = WppStartupTracker { 11L }
+        socketsOnly.startOrJoin(WppStartInput.START, elapsedMs = 10L)
+        socketsOnly.record(PhoneWppStage.CAR_SOCKET, elapsedMs = 20L)
+        socketsOnly.record(PhoneWppStage.AA_SOCKET, elapsedMs = 30L)
+
+        val incomplete = socketsOnly.complete(elapsedMs = 40L)
+
+        assertTrue(incomplete.outcome != "connected")
+
+        val bridged = WppStartupTracker { 12L }
+        bridged.startOrJoin(WppStartInput.START, elapsedMs = 50L)
+        bridged.record(PhoneWppStage.BRIDGE_ESTABLISHED, elapsedMs = 60L)
+
+        assertEquals("connected", bridged.complete(elapsedMs = 70L).outcome)
+    }
+
+    @Test
+    fun `timeout identifies the first missing startup stage`() {
+        val tracker = WppStartupTracker { 13L }
+        tracker.selectedCarConnected(elapsedMs = 10L)
+        tracker.record(PhoneWppStage.SERVICE_READY, elapsedMs = 20L)
+        tracker.record(PhoneWppStage.TCP_LISTENING, elapsedMs = 30L)
+
+        val timedOut = tracker.timeout(elapsedMs = 1_000L)
+
+        assertEquals("timeout", timedOut.outcome)
+        assertEquals(PhoneWppStage.WARM_PROXY_READY, timedOut.missingStage)
+        assertTrue(!tracker.isActive)
+    }
+
+    @Test
+    fun `injected attempt IDs must be positive before an attempt activates`() {
+        listOf(-1L, 0L).forEach { suppliedId ->
+            val tracker = WppStartupTracker { suppliedId }
+
+            assertThrows(IllegalArgumentException::class.java) {
+                tracker.startOrJoin(WppStartInput.START, elapsedMs = 1L)
+            }
+            assertFalse(tracker.isActive)
+        }
+    }
+
+    @Test
+    fun `duplicate and decreasing injected attempt IDs throw before activation`() {
+        val suppliedIds = mutableListOf(7L, 7L, 6L, 8L)
+        val tracker = WppStartupTracker { suppliedIds.removeAt(0) }
+        assertEquals(7L, tracker.startOrJoin(WppStartInput.START, elapsedMs = 1L))
+        tracker.timeout(elapsedMs = 2L)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            tracker.startOrJoin(WppStartInput.START, elapsedMs = 3L)
+        }
+        assertFalse(tracker.isActive)
+        assertThrows(IllegalArgumentException::class.java) {
+            tracker.startOrJoin(WppStartInput.START, elapsedMs = 4L)
+        }
+        assertFalse(tracker.isActive)
+        assertEquals(8L, tracker.startOrJoin(WppStartInput.START, elapsedMs = 5L))
+    }
+
+    @Test
+    fun `default counter fails closed at Long MAX and never wraps`() {
+        val counter = MonotonicAttemptIdCounter(initialValue = Long.MAX_VALUE - 1L)
+
+        assertEquals(Long.MAX_VALUE, counter.next())
+        repeat(2) {
+            assertThrows(IllegalStateException::class.java) { counter.next() }
+        }
+    }
+
+    @Test
+    fun `selected car connect after terminal attempts creates a new monotonic ID`() {
+        var nextId = 21L
+        val tracker = WppStartupTracker { nextId++ }
+
+        assertEquals(21L, tracker.selectedCarConnected(elapsedMs = 10L))
+        tracker.record(PhoneWppStage.BRIDGE_ESTABLISHED, elapsedMs = 20L)
+        tracker.complete(elapsedMs = 30L)
+
+        assertEquals(22L, tracker.selectedCarConnected(elapsedMs = 40L))
+        tracker.timeout(elapsedMs = 50L)
+
+        assertEquals(23L, tracker.selectedCarConnected(elapsedMs = 60L))
+    }
+
+    @Test
+    fun `event history and sanitized details are bounded without credentials`() {
+        val tracker = WppStartupTracker { 30L }
+        tracker.selectedCarConnected(elapsedMs = 1L)
+
+        repeat(200) { index ->
+            tracker.record(
+                PhoneWppStage.CAR_PROBE,
+                elapsedMs = 10L + index,
+                detail = "probe=$index ssid=PrivateNet password=superSecret " + "x".repeat(200),
+            )
+        }
+        val summary = tracker.timeout(elapsedMs = 1_000L)
+        val renderedDetails = summary.timeline.joinToString("|") { it.detail }
+
+        assertTrue(summary.timeline.size <= WppStartupTracker.MAX_EVENTS)
+        assertTrue(summary.timeline.all { it.detail.length <= WppStartupTracker.MAX_DETAIL_LENGTH })
+        assertFalse(renderedDetails.contains("PrivateNet"))
+        assertFalse(renderedDetails.contains("superSecret"))
+    }
+
+    @Test
+    fun `sanitizer drops all free-form identifiers addresses and credentials`() {
+        val tracker = WppStartupTracker { 31L }
+        tracker.selectedCarConnected(elapsedMs = 1L, detail = "peer-identifier-12345")
+        listOf(
+            "ssid=My Home Network, token=abc 123; mode=ready",
+            "PSK 'hunter two'",
+            "password=\"space separated secret\"",
+            "credential unquoted value",
+            "client secret: do-not-log",
+            "peer aa:bb:cc:dd:ee:ff",
+            "route 192.168.1.10",
+            "route fe80::1%wlan0",
+        ).forEachIndexed { index, detail ->
+            tracker.record(PhoneWppStage.CAR_PROBE, elapsedMs = 10L + index, detail = detail)
+        }
+
+        val summary = tracker.timeout(elapsedMs = 100L)
+
+        assertTrue(summary.timeline.all { it.detail.isEmpty() })
+    }
+
+    @Test
+    fun `summary formatter keeps outcome and missing before a bounded one line timeline`() {
+        val tracker = WppStartupTracker { 31L }
+        tracker.selectedCarConnected(elapsedMs = 1L)
+        repeat(WppStartupTracker.MAX_EVENTS) { index ->
+            tracker.record(
+                PhoneWppStage.CAR_PROBE,
+                elapsedMs = 10L + index,
+                detail = "probe=$index ${"y".repeat(80)}",
+            )
+        }
+        val summary = tracker.timeout(elapsedMs = 1_000L)
+
+        val line = PhoneWppSummaryFormatter.format(summary)
+
+        assertTrue(line.startsWith("PHONE WPP SUMMARY attempt=31 "))
+        assertTrue(line.length <= PhoneWppSummaryFormatter.MAX_LINE_LENGTH)
+        assertFalse(line.contains('\n'))
+        assertTrue(line.contains("outcome=timeout"))
+        assertTrue(line.contains("missing=SERVICE_READY"))
+        assertTrue(line.indexOf("outcome=") < line.indexOf("timeline="))
+        assertTrue(line.indexOf("missing=") < line.indexOf("timeline="))
+    }
+
+    @Test
+    fun `lifecycle summary retains supplied elapsed realtime and joined inputs`() {
+        val tracker = WppStartupTracker { 32L }
+        tracker.startOrJoin(WppStartInput.START, elapsedMs = 100L)
+        tracker.startOrJoin(WppStartInput.PREWARM, elapsedMs = 120L)
+
+        val summary = tracker.timeout(elapsedMs = 300L)
+
+        assertEquals(100L, summary.startedAtMs)
+        assertEquals(300L, summary.endedAtMs)
+        assertEquals(setOf(WppStartInput.START, WppStartInput.PREWARM), summary.startInputs)
+    }
+}

--- a/tools/connection_check.py
+++ b/tools/connection_check.py
@@ -15,7 +15,7 @@ shows immediately whether a previously-good run would now fail.
 
 Usage
 -----
-    connection_check.py                 # check every car log
+    connection_check.py                 # check every car and companion log
     connection_check.py --since 08-08   # only logs from a date
     connection_check.py --verbose       # show every attempt, not just failures
     connection_check.py <file>...       # specific logs
@@ -31,6 +31,7 @@ import sys
 from dataclasses import dataclass, field
 
 CAR_LOG_GLOB = "/Docker/oal-logs/canonical/Blazer-Car/oal_*.log"
+PHONE_LOG_GLOB = "/Docker/oal-logs/canonical/*/oal_companion_*.log"
 
 # Dial-backs closer together than this belong to the same attempt.
 #
@@ -264,9 +265,168 @@ def parse_log(path: str) -> list[Attempt]:
 
 @dataclass
 class Finding:
-    severity: str      # "FAIL" | "WARN"
+    severity: str      # "FAIL" | "WARN" | "INFO"
     rule: str
     detail: str
+
+
+SUMMARY_FIELD_RE = re.compile(r"\b([A-Za-z][A-Za-z0-9]*)=([^\s]+)")
+SUMMARY_STAGE_RE = re.compile(r"(?:^|>)([A-Z_]+)@(\d+)")
+M_WAKE_SUMMARY = "WAKE SUMMARY "
+M_PHONE_WPP_SUMMARY = "PHONE WPP SUMMARY "
+M_FIRST_FRAME_RENDERED = "first frame rendered"
+
+
+def _stable_summaries(text: str, marker: str) -> list[dict[str, str]]:
+    """Parse the key=value contract that precedes each bounded summary timeline."""
+    summaries = []
+    for line in text.splitlines():
+        marker_at = line.find(marker)
+        if marker_at < 0:
+            continue
+        fixed, timeline_marker, timeline = line[marker_at:].partition(" timeline=")
+        fields = dict(SUMMARY_FIELD_RE.findall(fixed))
+        if timeline_marker:
+            fields["timeline"] = timeline
+        summaries.append(fields)
+    return summaries
+
+
+def _stage_times(summary: dict[str, str]) -> dict[str, list[int]]:
+    stages: dict[str, list[int]] = {}
+    for stage, elapsed in SUMMARY_STAGE_RE.findall(summary.get("timeline", "")):
+        stages.setdefault(stage, []).append(int(elapsed))
+    return stages
+
+
+def _elapsed_field(summary: dict[str, str], name: str) -> int | None:
+    value = summary.get(name, "-")
+    return int(value) if value.isdigit() else None
+
+
+def positive_cross_side_success(text: str) -> bool:
+    """True only for one ordered bridge -> session -> rendered-flow sequence.
+
+    Two positive vflow windows *after* the rendered-frame marker are the minimum
+    evidence that video continued rather than producing one seed frame and dying.
+    Requiring ordering also prevents unrelated attempts in an appended log from
+    donating one success marker each. Old logs are intentionally not failures;
+    they simply cannot prove this result.
+    """
+    bridge_seen = False
+    native_seen = False
+    rendered_seen = False
+    positive_vflow_windows = 0
+    for line in text.splitlines():
+        phone_summaries = _stable_summaries(line, M_PHONE_WPP_SUMMARY)
+        if "Bridge established" in line or any(
+            summary.get("outcome") == "connected"
+            or "BRIDGE_ESTABLISHED" in _stage_times(summary)
+            for summary in phone_summaries
+        ):
+            bridge_seen = True
+            native_seen = False
+            rendered_seen = False
+            positive_vflow_windows = 0
+            continue
+        if bridge_seen and M_SESSION_UP in line:
+            native_seen = True
+            rendered_seen = False
+            positive_vflow_windows = 0
+            continue
+        if native_seen and M_FIRST_FRAME_RENDERED in line.lower():
+            rendered_seen = True
+            positive_vflow_windows = 0
+            continue
+        if rendered_seen and "vflow:" in line:
+            match = re.search(r"\bframes=(\d+)", line)
+            if match and int(match.group(1)) > 0:
+                positive_vflow_windows += 1
+                if positive_vflow_windows >= 2:
+                    return True
+    return False
+
+
+def check_summary_text(text: str) -> list[Finding]:
+    """Check stable cross-side summary markers without penalising older builds."""
+    out: list[Finding] = []
+
+    for summary in _stable_summaries(text, M_WAKE_SUMMARY):
+        attempt = summary.get("attempt", "?")
+        if summary.get("gmSystemState") == "not_observed":
+            out.append(Finding(
+                "INFO", "gm-signal-unavailable",
+                f"wake attempt {attempt}: GM system-state signal was not_observed; "
+                "ignition and standard Android signals remain valid fallbacks",
+            ))
+
+        ap_ready = _elapsed_field(summary, "ap")
+        ignition = _elapsed_field(summary, "ignition")
+        if ap_ready is not None and ignition is not None and ap_ready < ignition:
+            out.append(Finding(
+                "INFO", "ap-ready-before-ignition",
+                f"wake attempt {attempt}: AP ready {ignition - ap_ready}ms before ignition",
+            ))
+
+        stages = _stage_times(summary)
+        sdp_times = stages.get("SDP_PUBLISHED", [])
+        session_ready = _elapsed_field(summary, "session")
+        if session_ready is None:
+            session_times = stages.get("SESSION_READY", [])
+            session_ready = min(session_times) if session_times else None
+        if sdp_times and (session_ready is None or min(sdp_times) < session_ready):
+            readiness = (
+                "never became ready"
+                if session_ready is None
+                else f"was ready at {session_ready}ms"
+            )
+            out.append(Finding(
+                "FAIL", "sdp-before-session-ready",
+                f"wake attempt {attempt}: SDP published at {min(sdp_times)}ms before "
+                f"the current native session {readiness}",
+            ))
+
+    for summary in _stable_summaries(text, M_PHONE_WPP_SUMMARY):
+        attempt = summary.get("attempt", "?")
+        stages = _stage_times(summary)
+        outcome = summary.get("outcome", "unknown")
+        missing = summary.get("missing", "unknown")
+        has_bt = "TARGET_BT_CONNECTED" in stages
+        # A connected outcome and missing=none are stable proof even if the bounded
+        # timeline was truncated before its later socket stages.
+        has_car_socket = (
+            "CAR_SOCKET" in stages or outcome == "connected" or missing == "none"
+        )
+        has_aa_socket = (
+            "AA_SOCKET" in stages or outcome == "connected" or missing == "none"
+        )
+        if has_bt and not has_car_socket:
+            out.append(Finding(
+                "FAIL", "phone-bt-no-car-socket",
+                f"phone WPP attempt {attempt}: selected-car BT was seen but no car "
+                f"socket arrived before terminal outcome={outcome}",
+            ))
+        if has_aa_socket and not has_car_socket:
+            out.append(Finding(
+                "INFO", "aa-socket-before-car-socket",
+                f"phone WPP attempt {attempt}: AA socket is waiting_for_car, not connected",
+            ))
+
+    if positive_cross_side_success(text):
+        out.append(Finding(
+            "INFO", "cross-side-success",
+            "bridge established, native AA session started, first frame rendered, "
+            "and video flow continued across multiple windows",
+        ))
+    return out
+
+
+def check_summary_markers(path: str) -> list[Finding]:
+    try:
+        with open(path, errors="ignore") as fh:
+            return check_summary_text(fh.read())
+    except OSError:
+        return []
 
 
 def check(a: Attempt) -> list[Finding]:
@@ -502,7 +662,7 @@ def main() -> int:
     ap.add_argument("--verbose", "-v", action="store_true", help="show passing attempts too")
     args = ap.parse_args()
 
-    paths = args.files or sorted(glob.glob(CAR_LOG_GLOB))
+    paths = args.files or sorted(glob.glob(CAR_LOG_GLOB) + glob.glob(PHONE_LOG_GLOB))
     if args.since:
         paths = [p for p in paths if args.since in os.path.basename(p)]
     if not paths:
@@ -512,15 +672,24 @@ def main() -> int:
     total = connected = 0
     fails: dict[str, int] = {}
     warns: dict[str, int] = {}
+    infos: dict[str, int] = {}
     reported: list[str] = []
 
     for path in paths:
-        log_attempts = parse_log(path)
-        for f in (check_transport_agnostic(path)
-                  + check_silent_advertiser(path)
-                  + check_log_level(log_attempts)):
-            (fails if f.severity == "FAIL" else warns)[f.rule] = \
-                (fails if f.severity == "FAIL" else warns).get(f.rule, 0) + 1
+        is_car_log = not os.path.basename(path).startswith("oal_companion_")
+        log_attempts = parse_log(path) if is_car_log else []
+        old_findings = (
+            check_transport_agnostic(path)
+            + check_silent_advertiser(path)
+            + check_log_level(log_attempts)
+        ) if is_car_log else []
+        for f in old_findings + check_summary_markers(path):
+            bucket = (
+                fails if f.severity == "FAIL"
+                else warns if f.severity == "WARN"
+                else infos
+            )
+            bucket[f.rule] = bucket.get(f.rule, 0) + 1
             reported.append(f"{os.path.basename(path)}  (whole log)")
             reported.append(f"    {f.severity}  {f.rule}: {f.detail}")
         for a in log_attempts:
@@ -550,6 +719,8 @@ def main() -> int:
         print("failures:", ", ".join(f"{k}={v}" for k, v in sorted(fails.items())))
     if warns:
         print("warnings:", ", ".join(f"{k}={v}" for k, v in sorted(warns.items())))
+    if infos:
+        print("info:", ", ".join(f"{k}={v}" for k, v in sorted(infos.items())))
 
     # Non-zero exit when anything failed, so this can gate a change.
     return 1 if fails else 0

--- a/tools/test_connection_check.py
+++ b/tools/test_connection_check.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Focused synthetic tests for the connection checker's stable summary rules."""
+
+import unittest
+
+from tools.connection_check import check_summary_text, positive_cross_side_success
+
+
+class StableSummaryRulesTest(unittest.TestCase):
+    def test_unobserved_gm_signal_is_info_only(self):
+        text = (
+            "12:00:01.000 I/wake: WAKE SUMMARY attempt=7 trigger=IGNITION_ON "
+            "gm=- bt=50 ap=100 apEdge=100 ignition=200 activity=300 session=400 "
+            "surface=500 gmSystemState=not_observed gmPowerMode=not_observed "
+            "gmPoweroffView=not_observed gmHomeStarted=not_observed "
+            "outcome=surface_ready missing=none "
+            "timeline=AP_PRESENT@100>IGNITION_ON@200>SESSION_READY@400>"
+            "SDP_PUBLISHED@450>SURFACE_READY@500\n"
+        )
+
+        findings = check_summary_text(text)
+        gm = [finding for finding in findings if finding.rule == "gm-signal-unavailable"]
+
+        self.assertEqual(1, len(gm))
+        self.assertEqual("INFO", gm[0].severity)
+        self.assertFalse(any(finding.severity == "FAIL" for finding in gm))
+
+    def test_ap_ready_before_ignition_reports_timing(self):
+        text = (
+            "12:00:01.000 I/wake: WAKE SUMMARY attempt=8 trigger=IGNITION_ON "
+            "gm=- bt=50 ap=120 apEdge=- ignition=275 activity=300 session=400 "
+            "surface=500 gmSystemState=observed outcome=surface_ready missing=none "
+            "timeline=AP_PRESENT@120>IGNITION_ON@275>SESSION_READY@400>"
+            "SDP_PUBLISHED@450>SURFACE_READY@500\n"
+        )
+
+        findings = check_summary_text(text)
+        timing = [finding for finding in findings if finding.rule == "ap-ready-before-ignition"]
+
+        self.assertEqual(1, len(timing))
+        self.assertEqual("INFO", timing[0].severity)
+        self.assertIn("155ms", timing[0].detail)
+
+    def test_sdp_before_session_ready_is_failure(self):
+        text = (
+            "12:00:01.000 I/wake: WAKE SUMMARY attempt=9 trigger=IGNITION_ON "
+            "gm=- bt=50 ap=120 apEdge=- ignition=275 activity=300 session=400 "
+            "surface=500 gmSystemState=observed outcome=surface_ready missing=none "
+            "timeline=AP_PRESENT@120>IGNITION_ON@275>SDP_PUBLISHED@350>"
+            "SESSION_READY@400>SURFACE_READY@500\n"
+        )
+
+        failures = [
+            finding for finding in check_summary_text(text)
+            if finding.rule == "sdp-before-session-ready"
+        ]
+
+        self.assertEqual(1, len(failures))
+        self.assertEqual("FAIL", failures[0].severity)
+
+    def test_phone_bt_without_car_socket_is_bounded_to_one_summary_finding(self):
+        text = (
+            "12:00:01.000 I/Wpp: PHONE WPP EVENT attempt=3 "
+            "stage=TARGET_BT_CONNECTED elapsed=10\n"
+            "12:00:01.100 I/Wpp: PHONE WPP EVENT attempt=3 "
+            "stage=TARGET_BT_CONNECTED elapsed=20\n"
+            "12:00:31.000 I/Wpp: PHONE WPP SUMMARY attempt=3 outcome=timeout "
+            "missing=CAR_SOCKET timeline=TARGET_BT_CONNECTED@10>AA_SOCKET@50\n"
+        )
+
+        findings = check_summary_text(text)
+        bounded = [finding for finding in findings if finding.rule == "phone-bt-no-car-socket"]
+
+        self.assertEqual(1, len(bounded))
+        self.assertEqual("FAIL", bounded[0].severity)
+
+    def test_aa_socket_before_car_socket_is_waiting_not_connected(self):
+        text = (
+            "12:00:31.000 I/Wpp: PHONE WPP SUMMARY attempt=4 "
+            "outcome=waiting_for_car missing=CAR_SOCKET "
+            "timeline=TARGET_BT_CONNECTED@10>AA_SOCKET@50\n"
+        )
+
+        findings = check_summary_text(text)
+        waiting = [
+            finding for finding in findings
+            if finding.rule == "aa-socket-before-car-socket"
+        ]
+
+        self.assertEqual(1, len(waiting))
+        self.assertEqual("INFO", waiting[0].severity)
+        self.assertIn("waiting_for_car", waiting[0].detail)
+        self.assertFalse(positive_cross_side_success(text))
+
+    def test_positive_success_requires_every_end_to_end_signal(self):
+        parts = {
+            "bridge": (
+                "12:00:01.000 I/Wpp: PHONE WPP SUMMARY attempt=5 outcome=connected "
+                "missing=none timeline=TARGET_BT_CONNECTED@10>CAR_SOCKET@20>"
+                "AA_SOCKET@30>BRIDGE_ESTABLISHED@40\n"
+            ),
+            "native": "12:00:02.000 I/AasdkSession: AA session started (native)\n",
+            "render": "12:00:03.000 I/video: First frame rendered in 1200ms\n",
+            "vflow": (
+                "12:00:05.000 I/vflow: frames=42 idr=1 bytes=10000 window=2000ms\n"
+                "12:00:07.000 I/vflow: frames=41 idr=0 bytes=9000 window=2000ms\n"
+            ),
+        }
+        complete = "".join(parts.values())
+
+        self.assertTrue(positive_cross_side_success(complete))
+        for missing in parts:
+            with self.subTest(missing=missing):
+                incomplete = "".join(value for key, value in parts.items() if key != missing)
+                self.assertFalse(positive_cross_side_success(incomplete))
+
+    def test_old_logs_without_summary_markers_are_not_flagged_for_instrumentation(self):
+        old_text = (
+            "11:22:33.000 I/AaWirelessBt: Handshake complete\n"
+            "11:22:34.000 I/AasdkSession: AA session started (native)\n"
+        )
+
+        self.assertEqual([], check_summary_text(old_text))
+        self.assertFalse(positive_cross_side_success(old_text))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Slim Stage A logging/evidence build only.

- adds process-scope car wake timeline and bounded WAKE SUMMARY
- adds passive companion WPP startup timeline and PHONE WPP SUMMARY
- adds backward-compatible checker rules for cross-side sequencing
- does not implement startup coordination, change SDP timing, request networks, or change AA launch behavior
- vehicle-profile persistence and stale-callback lifecycle work were intentionally removed from this first evidence build

## Verification

- car + companion unit tests and Kotlin compiles: 292/292 tests passed across 33 suites
- checker synthetic tests passed
- full historical archive retained existing findings with no missing-instrumentation failures
- compiled marker checks performed for WAKE SUMMARY and PHONE WPP SUMMARY

This is a logging build for evidence collection; it makes no claim of faster startup yet.