### PR TITLE
fix(wake): preserve successful wake summaries across shutdown

### DIFF
--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -1424,7 +1424,7 @@ class SessionManager(
             { ip -> if (ip.isNotBlank()) session.dialCompanion(ip) }
         // The new session is now current and its live companion callback is
         // installed. Report readiness only at this truthful lifecycle point.
-        com.openautolink.app.wake.PreWakeMonitor.reportSessionReady()
+        com.openautolink.app.wake.PreWakeMonitor.reportSessionReady("callback-installed")
         // Answer the phone's SensorStartRequest with current vehicle state.
         // Without this, a parked car never sends driving status and the phone
         // stays FULLY_RESTRICTED (no Maps keyboard). Issue #61.

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -600,6 +600,7 @@ class AasdkSession(
         // session actually came up, which is what a log reader needs to see.
         OalLog.i(TAG, "CONNECT SUMMARY: result=session started — " +
                 "video should follow within a few seconds")
+        com.openautolink.app.wake.PreWakeMonitor.reportSessionReady("native-session-started")
         // Cancel any pending auto-reconnect timer: this session is now healthy,
         // so a leftover retry from an earlier teardown must NOT fire and restart
         // the transport underneath us (the deep-sleep reconnect-storm root cause).

--- a/app/src/main/java/com/openautolink/app/wake/BoundedObservationDispatcher.kt
+++ b/app/src/main/java/com/openautolink/app/wake/BoundedObservationDispatcher.kt
@@ -1,0 +1,102 @@
+package com.openautolink.app.wake
+
+import java.util.ArrayDeque
+
+/**
+ * Moves observations from latency-sensitive callers to one deferred worker drain.
+ *
+ * [schedule] must defer the supplied drain runnable. [offer] only mutates the bounded in-memory
+ * queue and requests a drain; observation callbacks are invoked exclusively by that drain.
+ */
+class BoundedObservationDispatcher<T>(
+    private val capacity: Int,
+    private val schedule: (() -> Unit) -> Unit,
+    private val consume: (T) -> Unit,
+    private val onDropped: (Int) -> Unit,
+    private val onFailure: (Throwable) -> Unit,
+) {
+    private val lock = Any()
+    private val queue = ArrayDeque<T>(capacity)
+    private var drainScheduled = false
+    private var droppedCount = 0
+
+    init {
+        require(capacity > 0) { "capacity must be positive" }
+    }
+
+    fun offer(observation: T): Boolean {
+        var shouldSchedule = false
+        val accepted = synchronized(lock) {
+            if (queue.size >= capacity) {
+                droppedCount += 1
+                false
+            } else {
+                queue.addLast(observation)
+                if (!drainScheduled) {
+                    drainScheduled = true
+                    shouldSchedule = true
+                }
+                true
+            }
+        }
+        if (shouldSchedule) {
+            try {
+                schedule(::drain)
+            } catch (_: Throwable) {
+                synchronized(lock) {
+                    droppedCount += queue.size
+                    queue.clear()
+                    drainScheduled = false
+                }
+                return false
+            }
+        }
+        return accepted
+    }
+
+    private fun drain() {
+        while (true) {
+            val work = synchronized(lock) {
+                when {
+                    queue.isNotEmpty() -> DrainWork.Observation(queue.removeFirst())
+                    droppedCount > 0 -> DrainWork.Dropped(droppedCount.also { droppedCount = 0 })
+                    else -> {
+                        drainScheduled = false
+                        null
+                    }
+                }
+            } ?: return
+
+            when (work) {
+                is DrainWork.Observation -> {
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        consume(work.value as T)
+                    } catch (error: Throwable) {
+                        notifyFailure(error)
+                    }
+                }
+                is DrainWork.Dropped -> {
+                    try {
+                        onDropped(work.count)
+                    } catch (error: Throwable) {
+                        notifyFailure(error)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun notifyFailure(error: Throwable) {
+        try {
+            onFailure(error)
+        } catch (_: Throwable) {
+            // Diagnostics must never strand the drain or block later observations.
+        }
+    }
+
+    private sealed interface DrainWork {
+        data class Observation(val value: Any?) : DrainWork
+        data class Dropped(val count: Int) : DrainWork
+    }
+}

--- a/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
+++ b/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
@@ -60,6 +60,29 @@ object PreWakeMonitor {
         },
         emit = { summary, outcome -> emitSummary(summary, outcome.name.lowercase()) },
     )
+    private val sessionReadinessDispatcher = BoundedObservationDispatcher<SessionReadinessObservation>(
+        capacity = 8,
+        schedule = { drain -> scope.launch { drain() } },
+        consume = { observation ->
+            record(
+                policy.sessionReady(observation.source, observation.elapsedMs),
+                candidateSource = false,
+            )
+        },
+        onDropped = { count ->
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT session readiness outcome=dropped count=$count",
+            )
+        },
+        onFailure = { error ->
+            DiagnosticLog.w(
+                TAG,
+                "WAKE EVENT session readiness outcome=record-failed " +
+                    "error=${safe(error.javaClass.simpleName)}",
+            )
+        },
+    )
 
     private var nextAttemptId = 1L
     private var initialized = false
@@ -192,8 +215,13 @@ object PreWakeMonitor {
         record(policy.activity(callback, SystemClock.elapsedRealtime()), candidateSource = true)
     }
 
-    fun reportSessionReady() {
-        record(policy.sessionReady(SystemClock.elapsedRealtime()), candidateSource = false)
+    fun reportSessionReady(source: String) {
+        val elapsedMs = SystemClock.elapsedRealtime()
+        val observation = SessionReadinessObservation(
+            source = safe(source),
+            elapsedMs = elapsedMs,
+        )
+        sessionReadinessDispatcher.offer(observation)
     }
 
     fun reportSurfaceReady(width: Int, height: Int) {
@@ -563,6 +591,11 @@ object PreWakeMonitor {
     private fun safe(value: String): String = value
         .replace(Regex("[\\p{Cc}>(),=]"), "_")
         .take(96)
+
+    private data class SessionReadinessObservation(
+        val source: String,
+        val elapsedMs: Long,
+    )
 
     private data class ApSnapshot(val ip: String?, val error: String?)
 

--- a/app/src/main/java/com/openautolink/app/wake/PreWakeSignalPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/wake/PreWakeSignalPolicy.kt
@@ -150,12 +150,15 @@ class PreWakeSignalPolicy {
         )
     }
 
-    fun sessionReady(elapsedMs: Long): PreWakePolicyDecision = decision(
-        kind = PreWakeObservationKind.SESSION,
-        detail = "ready=true",
-        event = WakeEvent(WakeSignal.SESSION_READY, elapsedMs),
-        impliesSessionReadiness = true,
-    )
+    fun sessionReady(source: String, elapsedMs: Long): PreWakePolicyDecision {
+        val detail = "ready=true,source=${safeField(source)}"
+        return decision(
+            kind = PreWakeObservationKind.SESSION,
+            detail = detail,
+            event = WakeEvent(WakeSignal.SESSION_READY, elapsedMs, detail),
+            impliesSessionReadiness = true,
+        )
+    }
 
     fun surfaceReady(width: Int, height: Int, elapsedMs: Long): PreWakePolicyDecision = decision(
         kind = PreWakeObservationKind.SURFACE,

--- a/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
+++ b/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
@@ -109,7 +109,9 @@ class WakeAttemptReducer(
 
     private fun Attempt.shouldRollOverFor(event: WakeEvent): Boolean {
         val lastIgnitionOff = lastIgnitionOffMs() ?: return false
-        return event.elapsedMs > lastIgnitionOff && event.signal in ATTEMPT_START_SIGNALS
+        return event.elapsedMs > lastIgnitionOff &&
+            event.signal in ATTEMPT_START_SIGNALS &&
+            (event.signal != WakeSignal.GM_SYSTEM_STATE || event.detail in OBSERVATIONAL_GM_DETAILS)
     }
 
     private fun Attempt.lastIgnitionOffMs(): Long? = events

--- a/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
+++ b/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
@@ -39,6 +39,7 @@ data class WakeSummary(
     val ignitionOnAtMs: Long?,
     val activityStartedAtMs: Long?,
     val sessionReadyAtMs: Long?,
+    val sessionReadySource: String?,
     val surfaceReadyAtMs: Long?,
     val apAbsentToPresentAtMs: Long?,
     val timeline: List<WakeEvent>,
@@ -165,6 +166,7 @@ class WakeAttemptReducer(
             ignitionOnAtMs = timeline.firstTime(WakeSignal.IGNITION_ON),
             activityStartedAtMs = timeline.firstTime(WakeSignal.ACTIVITY_START),
             sessionReadyAtMs = timeline.firstTime(WakeSignal.SESSION_READY),
+            sessionReadySource = timeline.firstSource(WakeSignal.SESSION_READY),
             surfaceReadyAtMs = timeline.firstTime(WakeSignal.SURFACE_READY),
             apAbsentToPresentAtMs = apEdgeAtMs,
             timeline = timeline,
@@ -201,6 +203,14 @@ class WakeAttemptReducer(
 
     private fun List<WakeEvent>.firstDetail(signal: WakeSignal): String? =
         firstOrNull { it.signal == signal }?.detail?.takeIf { it.isNotBlank() }
+
+    private fun List<WakeEvent>.firstSource(signal: WakeSignal): String? =
+        firstOrNull { it.signal == signal }
+            ?.detail
+            ?.split(',')
+            ?.firstOrNull { it.startsWith("source=") }
+            ?.substringAfter("source=")
+            ?.takeIf { it.isNotBlank() }
 
     companion object {
         const val MAX_TIMELINE_EVENTS = 64
@@ -277,6 +287,7 @@ object WakeSummaryFormatter {
             append(" ignition=").append(summary.ignitionOnAtMs.stageField(compact))
             append(" activity=").append(summary.activityStartedAtMs.stageField(compact))
             append(" session=").append(summary.sessionReadyAtMs.stageField(compact))
+            append(" sessionSource=").append(summary.sessionReadySource.asField())
             append(" surface=").append(summary.surfaceReadyAtMs.stageField(compact))
         }
 

--- a/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
@@ -61,6 +61,69 @@ class AttemptSummarySchedulerTest {
         assertEquals(listOf(30L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
     }
 
+    @Test
+    fun `real reducer retains first readiness source and scheduler emits once per attempt`() {
+        var nextId = 40L
+        val reducer = WakeAttemptReducer { nextId++ }
+        val harness = Harness()
+
+        fun record(event: WakeEvent): WakeSummary {
+            val current = reducer.record(event)
+            harness.scheduler.observe(current, reducer.previousSummary)
+            if (current.sessionReadyAtMs != null && current.surfaceReadyAtMs != null) {
+                harness.scheduler.ready(current)
+            }
+            return current
+        }
+
+        record(
+            WakeEvent(
+                WakeSignal.SESSION_READY,
+                elapsedMs = 100L,
+                detail = "ready=true,source=callback-installed",
+            )
+        )
+        val staleFirstTimeout = harness.callback(40L)
+        record(WakeEvent(WakeSignal.SURFACE_READY, elapsedMs = 110L))
+        record(
+            WakeEvent(
+                WakeSignal.SESSION_READY,
+                elapsedMs = 120L,
+                detail = "ready=true,source=native-session-started",
+            )
+        )
+        staleFirstTimeout()
+
+        assertEquals(listOf(40L to AttemptSummaryOutcome.READY), harness.emitted)
+        assertEquals("callback-installed", harness.emittedSummaries.single().sessionReadySource)
+        assertTrue(harness.cancelled.getValue(40L))
+
+        record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        record(
+            WakeEvent(
+                WakeSignal.SESSION_READY,
+                elapsedMs = 300L,
+                detail = "ready=true,source=native-session-started",
+            )
+        )
+        val staleReconnectTimeout = harness.callback(41L)
+        record(WakeEvent(WakeSignal.SURFACE_READY, elapsedMs = 310L))
+        staleReconnectTimeout()
+
+        assertEquals(
+            listOf(
+                40L to AttemptSummaryOutcome.READY,
+                41L to AttemptSummaryOutcome.READY,
+            ),
+            harness.emitted,
+        )
+        assertEquals(
+            listOf("callback-installed", "native-session-started"),
+            harness.emittedSummaries.map { it.sessionReadySource },
+        )
+        assertEquals(0, harness.scheduler.activeTimeoutCount)
+    }
+
     private class Harness {
         val callbacks = mutableMapOf<Long, () -> Unit>()
         val cancelled = mutableMapOf<Long, Boolean>()
@@ -94,6 +157,7 @@ class AttemptSummarySchedulerTest {
         ignitionOnAtMs = null,
         activityStartedAtMs = null,
         sessionReadyAtMs = null,
+        sessionReadySource = null,
         surfaceReadyAtMs = null,
         apAbsentToPresentAtMs = null,
         timeline = listOf(WakeEvent(trigger, attemptId)),

--- a/app/src/test/java/com/openautolink/app/wake/BoundedObservationDispatcherTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/BoundedObservationDispatcherTest.kt
@@ -1,0 +1,148 @@
+package com.openautolink.app.wake
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BoundedObservationDispatcherTest {
+
+    @Test
+    fun `schedule rejection abandons queued work without callbacks and later offer rearms drain`() {
+        val scheduled = mutableListOf<() -> Unit>()
+        val consumed = mutableListOf<String>()
+        val dropped = mutableListOf<Int>()
+        val failures = mutableListOf<Throwable>()
+        var rejectNextSchedule = true
+        val dispatcher = BoundedObservationDispatcher<String>(
+            capacity = 2,
+            schedule = { drain ->
+                if (rejectNextSchedule) {
+                    rejectNextSchedule = false
+                    throw IllegalStateException("schedule rejected")
+                }
+                scheduled += drain
+            },
+            consume = { item -> consumed += item },
+            onDropped = { count -> dropped += count },
+            onFailure = { error -> failures += error },
+        )
+
+        assertFalse(dispatcher.offer("abandoned"))
+        assertTrue(scheduled.isEmpty())
+        assertTrue(consumed.isEmpty())
+        assertTrue(dropped.isEmpty())
+        assertTrue(failures.isEmpty())
+
+        assertTrue(dispatcher.offer("second"))
+        assertEquals(1, scheduled.size)
+        assertTrue(consumed.isEmpty())
+        assertTrue(dropped.isEmpty())
+        assertTrue(failures.isEmpty())
+
+        scheduled.single().invoke()
+
+        assertEquals(listOf("second"), consumed)
+        assertEquals(listOf(1), dropped)
+        assertTrue(failures.isEmpty())
+    }
+
+    @Test
+    fun `full queue rejects immediately and reports one drop only from deferred drain`() {
+        val scheduled = mutableListOf<() -> Unit>()
+        val consumed = mutableListOf<String>()
+        val dropped = mutableListOf<Int>()
+        val dispatcher = BoundedObservationDispatcher<String>(
+            capacity = 1,
+            schedule = { drain -> scheduled += drain },
+            consume = { item -> consumed += item },
+            onDropped = { count -> dropped += count },
+            onFailure = { error -> throw AssertionError("Unexpected failure", error) },
+        )
+
+        assertTrue(dispatcher.offer("first"))
+        assertEquals(1, scheduled.size)
+        assertFalse(dispatcher.offer("second"))
+        assertEquals(1, scheduled.size)
+        assertTrue(consumed.isEmpty())
+        assertTrue(dropped.isEmpty())
+
+        scheduled.single().invoke()
+
+        assertEquals(listOf("first"), consumed)
+        assertEquals(listOf(1), dropped)
+    }
+
+    @Test
+    fun `multiple accepted offers schedule one drain and preserve order`() {
+        val scheduled = mutableListOf<() -> Unit>()
+        val consumed = mutableListOf<Int>()
+        val dispatcher = BoundedObservationDispatcher<Int>(
+            capacity = 3,
+            schedule = { drain -> scheduled += drain },
+            consume = { item -> consumed += item },
+            onDropped = { count -> throw AssertionError("Unexpected $count dropped") },
+            onFailure = { error -> throw AssertionError("Unexpected failure", error) },
+        )
+
+        assertTrue(dispatcher.offer(1))
+        assertTrue(dispatcher.offer(2))
+        assertTrue(dispatcher.offer(3))
+        assertEquals(1, scheduled.size)
+        assertTrue(consumed.isEmpty())
+
+        scheduled.single().invoke()
+
+        assertEquals(listOf(1, 2, 3), consumed)
+    }
+
+    @Test
+    fun `consumer failure is reported from drain and later items are still consumed`() {
+        val scheduled = mutableListOf<() -> Unit>()
+        val consumed = mutableListOf<String>()
+        val failures = mutableListOf<Throwable>()
+        val dispatcher = BoundedObservationDispatcher<String>(
+            capacity = 2,
+            schedule = { drain -> scheduled += drain },
+            consume = { item ->
+                if (item == "bad") error("consume failed")
+                consumed += item
+            },
+            onDropped = { count -> throw AssertionError("Unexpected $count dropped") },
+            onFailure = { error -> failures += error },
+        )
+
+        assertTrue(dispatcher.offer("bad"))
+        assertTrue(dispatcher.offer("good"))
+        assertTrue(consumed.isEmpty())
+        assertTrue(failures.isEmpty())
+
+        scheduled.single().invoke()
+
+        assertEquals(listOf("good"), consumed)
+        assertEquals(listOf("consume failed"), failures.map(Throwable::message))
+    }
+
+    @Test
+    fun `offer after an empty drain schedules a new drain`() {
+        val scheduled = mutableListOf<() -> Unit>()
+        val consumed = mutableListOf<String>()
+        val dispatcher = BoundedObservationDispatcher<String>(
+            capacity = 1,
+            schedule = { drain -> scheduled += drain },
+            consume = { item -> consumed += item },
+            onDropped = { count -> throw AssertionError("Unexpected $count dropped") },
+            onFailure = { error -> throw AssertionError("Unexpected failure", error) },
+        )
+
+        assertTrue(dispatcher.offer("first"))
+        scheduled.single().invoke()
+        assertEquals(listOf("first"), consumed)
+
+        assertTrue(dispatcher.offer("second"))
+        assertEquals(2, scheduled.size)
+        scheduled.last().invoke()
+
+        assertEquals(listOf("first", "second"), consumed)
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/PreWakeSignalPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/PreWakeSignalPolicyTest.kt
@@ -66,6 +66,19 @@ class PreWakeSignalPolicyTest {
     }
 
     @Test
+    fun `session readiness source is sanitized into observation and event atomically`() {
+        val decision = policy.sessionReady(
+            source = "native session,start",
+            elapsedMs = 250L,
+        )
+
+        assertEquals("ready=true,source=native_session_start", decision.observation.detail)
+        assertEquals("ready=true,source=native_session_start", decision.event?.detail)
+        assertTrue(decision.impliesSessionReadiness)
+        assertFalse(decision.authorizesBehavior)
+    }
+
+    @Test
     fun `configured AP observation records only interface and local IP`() {
         val decision = policy.accessPoint(
             interfaceName = "ap_br_swlan0",

--- a/app/src/test/java/com/openautolink/app/wake/SessionReadinessInstrumentationTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/SessionReadinessInstrumentationTest.kt
@@ -1,0 +1,134 @@
+package com.openautolink.app.wake
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionReadinessInstrumentationTest {
+
+    @Test
+    fun `readiness is reported only after native success while reconnect setup is retained`() {
+        val managerSource = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+        val nativeStart = managerSource.indexOf("session.onNativeSessionStarting = {")
+        val nativeEnd = managerSource.indexOf(
+            "AaWirelessBtControl.sessionIsStreaming",
+            startIndex = nativeStart,
+        )
+
+        assertTrue("Native session start hook must exist", nativeStart >= 0)
+        assertTrue("Native session start block must have a boundary", nativeEnd > nativeStart)
+
+        val nativeStartBlock = managerSource.substring(nativeStart, nativeEnd)
+        assertTrue(
+            "Native start must still bind session collectors",
+            nativeStartBlock.contains("bindSessionCollectors(session)"),
+        )
+        assertTrue(
+            "Native start must still re-adopt the session",
+            nativeStartBlock.contains("aasdkSession = session"),
+        )
+        assertEquals(
+            "Pre-native setup must never report session readiness",
+            0,
+            Regex("""PreWakeMonitor\.reportSessionReady\(""")
+                .findAll(nativeStartBlock)
+                .count(),
+        )
+        assertTrue(
+            "Initial setup must retain exact callback-installed readiness",
+            managerSource.contains(
+                "PreWakeMonitor.reportSessionReady(\"callback-installed\")",
+            ),
+        )
+
+        val sessionSource = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val started = sessionSource.indexOf("override fun onSessionStarted()")
+        val stopped = sessionSource.indexOf("override fun onSessionStopped", startIndex = started)
+        assertTrue("Native onSessionStarted callback must exist", started >= 0)
+        assertTrue("Native callback block must have a boundary", stopped > started)
+
+        val startedBlock = sessionSource.substring(started, stopped)
+        val nativeStartedLog = startedBlock.indexOf("AA session started (native)")
+        val connectSummary = startedBlock.indexOf("CONNECT SUMMARY")
+        val reportReady = startedBlock.indexOf(
+            "PreWakeMonitor.reportSessionReady(\"native-session-started\")",
+        )
+        assertTrue("Native success log must remain", nativeStartedLog >= 0)
+        assertTrue("CONNECT SUMMARY must remain", connectSummary >= 0)
+        assertTrue("Native success callback must report exact readiness source", reportReady >= 0)
+        assertTrue(
+            "Native readiness must follow the actual native-start success log",
+            reportReady > nativeStartedLog,
+        )
+        assertTrue(
+            "Native readiness must follow CONNECT SUMMARY",
+            reportReady > connectSummary,
+        )
+
+        val productionSources = managerSource + sessionSource
+        assertEquals(
+            "Production must have exactly the initial and native-success readiness calls",
+            2,
+            Regex("""PreWakeMonitor\.reportSessionReady\(""")
+                .findAll(productionSources)
+                .count(),
+        )
+        assertEquals(
+            "Every readiness call site must provide an explicit source",
+            0,
+            Regex("""PreWakeMonitor\.reportSessionReady\(\)""")
+                .findAll(productionSources)
+                .count(),
+        )
+    }
+
+    @Test
+    fun `session readiness callback only timestamps sanitizes and enqueues observation`() {
+        val monitorSource = projectFile(
+            "app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt",
+        ).readText()
+        val functionStart = monitorSource.indexOf("fun reportSessionReady(source: String) {")
+        val functionEnd = monitorSource.indexOf("fun reportSurfaceReady", startIndex = functionStart)
+
+        assertTrue("Session readiness hook must exist", functionStart >= 0)
+        assertTrue("Session readiness hook must have a boundary", functionEnd > functionStart)
+
+        val functionBody = monitorSource.substring(functionStart, functionEnd)
+        val timestamp = functionBody.indexOf("val elapsedMs = SystemClock.elapsedRealtime()")
+        val offer = functionBody.indexOf("sessionReadinessDispatcher.offer(")
+        assertTrue("Readiness hook must capture monotonic elapsed time", timestamp >= 0)
+        assertTrue("Readiness hook must offer to the bounded dispatcher", offer >= 0)
+        assertTrue("Readiness timestamp must be captured before enqueue", timestamp < offer)
+        assertTrue("Readiness source must be sanitized before enqueue", functionBody.contains("safe(source)"))
+        assertEquals(
+            "Readiness hook must not call the reducer directly",
+            0,
+            Regex("""\brecord\(""").findAll(functionBody).count(),
+        )
+        assertEquals(
+            "Readiness hook must not log synchronously",
+            0,
+            Regex("""DiagnosticLog""").findAll(functionBody).count(),
+        )
+        assertEquals(
+            "Readiness hook must not perform file operations",
+            0,
+            Regex("""FileLogWriter|java\.io\.File|\bFile\(|\.write(?:Text|Bytes)?\(|\.append(?:Text)?\(|\.flush\(""")
+                .findAll(functionBody)
+                .count(),
+        )
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
@@ -168,6 +168,46 @@ class WakeAttemptReducerTest {
     }
 
     @Test
+    fun `session readiness source survives timeline compaction and diagnostic truncation`() {
+        val reducer = WakeAttemptReducer { 103L }
+        reducer.record(
+            WakeEvent(
+                WakeSignal.SESSION_READY,
+                elapsedMs = 100L,
+                detail = "ready=true,source=native-session-started",
+            )
+        )
+        repeat(500) { index ->
+            reducer.record(
+                WakeEvent(
+                    WakeSignal.GM_SYSTEM_STATE,
+                    elapsedMs = 200L + index,
+                    detail = "raw=$index,name=${"X".repeat(140)}",
+                )
+            )
+        }
+
+        val summary = reducer.currentSummary!!
+        val line = WakeSummaryFormatter.formatForDiagnosticLog(
+            summary = summary,
+            gmEvidenceFields =
+                "gmSystemState=observed gmPowerMode=not_observed " +
+                    "gmPoweroffView=not_observed gmHomeStarted=not_observed",
+            outcome = "ready",
+            missing = "surface",
+        )
+        val stored = fitLocalDiagnosticMessage(line)
+
+        assertEquals("native-session-started", summary.sessionReadySource)
+        assertTrue(summary.timeline.any { it.detail.contains("source=native-session-started") })
+        assertTrue(line.length <= WakeSummaryFormatter.MAX_DIAGNOSTIC_LINE_LENGTH)
+        assertEquals(line, stored)
+        assertTrue(stored.contains("sessionSource=native-session-started"))
+        assertTrue(stored.indexOf("sessionSource=") < stored.indexOf("timeline="))
+        assertTrue("Expected timeline truncation marker", stored.endsWith("~"))
+    }
+
+    @Test
     fun `AP absent after shutdown rolls into the next wake attempt`() {
         var nextId = 200L
         val reducer = WakeAttemptReducer { nextId++ }
@@ -350,7 +390,7 @@ class WakeAttemptReducerTest {
 
         assertEquals(
             "WAKE SUMMARY attempt=9 trigger=IGNITION_ON gm=- bt=- ap=120 " +
-                "apEdge=- ignition=200 activity=- session=- surface=- " +
+                "apEdge=- ignition=200 activity=- session=- sessionSource=- surface=- " +
                 "timeline=AP_PRESENT@120>IGNITION_ON@200",
             line
         )
@@ -369,6 +409,7 @@ class WakeAttemptReducerTest {
             ignitionOnAtMs = 40L,
             activityStartedAtMs = 50L,
             sessionReadyAtMs = 60L,
+            sessionReadySource = "native-session-started",
             surfaceReadyAtMs = 70L,
             apAbsentToPresentAtMs = 30L,
             timeline = List(WakeAttemptReducer.MAX_TIMELINE_EVENTS) { index ->

--- a/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
@@ -88,6 +88,56 @@ class WakeAttemptReducerTest {
     }
 
     @Test
+    fun `GM HMI inactive after shutdown waits for a true GM wake state`() {
+        var nextId = 500L
+        val reducer = WakeAttemptReducer { nextId++ }
+
+        reducer.record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 100L))
+        reducer.record(WakeEvent(WakeSignal.SESSION_READY, elapsedMs = 150L))
+        reducer.record(WakeEvent(WakeSignal.SURFACE_READY, elapsedMs = 160L))
+        reducer.record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 200L))
+        val inactive = reducer.record(
+            WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs = 210L,
+                detail = "raw=3,name=HMI_INACTIVE",
+            )
+        )
+        reducer.record(WakeEvent(WakeSignal.AP_ABSENT, elapsedMs = 220L))
+        reducer.record(WakeEvent(WakeSignal.BLUETOOTH_OFF, elapsedMs = 230L))
+
+        assertEquals(500L, inactive.attemptId)
+        assertEquals(500L, reducer.currentSummary!!.attemptId)
+        assertEquals(501L, nextId)
+
+        val wake = reducer.record(
+            WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs = 1_000L,
+                detail = "raw=1,name=ANIMATION_INIT",
+            )
+        )
+
+        assertEquals(501L, wake.attemptId)
+        assertEquals(502L, nextId)
+        assertEquals(WakeSignal.GM_SYSTEM_STATE, wake.trigger)
+        assertEquals(
+            listOf(
+                WakeSignal.GM_SYSTEM_STATE,
+                WakeSignal.AP_ABSENT,
+                WakeSignal.BLUETOOTH_OFF,
+                WakeSignal.GM_SYSTEM_STATE,
+            ),
+            wake.timeline.map { it.signal }
+        )
+        assertEquals(listOf(210L, 220L, 230L, 1_000L), wake.timeline.map { it.elapsedMs })
+        assertTrue(reducer.previousSummary!!.timeline.all { it.elapsedMs <= 200L })
+        assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.AP_ABSENT })
+        assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.BLUETOOTH_OFF })
+        assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.GM_SYSTEM_STATE })
+    }
+
+    @Test
     fun `timeline ordering uses elapsed realtime instead of input order`() {
         val reducer = WakeAttemptReducer { 101L }
 


### PR DESCRIPTION
## Evidence-gate logging correction

The 0.1.435 in-vehicle capture collected the raw Stage A signals but exposed two car-side instrumentation defects:

1. Shutdown `HMI_INACTIVE` prematurely rolled to the next attempt. Its 15-second timeout completed before the later wake, so successful wake events never produced a ready `WAKE SUMMARY`.
2. `SESSION_READY` was reported only during full setup. Ignition reconnects entered through the native restart path, so all four later native sessions lacked the required readiness marker.

This PR corrects diagnostics only:

- only exact GM wake states (`ANIMATION_INIT`/`HMI_INIT`) roll a post-shutdown attempt; `HMI_INACTIVE` remains shutdown evidence
- initial callback readiness is tagged `callback-installed`
- reconnect readiness is tagged `native-session-started` only after the native AA session positively starts
- readiness source is carried atomically in the event and fixed `sessionSource` summary field
- latency-sensitive callbacks only timestamp/sanitize/enqueue into a bounded 8-entry dispatcher; reducer and file-sink work runs on the existing IO scope

No networking, Bluetooth, SDP publication, Android Auto launch, retry, or session-control behavior changes.

## Verification

- strict RED/GREEN for rollover, source propagation, native failure, exact-once summary, queue saturation/drop/order/failure/re-arm, and hook isolation
- car unit suite + Kotlin compile: 272 tests, 0 failures/errors/skipped
- independent spec and quality review gates
- static added-line scan: no network/BT/SDP/service/process control additions
- pre-change control: `native-session-started` marker absent
- compiled production classes contain `native-session-started`, `callback-installed`, and `sessionSource`

Stage B remains blocked until one corrected paired in-vehicle recapture produces a ready car summary and the new runtime marker.
