### PR TITLE
fix: harden wake recovery and connection truth

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -741,7 +741,10 @@ void JniSession::onByeByeResponse(
     const aap_protobuf::service::control::message::ByeByeResponse& /*response*/)
 {
     LOGI("ByeBye response received");
-    stop();
+    // This callback runs on ioThread_. stop() joins ioThread_, so dispatch the
+    // teardown off-thread rather than self-joining and aborting with EDEADLK.
+    auto self = shared_from_this();
+    std::thread([self] { self->stop(); }).detach();
 }
 
 void JniSession::onBatteryStatusNotification(

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -147,6 +147,7 @@ class SessionManager(
         }
     }.asCoroutineDispatcher()
 
+    private val sessionStateLock = Any()
     private val _sessionState = MutableStateFlow(SessionState.IDLE)
     val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
 
@@ -1436,26 +1437,36 @@ class SessionManager(
         // Observe session state
         scope.launch {
             session.connectionState.collect { connState ->
-                val newState = connState.toSessionState()
-                _sessionState.value = newState
+                val reportedState = connState.toSessionState()
                 val attempt = _reconnectAttempt.value
-                _statusMessage.value = when (newState) {
-                    SessionState.IDLE ->
-                        if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                        else when (directTransport) {
-                            "usb" -> "USB: ${UsbConnectionManager.status.value}"
-                            else -> "Searching for phone…"
+                var startStreamingServices = false
+                synchronized(sessionStateLock) {
+                    val currentState = _sessionState.value
+                    startStreamingServices = shouldStartStreamingServices(
+                        currentState,
+                        reportedState,
+                    )
+                    reconcileTransportSessionState(currentState, reportedState).also {
+                        _sessionState.value = it
+                        _statusMessage.value = when (it) {
+                            SessionState.IDLE ->
+                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                else when (directTransport) {
+                                    "usb" -> "USB: ${UsbConnectionManager.status.value}"
+                                    else -> "Searching for phone…"
+                                }
+                            SessionState.CONNECTING ->
+                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                else "Phone connecting..."
+                            SessionState.CONNECTED -> "Handshake..."
+                            SessionState.STREAMING -> "Streaming"
+                            SessionState.ERROR ->
+                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                else "Error"
                         }
-                    SessionState.CONNECTING ->
-                        if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                        else "Phone connecting..."
-                    SessionState.CONNECTED -> "Handshake..."
-                    SessionState.STREAMING -> "Streaming"
-                    SessionState.ERROR ->
-                        if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                        else "Error"
+                    }
                 }
-                if (newState == SessionState.STREAMING) {
+                if (startStreamingServices) {
                     startLocationForwarding(session)
                     _vehicleDataForwarder?.start()
                     _imuForwarder?.start()
@@ -1616,8 +1627,10 @@ class SessionManager(
         _telemetryCollector = null
         DiagnosticLog.instance = null
         _remoteDiagnostics = null
-        _sessionState.value = SessionState.IDLE
-        _statusMessage.value = "Disconnected"
+        synchronized(sessionStateLock) {
+            _sessionState.value = SessionState.IDLE
+            _statusMessage.value = "Disconnected"
+        }
         _phoneBatteryLevel.value = null
         _phoneBatteryCritical.value = false
         _voiceSessionActive.value = false
@@ -2450,15 +2463,24 @@ class SessionManager(
                 _remoteDiagnostics?.log(DiagnosticLevel.INFO, "session", "Phone connected: ${message.phoneName}")
                 resetLatchedVehicleSensorState("phone_connected")
                 seedCurrentUiNightMode("phone_connected")
-                _sessionState.value = SessionState.STREAMING
-                _statusMessage.value = "Streaming"
+                val startStreamingServices = synchronized(sessionStateLock) {
+                    shouldStartStreamingServices(
+                        _sessionState.value,
+                        SessionState.STREAMING,
+                    ).also {
+                        _sessionState.value = SessionState.STREAMING
+                        _statusMessage.value = "Streaming"
+                    }
+                }
                 // Reset the stall watchdog baseline: give the fresh session a
                 // full warmup window before it can fire (avoids a stale
                 // timestamp from a prior session tripping it immediately).
                 lastVideoFrameArrivedMs = SystemClock.elapsedRealtime() + VIDEO_STALL_WARMUP_MS
-                aasdkSession?.let { startLocationForwarding(it) }
-                _vehicleDataForwarder?.start()
-                _imuForwarder?.start()
+                if (startStreamingServices) {
+                    aasdkSession?.let { startLocationForwarding(it) }
+                    _vehicleDataForwarder?.start()
+                    _imuForwarder?.start()
+                }
             }
             is ControlMessage.PhoneDisconnected -> {
                 _remoteDiagnostics?.log(DiagnosticLevel.INFO, "session", "Phone disconnected: ${message.reason}")

--- a/app/src/main/java/com/openautolink/app/session/SessionState.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionState.kt
@@ -23,3 +23,24 @@ fun ConnectionState.toSessionState(): SessionState = when (this) {
     ConnectionState.PHONE_CONNECTED -> SessionState.STREAMING
     ConnectionState.STREAMING -> SessionState.STREAMING
 }
+
+fun shouldStartStreamingServices(
+    current: SessionState,
+    reported: SessionState,
+): Boolean = current != SessionState.STREAMING && reported == SessionState.STREAMING
+
+/**
+ * Transport callbacks can arrive after the AA control channel has already proved
+ * that media is streaming. Preserve that stronger state across a late CONNECTED
+ * report, while still honoring reconnects, disconnects, and errors.
+ */
+fun reconcileTransportSessionState(
+    current: SessionState,
+    reported: SessionState,
+): SessionState = if (
+    current == SessionState.STREAMING && reported == SessionState.CONNECTED
+) {
+    SessionState.STREAMING
+} else {
+    reported
+}

--- a/app/src/main/java/com/openautolink/app/wake/AttemptSummaryScheduler.kt
+++ b/app/src/main/java/com/openautolink/app/wake/AttemptSummaryScheduler.kt
@@ -9,12 +9,28 @@ enum class AttemptSummaryOutcome {
     TIMEOUT,
 }
 
+internal const val PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS = 60_000L
+
+internal fun selectAttemptSummaryTimeoutMs(
+    summary: WakeSummary,
+    defaultTimeoutMs: Long,
+): Long = if (
+    summary.trigger == WakeSignal.GM_SYSTEM_STATE &&
+    summary.gmState in OBSERVATIONAL_GM_DETAILS &&
+    summary.ignitionOnAtMs == null
+) {
+    PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS
+} else {
+    defaultTimeoutMs
+}
+
 /**
  * Owns one terminal deadline per retained attempt. Attempt IDs, rather than a process-global
  * sampler, identify every callback so an old timeout can never summarize a newer attempt.
  */
 class AttemptSummaryScheduler(
     private val timeoutMs: Long,
+    private val timeoutSelector: (WakeSummary) -> Long = { timeoutMs },
     private val schedule: (Long, Long, () -> Unit) -> AttemptSummaryTimeout,
     private val emit: (WakeSummary, AttemptSummaryOutcome) -> Unit,
 ) {
@@ -54,7 +70,8 @@ class AttemptSummaryScheduler(
                 if (existing != null) {
                     existing.summary = summary
                 } else if (attemptId !in completedAttemptIds) {
-                    val timeout = schedule(attemptId, timeoutMs) { timeout(attemptId) }
+                    val selectedTimeoutMs = timeoutSelector(summary).takeIf { it > 0L } ?: timeoutMs
+                    val timeout = schedule(attemptId, selectedTimeoutMs) { timeout(attemptId) }
                     pendingByAttempt[attemptId] = Pending(summary, timeout)
                 }
             }

--- a/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
+++ b/app/src/main/java/com/openautolink/app/wake/PreWakeMonitor.kt
@@ -51,6 +51,12 @@ object PreWakeMonitor {
     private val receivers = mutableListOf<BroadcastReceiver>()
     private val summaryScheduler = AttemptSummaryScheduler(
         timeoutMs = PreWakeSignalPolicy.DEFAULT_SAMPLING_PLAN.durationMs,
+        timeoutSelector = { summary ->
+            selectAttemptSummaryTimeoutMs(
+                summary,
+                PreWakeSignalPolicy.DEFAULT_SAMPLING_PLAN.durationMs,
+            )
+        },
         schedule = { attemptId, delayMs, callback ->
             val job = scope.launch {
                 delay(delayMs)

--- a/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
+++ b/app/src/main/java/com/openautolink/app/wake/WakeAttemptReducer.kt
@@ -45,6 +45,11 @@ data class WakeSummary(
     val timeline: List<WakeEvent>,
 )
 
+internal val OBSERVATIONAL_GM_DETAILS = setOf(
+    "raw=1,name=ANIMATION_INIT",
+    "raw=2,name=HMI_INIT",
+)
+
 /**
  * Reduces logging signals into one bounded wake timeline. It intentionally has no behavior hooks.
  */
@@ -129,6 +134,10 @@ class WakeAttemptReducer(
         WakeSignal.entries.forEach { signal ->
             ordered.firstOrNull { it.signal == signal }?.let(protected::add)
         }
+        ordered.firstOrNull {
+            it.signal == WakeSignal.GM_SYSTEM_STATE &&
+                it.detail in OBSERVATIONAL_GM_DETAILS
+        }?.let(protected::add)
         ordered.firstTrueApEdge()?.let(protected::add)
         LATEST_EDGE_SIGNALS.forEach { signal ->
             ordered.lastOrNull { it.signal == signal }?.let(protected::add)
@@ -142,6 +151,7 @@ class WakeAttemptReducer(
 
     private fun Attempt.toSummary(): WakeSummary {
         val timeline = events.sortedWith(EVENT_ORDER)
+        val trigger = timeline.trigger()
         var apAbsent = false
         var apEdgeAtMs: Long? = null
         timeline.forEach { event ->
@@ -159,8 +169,8 @@ class WakeAttemptReducer(
 
         return WakeSummary(
             attemptId = id,
-            trigger = timeline.trigger(),
-            gmState = timeline.firstDetail(WakeSignal.GM_SYSTEM_STATE),
+            trigger = trigger,
+            gmState = timeline.gmStateFor(trigger),
             btReadyAtMs = timeline.firstTime(WakeSignal.BLUETOOTH_ON),
             apReadyAtMs = timeline.firstTime(WakeSignal.AP_PRESENT),
             ignitionOnAtMs = timeline.firstTime(WakeSignal.IGNITION_ON),
@@ -204,6 +214,16 @@ class WakeAttemptReducer(
     private fun List<WakeEvent>.firstDetail(signal: WakeSignal): String? =
         firstOrNull { it.signal == signal }?.detail?.takeIf { it.isNotBlank() }
 
+    private fun List<WakeEvent>.gmStateFor(trigger: WakeSignal): String? =
+        if (trigger == WakeSignal.GM_SYSTEM_STATE) {
+            firstOrNull {
+                it.signal == WakeSignal.GM_SYSTEM_STATE &&
+                    it.detail in OBSERVATIONAL_GM_DETAILS
+            }?.detail
+        } else {
+            firstDetail(WakeSignal.GM_SYSTEM_STATE)
+        }
+
     private fun List<WakeEvent>.firstSource(signal: WakeSignal): String? =
         firstOrNull { it.signal == signal }
             ?.detail
@@ -230,11 +250,6 @@ class WakeAttemptReducer(
             WakeSignal.IGNITION_OFF,
             WakeSignal.IGNITION_ON,
             WakeSignal.IGNITION_START,
-        )
-
-        private val OBSERVATIONAL_GM_DETAILS = setOf(
-            "raw=1,name=ANIMATION_INIT",
-            "raw=2,name=HMI_INIT",
         )
 
         private val ATTEMPT_START_SIGNALS = WakeSignal.entries.toSet() - setOf(

--- a/app/src/test/java/com/openautolink/app/session/SessionStateTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/SessionStateTest.kt
@@ -32,6 +32,50 @@ class SessionStateTest {
     }
 
     @Test
+    fun `late transport CONNECTED cannot downgrade an active stream`() {
+        assertEquals(
+            SessionState.STREAMING,
+            reconcileTransportSessionState(SessionState.STREAMING, SessionState.CONNECTED),
+        )
+    }
+
+    @Test
+    fun `suppressed CONNECTED does not restart streaming services`() {
+        assertEquals(
+            false,
+            shouldStartStreamingServices(SessionState.STREAMING, SessionState.CONNECTED),
+        )
+        assertEquals(
+            false,
+            shouldStartStreamingServices(SessionState.STREAMING, SessionState.STREAMING),
+        )
+        assertEquals(
+            true,
+            shouldStartStreamingServices(SessionState.CONNECTED, SessionState.STREAMING),
+        )
+    }
+
+    @Test
+    fun `transport CONNECTING still leaves an active stream for real recovery`() {
+        assertEquals(
+            SessionState.CONNECTING,
+            reconcileTransportSessionState(SessionState.STREAMING, SessionState.CONNECTING),
+        )
+    }
+
+    @Test
+    fun `transport disconnect and error still leave streaming`() {
+        assertEquals(
+            SessionState.IDLE,
+            reconcileTransportSessionState(SessionState.STREAMING, SessionState.IDLE),
+        )
+        assertEquals(
+            SessionState.ERROR,
+            reconcileTransportSessionState(SessionState.STREAMING, SessionState.ERROR),
+        )
+    }
+
+    @Test
     fun `all ConnectionState values have a mapping`() {
         ConnectionState.entries.forEach { state ->
             // Should not throw

--- a/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/AttemptSummarySchedulerTest.kt
@@ -18,6 +18,121 @@ class AttemptSummarySchedulerTest {
     }
 
     @Test
+    fun `non observational GM summary retains default deadline`() {
+        val harness = Harness()
+        val summary = summary(attemptId = 2L, WakeSignal.GM_SYSTEM_STATE).copy(
+            gmState = "raw=3,name=HMI_INACTIVE",
+        )
+
+        harness.scheduler.observe(current = summary, previous = null)
+
+        assertEquals(15_000L, harness.scheduledDelaysMs.getValue(2L))
+    }
+
+    @Test
+    fun `process start and ignition first attempts retain fifteen second deadline`() {
+        listOf(WakeSignal.PROCESS_START, WakeSignal.IGNITION_ON).forEachIndexed { index, trigger ->
+            val attemptId = 10L + index
+            val harness = Harness()
+
+            harness.scheduler.observe(summary(attemptId, trigger), previous = null)
+
+            assertEquals(15_000L, harness.scheduledDelaysMs.getValue(attemptId))
+        }
+    }
+
+    @Test
+    fun `prewake without ignition times out exactly once at sixty seconds`() {
+        val harness = Harness()
+        val prewake = observationalGmSummary(attemptId = 12L)
+
+        harness.scheduler.observe(prewake, previous = null)
+        assertEquals(PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS, harness.scheduledDelaysMs.getValue(12L))
+
+        harness.advanceTo(PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS - 1L)
+        assertTrue(harness.emitted.isEmpty())
+        harness.advanceTo(PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS)
+        harness.callback(12L).invoke()
+
+        assertEquals(listOf(12L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+        assertEquals(0, harness.scheduler.activeTimeoutCount)
+    }
+
+    @Test
+    fun `noisy observations do not refresh the prewake deadline`() {
+        val harness = Harness()
+        val prewake = observationalGmSummary(attemptId = 13L)
+
+        harness.scheduler.observe(prewake, previous = null)
+        val originalDueAtMs = harness.dueAtMs.getValue(13L)
+        repeat(100) { index ->
+            harness.advanceTo(index + 1L)
+            harness.scheduler.observe(
+                current = prewake.copy(
+                    timeline = prewake.timeline +
+                        WakeEvent(
+                            WakeSignal.GM_SYSTEM_STATE,
+                            elapsedMs = index + 1L,
+                            detail = "raw=9,name=NOISE_$index",
+                        ),
+                ),
+                previous = null,
+            )
+        }
+
+        assertEquals(1, harness.scheduleCounts.getValue(13L))
+        assertEquals(originalDueAtMs, harness.dueAtMs.getValue(13L))
+        harness.advanceTo(PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS)
+        assertEquals(listOf(13L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+    }
+
+    @Test
+    fun `prewake attempt remains open through measured ignition delay and emits ready once`() {
+        var nextId = 436L
+        val reducer = WakeAttemptReducer { nextId++ }
+        val harness = Harness()
+
+        fun record(event: WakeEvent): WakeSummary {
+            harness.advanceTo(event.elapsedMs)
+            val current = reducer.record(event)
+            harness.scheduler.observe(current, reducer.previousSummary)
+            return current
+        }
+
+        val priorDrive = record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 1_000L))
+        assertTrue(harness.scheduler.ready(priorDrive))
+        harness.emitted.clear()
+        harness.emittedSummaries.clear()
+        record(WakeEvent(WakeSignal.IGNITION_OFF, elapsedMs = 2_000L))
+        val prewake = record(
+            WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs = 10_000L,
+                detail = "raw=1,name=ANIMATION_INIT",
+            )
+        )
+
+        harness.advanceTo(25_000L)
+
+        assertTrue(harness.emitted.isEmpty())
+        val ignition = record(WakeEvent(WakeSignal.IGNITION_ON, elapsedMs = 39_620L))
+        val sessionReady = record(
+            WakeEvent(
+                WakeSignal.SESSION_READY,
+                elapsedMs = 47_507L,
+                detail = "ready=true,source=native-session-started",
+            )
+        )
+        assertEquals(prewake.attemptId, ignition.attemptId)
+        assertTrue(harness.scheduler.ready(sessionReady))
+        assertEquals(
+            listOf(prewake.attemptId to AttemptSummaryOutcome.READY),
+            harness.emitted,
+        )
+        assertEquals("native-session-started", harness.emittedSummaries.single().sessionReadySource)
+    }
+
+    @Test
     fun `old attempt timer resolves old summary after rollover`() {
         val harness = Harness()
         val old = summary(attemptId = 10L, WakeSignal.PROCESS_START)
@@ -28,6 +143,7 @@ class AttemptSummarySchedulerTest {
         harness.fire(10L)
 
         assertEquals(listOf(10L to AttemptSummaryOutcome.TIMEOUT), harness.emitted)
+        assertEquals(10L, harness.emittedSummaries.single().attemptId)
         assertEquals(setOf(10L, 11L), harness.scheduler.retainedAttemptIds)
         assertEquals(1, harness.scheduler.activeTimeoutCount)
     }
@@ -35,9 +151,10 @@ class AttemptSummarySchedulerTest {
     @Test
     fun `ready racing timeout emits exactly once and cancels that attempt timer`() {
         val harness = Harness()
-        val summary = summary(attemptId = 20L, WakeSignal.IGNITION_ON)
+        val summary = observationalGmSummary(attemptId = 20L)
 
         harness.scheduler.observe(current = summary, previous = null)
+        assertEquals(PRE_WAKE_ATTEMPT_SUMMARY_TIMEOUT_MS, harness.scheduledDelaysMs.getValue(20L))
         val staleTimeout = harness.callback(20L)
         assertTrue(harness.scheduler.ready(summary))
         staleTimeout()
@@ -125,15 +242,22 @@ class AttemptSummarySchedulerTest {
     }
 
     private class Harness {
+        var nowMs = 0L
         val callbacks = mutableMapOf<Long, () -> Unit>()
+        val dueAtMs = mutableMapOf<Long, Long>()
+        val scheduledDelaysMs = mutableMapOf<Long, Long>()
+        val scheduleCounts = mutableMapOf<Long, Int>()
         val cancelled = mutableMapOf<Long, Boolean>()
         val emitted = mutableListOf<Pair<Long, AttemptSummaryOutcome>>()
         val emittedSummaries = mutableListOf<WakeSummary>()
         val scheduler = AttemptSummaryScheduler(
             timeoutMs = 15_000L,
+            timeoutSelector = { summary -> selectAttemptSummaryTimeoutMs(summary, 15_000L) },
             schedule = { attemptId, delayMs, callback ->
-                assertEquals(15_000L, delayMs)
                 callbacks[attemptId] = callback
+                scheduledDelaysMs[attemptId] = delayMs
+                scheduleCounts[attemptId] = scheduleCounts.getOrDefault(attemptId, 0) + 1
+                dueAtMs[attemptId] = nowMs + delayMs
                 cancelled[attemptId] = false
                 AttemptSummaryTimeout { cancelled[attemptId] = true }
             },
@@ -146,7 +270,27 @@ class AttemptSummarySchedulerTest {
         fun callback(attemptId: Long): () -> Unit = callbacks.getValue(attemptId)
 
         fun fire(attemptId: Long) = callback(attemptId).invoke()
+
+        fun advanceTo(targetMs: Long) {
+            require(targetMs >= nowMs)
+            nowMs = targetMs
+            dueAtMs
+                .filter { (attemptId, dueAt) ->
+                    dueAt <= targetMs && cancelled[attemptId] == false
+                }
+                .keys
+                .toList()
+                .forEach { attemptId ->
+                    cancelled[attemptId] = true
+                    callback(attemptId).invoke()
+                }
+        }
     }
+
+    private fun observationalGmSummary(attemptId: Long): WakeSummary =
+        summary(attemptId, WakeSignal.GM_SYSTEM_STATE).copy(
+            gmState = "raw=1,name=ANIMATION_INIT",
+        )
 
     private fun summary(attemptId: Long, trigger: WakeSignal): WakeSummary = WakeSummary(
         attemptId = attemptId,

--- a/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/WakeAttemptReducerTest.kt
@@ -121,6 +121,7 @@ class WakeAttemptReducerTest {
         assertEquals(501L, wake.attemptId)
         assertEquals(502L, nextId)
         assertEquals(WakeSignal.GM_SYSTEM_STATE, wake.trigger)
+        assertEquals("raw=1,name=ANIMATION_INIT", wake.gmState)
         assertEquals(
             listOf(
                 WakeSignal.GM_SYSTEM_STATE,
@@ -131,6 +132,9 @@ class WakeAttemptReducerTest {
             wake.timeline.map { it.signal }
         )
         assertEquals(listOf(210L, 220L, 230L, 1_000L), wake.timeline.map { it.elapsedMs })
+        val line = WakeSummaryFormatter.format(wake)
+        assertTrue(line.contains(" gm=raw=1,name=ANIMATION_INIT "))
+        assertTrue(line.contains("GM_SYSTEM_STATE@210(raw=3,name=HMI_INACTIVE)"))
         assertTrue(reducer.previousSummary!!.timeline.all { it.elapsedMs <= 200L })
         assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.AP_ABSENT })
         assertFalse(reducer.previousSummary!!.timeline.any { it.signal == WakeSignal.BLUETOOTH_OFF })
@@ -205,6 +209,40 @@ class WakeAttemptReducerTest {
         assertTrue(stored.contains("sessionSource=native-session-started"))
         assertTrue(stored.indexOf("sessionSource=") < stored.indexOf("timeline="))
         assertTrue("Expected timeline truncation marker", stored.endsWith("~"))
+    }
+
+    @Test
+    fun `observational GM trigger provenance survives timeline compaction`() {
+        val reducer = WakeAttemptReducer { 104L }
+        reducer.record(
+            WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs = 100L,
+                detail = "raw=3,name=HMI_INACTIVE",
+            )
+        )
+        reducer.record(
+            WakeEvent(
+                WakeSignal.GM_SYSTEM_STATE,
+                elapsedMs = 200L,
+                detail = "raw=1,name=ANIMATION_INIT",
+            )
+        )
+        repeat(100) { index ->
+            reducer.record(
+                WakeEvent(
+                    WakeSignal.GM_SYSTEM_STATE,
+                    elapsedMs = 300L + index,
+                    detail = "raw=${9 + index},name=NOISE_$index",
+                )
+            )
+        }
+
+        val summary = reducer.currentSummary!!
+
+        assertEquals(WakeSignal.GM_SYSTEM_STATE, summary.trigger)
+        assertEquals("raw=1,name=ANIMATION_INIT", summary.gmState)
+        assertTrue(summary.timeline.any { it.detail == "raw=1,name=ANIMATION_INIT" })
     }
 
     @Test

--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -172,7 +172,6 @@ class AaProxy(
             var bridgeAttemptId: Long? = null
             try {
                 activeBridges.incrementAndGet()
-                listener?.onConnected()
 
                 // Use the most-recently-updated car socket (from a reconnect
                 // while waiting for AA), falling back to the original socket.
@@ -197,13 +196,14 @@ class AaProxy(
                 pumpingBridges.incrementAndGet()
                 counted = true
 
-                CompanionLog.i(TAG, "Bridge established: AA <-> Car")
-                bridgeAttemptId = PhoneWppDiagnostics.bridgeEstablished()
-
                 val aaIn = aaSocket.getInputStream()
                 val aaOut = aaSocket.getOutputStream()
                 val carIn = carSocket.getInputStream()
                 val carOut = carSocket.getOutputStream()
+
+                CompanionLog.i(TAG, "Bridge established: AA <-> Car")
+                listener?.onConnected()
+                bridgeAttemptId = PhoneWppDiagnostics.bridgeEstablished()
 
                 val job1 = launch { pump(aaIn, carOut, "AA->Car") }
                 val job2 = launch { pump(carIn, aaOut, "Car->AA") }

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
@@ -215,6 +215,25 @@ class WppStartupIntegrationPolicyTest {
     }
 
     @Test
+    fun `proxy reports connected only after both sockets form a bridge`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt",
+        ).readText()
+        val bridgeFunction = source.substringAfter("private fun launchBridge(aaSocket: Socket)")
+            .substringBefore("private suspend fun awaitPendingCarSocket")
+
+        val carSocketAcquired = bridgeFunction.indexOf("activeCarSocket = carSocket")
+        val bridgeEstablished = bridgeFunction.indexOf("Bridge established: AA <-> Car")
+        val pipesReady = bridgeFunction.indexOf("val carOut = carSocket.getOutputStream()")
+        val connectedCallback = bridgeFunction.indexOf("listener?.onConnected()")
+
+        assertTrue(carSocketAcquired >= 0)
+        assertTrue(pipesReady > carSocketAcquired)
+        assertTrue(bridgeEstablished > pipesReady)
+        assertTrue(connectedCallback > bridgeEstablished)
+    }
+
+    @Test
     fun `bridge close keeps the generation captured at establishment`() {
         val source = projectFile(
             "companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt",

--- a/tools/connection_check.py
+++ b/tools/connection_check.py
@@ -114,6 +114,14 @@ M_IGNITION_ON = "IGNITION_STATE → 4 (ON)"
 # The app stopped responding: Android dumped every thread to tombstoned. Reads as
 # a crash to the user (the app restarts), but it is a blocked main thread.
 M_ANR = "Wrote stack traces to tombstoned"
+# Native process-fatal signals. SIGQUIT is deliberately excluded: Android uses
+# signal 3 for ANR thread dumps and the process survives. The app crash-handler
+# marker is authoritative; generic libc lines count only when the same line names
+# the OAL process, because paired logcat can contain unrelated processes.
+M_NATIVE_CRASH_HANDLER = re.compile(
+    r"NATIVE CRASH: signal=(?:6|11) \((SIGABRT|SIGSEGV)\)"
+)
+M_FATAL_SIGNAL = re.compile(r"Fatal signal (?:6|11) \((SIGABRT|SIGSEGV)\)")
 M_ADVERTISER_ANY = "AaWirelessBt"
 M_BT_WAIT = "Bluetooth is off — waiting"
 M_BT_BACK = "Bluetooth is back"
@@ -584,6 +592,22 @@ def check_transport_agnostic(path: str) -> list:
             "FAIL", "app-not-responding",
             f"{anrs} ANR(s) — the main thread stopped responding long enough for "
             "Android to dump threads; the app restarts and looks like a crash",
+        ))
+
+    # Native SIGABRT/SIGSEGV kills the process. OAL's crash handler and libc can
+    # both describe the same incident, so report distinct signal names rather
+    # than counting duplicate marker lines.
+    native_crash_signals = set(M_NATIVE_CRASH_HANDLER.findall(logcat_text))
+    for line in logcat_text.splitlines():
+        if "penautolink.app" not in line and "com.openautolink.app" not in line:
+            continue
+        native_crash_signals.update(M_FATAL_SIGNAL.findall(line))
+    native_crash_signals = sorted(native_crash_signals)
+    if native_crash_signals:
+        out.append(Finding(
+            "FAIL", "native-crash",
+            f"native process crash ({', '.join(native_crash_signals)}) — "
+            "the app process was killed and any later connection used a new process",
         ))
 
     # The phone announced audio and none of it reached the player.

--- a/tools/test_connection_check.py
+++ b/tools/test_connection_check.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Focused synthetic tests for the connection checker's stable summary rules."""
 
+import tempfile
 import unittest
+from pathlib import Path
 
-from tools.connection_check import check_summary_text, positive_cross_side_success
+from tools.connection_check import (
+    check_summary_text,
+    check_transport_agnostic,
+    positive_cross_side_success,
+)
 
 
 class StableSummaryRulesTest(unittest.TestCase):
@@ -113,6 +119,54 @@ class StableSummaryRulesTest(unittest.TestCase):
             with self.subTest(missing=missing):
                 incomplete = "".join(value for key, value in parts.items() if key != missing)
                 self.assertFalse(positive_cross_side_success(incomplete))
+
+    def test_native_sigabrt_in_paired_logcat_is_a_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            oal_path = Path(tmp) / "oal_2026-08-16_14-31-40.log"
+            logcat_path = Path(tmp) / "logcat_2026-08-16_14-31-40.log"
+            oal_path.write_text("14:32:05.498 I/session: ByeBye response received\n")
+            logcat_path.write_text(
+                "14:32:05.509 E/libc++abi: terminating due to uncaught exception "
+                "of type std::system_error: thread::join failed: Resource deadlock would occur\n"
+                "14:32:05.510 F/OAL-NativeCrash: NATIVE CRASH: signal=6 (SIGABRT)\n"
+                "14:32:05.970 F/libc: Fatal signal 6 (SIGABRT)\n"
+            )
+
+            findings = check_transport_agnostic(str(oal_path))
+
+        crashes = [finding for finding in findings if finding.rule == "native-crash"]
+        self.assertEqual(1, len(crashes))
+        self.assertEqual("FAIL", crashes[0].severity)
+        self.assertIn("SIGABRT", crashes[0].detail)
+
+    def test_unrelated_process_fatal_signal_is_not_attributed_to_oal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            oal_path = Path(tmp) / "oal_2026-08-16_14-31-40.log"
+            logcat_path = Path(tmp) / "logcat_2026-08-16_14-31-40.log"
+            oal_path.write_text("14:32:05.498 I/session: healthy\n")
+            logcat_path.write_text(
+                "14:32:05.970 88 99 F/libc: Fatal signal 11 (SIGSEGV), "
+                "code 1 in tid 99, pid 88 (com.unrelated.app)\n"
+            )
+
+            findings = check_transport_agnostic(str(oal_path))
+
+        self.assertFalse(any(finding.rule == "native-crash" for finding in findings))
+
+    def test_sigquit_anr_is_not_misclassified_as_native_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            oal_path = Path(tmp) / "oal_2026-08-16_14-31-40.log"
+            logcat_path = Path(tmp) / "logcat_2026-08-16_14-31-40.log"
+            oal_path.write_text("14:32:05.498 I/session: stopping\n")
+            logcat_path.write_text(
+                "14:32:05.970 I/runtime: reacting to signal 3 (SIGQUIT)\n"
+                "14:32:06.000 W/runtime: Wrote stack traces to tombstoned\n"
+            )
+
+            findings = check_transport_agnostic(str(oal_path))
+
+        self.assertFalse(any(finding.rule == "native-crash" for finding in findings))
+        self.assertTrue(any(finding.rule == "app-not-responding" for finding in findings))
 
     def test_old_logs_without_summary_markers_are_not_flagged_for_instrumentation(self):
         old_text = (

--- a/tools/test_native_shutdown_safety.py
+++ b/tools/test_native_shutdown_safety.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Regression checks for native AA shutdown thread ownership."""
+
+from pathlib import Path
+import unittest
+
+
+SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "app/src/main/cpp/jni_session.cpp"
+)
+
+
+def function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    opening = source.index("{", start)
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+class NativeShutdownSafetyTest(unittest.TestCase):
+    def test_bye_bye_response_never_stops_on_io_service_thread(self):
+        body = function_body(
+            SOURCE.read_text(encoding="utf-8"),
+            "void JniSession::onByeByeResponse(",
+        )
+
+        self.assertIn(
+            "auto self = shared_from_this();",
+            body,
+            "the detached stop worker must retain the session lifetime",
+        )
+        self.assertEqual(
+            1,
+            body.count("std::thread([self] { self->stop(); }).detach();"),
+            "ByeBye response must dispatch the real stop on one detached worker",
+        )
+        self.assertNotRegex(
+            body,
+            r"(?m)^\s*stop\(\);\s*$",
+            "direct stop() self-joins ioThread_ and aborts with EDEADLK",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- prevent the native ByeBye response callback from self-joining its I/O thread
- detect attributed native SIGABRT/SIGSEGV incidents in the archive checker
- report the companion as Connected only after the real AA-to-car bridge is established
- prevent a late transport CONNECTED state from replacing an already proven STREAMING state
- keep observational GM pre-wake summaries open for the measured approach-to-ignition interval

## Evidence

The August 16 capture contained both:

- a home power-cycle SIGABRT caused by `onByeByeResponse()` calling `stop()` on the I/O thread
- an actual 21-minute store parking cycle that retained the process and recovered projection automatically

The store cycle observed `ANIMATION_INIT` 29.620s before ignition, AP presence 27.552s before ignition, native session at +7.887s, and first rendered frame at +11.005s.

## Verification

- car: 282 tests, 0 failures/errors
- companion: 32 tests, 0 failures/errors
- native arm64-v8a and x86_64 builds successful
- checker tests: 11 passed
- archive checker identifies exactly the attributed SIGABRT incident
- static security scan clean
- independent reviews completed; reported issues corrected and re-reviewed

## Runtime status

These are code-level fixes and diagnostic corrections pending in-car confirmation. The next test intentionally disables the phone hotspot and removes the car's home Wi-Fi profile so the car AP is the only network route.
