### PR TITLE
Fix AP-only bootstrap and surface recovery

### DIFF
--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -187,6 +187,9 @@ class SessionManager(
     @Volatile
     private var lastKnownSurface: Triple<android.view.Surface, Int, Int>? = null
 
+    /** Ownership token for callbacks emitted by replaceable decoder instances. */
+    private val videoDecoderGeneration = java.util.concurrent.atomic.AtomicLong(0)
+
     /**
      * Decoder settings from the last full session setup, for rebuilding one.
      *
@@ -210,10 +213,18 @@ class SessionManager(
     @Volatile
     private var lastVolumeOffsetAssistant: Int = 0
 
-    /** Called by the UI whenever a surface becomes available or is destroyed. */
+    /**
+     * Reject dead/stale Surface objects before they become the singleton's cached
+     * output target. A stale target must not provoke a destructive session restart.
+     */
     fun publishSurface(surface: android.view.Surface?, width: Int, height: Int) {
-        lastKnownSurface = surface?.let { Triple(it, width, height) }
-        if (surface != null && surface.isValid && width > 0 && height > 0) {
+        val validSurface = surface?.takeIf { it.isValid && width > 0 && height > 0 }
+        lastKnownSurface = validSurface?.let { Triple(it, width, height) }
+        if (surface != null && validSurface == null) {
+            OalLog.w(TAG, "Ignoring invalid video surface ${width}x${height}")
+            return
+        }
+        if (validSurface != null) {
             com.openautolink.app.wake.PreWakeMonitor.reportSurfaceReady(width, height)
         }
         // attach() configures or swaps the MediaCodec output surface, which
@@ -221,7 +232,9 @@ class SessionManager(
         // the main thread. One archived ANR's last main-thread line is exactly
         // "Surface attached", immediately after a forced reconnect began tearing
         // the session down on another thread.
-        if (surface != null) scope.launch { _videoDecoder?.attach(surface, width, height) }
+        if (validSurface != null) {
+            scope.launch { _videoDecoder?.attach(validSurface, width, height) }
+        }
     }
 
     /**
@@ -325,6 +338,32 @@ class SessionManager(
         }
     }
 
+    private fun createVideoDecoder(
+        codecPreference: String,
+        scalingMode: String,
+    ): MediaCodecDecoder {
+        val decoderGeneration = videoDecoderGeneration.incrementAndGet()
+        return MediaCodecDecoder(
+            codecPreference = codecPreference,
+            scalingMode = scalingMode,
+            onSessionRestartNeeded = { reason ->
+                val targetSession = aasdkSession
+                OalLog.w(TAG, "Decoder cannot recover the output surface in-place — $reason")
+                scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                    if (decoderGeneration != videoDecoderGeneration.get()) {
+                        OalLog.i(TAG, "Ignoring surface recovery from stale decoder generation $decoderGeneration")
+                        return@launch
+                    }
+                    if (targetSession == null || aasdkSession !== targetSession) {
+                        OalLog.i(TAG, "Ignoring surface recovery from a replaced session")
+                        return@launch
+                    }
+                    targetSession.forceReconnect(reason)
+                }
+            },
+        )
+    }
+
     fun ensureVideoDecoder() {
         if (_videoDecoder != null) {
             // Say the decoder is fine AND whether it can draw. A decoder with no
@@ -338,7 +377,7 @@ class SessionManager(
             return
         }
         OalLog.i(TAG, "No video decoder for this session — creating one")
-        _videoDecoder = MediaCodecDecoder(lastCodecPreference, lastScalingMode)
+        _videoDecoder = createVideoDecoder(lastCodecPreference, lastScalingMode)
         lastKnownSurface?.let { (surface, w, h) ->
             if (surface.isValid) {
                 OalLog.i(TAG, "Attaching the last known surface to the new decoder")
@@ -834,7 +873,7 @@ class SessionManager(
         lastVolumeOffsetMedia = volumeOffsetMedia
         lastVolumeOffsetNavigation = volumeOffsetNavigation
         lastVolumeOffsetAssistant = volumeOffsetAssistant
-        _videoDecoder = MediaCodecDecoder(codecPreference, scalingMode)
+        _videoDecoder = createVideoDecoder(codecPreference, scalingMode)
         // Re-attach the surface the UI last reported, if there is one.
         //
         // Holding it here rather than only in the ViewModel removes the ordering
@@ -1815,7 +1854,7 @@ class SessionManager(
 
         // 3. Flush video decoder (codec/scaling may have changed)
         _videoDecoder?.release()
-        _videoDecoder = MediaCodecDecoder(codecPreference, scalingMode)
+        _videoDecoder = createVideoDecoder(codecPreference, scalingMode)
         _telemetryCollector?.videoDecoder = _videoDecoder
 
         // 4. Update audio volume offsets in-place (no release/recreate)

--- a/app/src/main/java/com/openautolink/app/transport/OalProtocol.kt
+++ b/app/src/main/java/com/openautolink/app/transport/OalProtocol.kt
@@ -10,6 +10,9 @@ object OalProtocol {
     /** Primary AA TCP port: companion's TcpAdvertiser listens here for the car. */
     const val AA_PORT = 5277
 
+    /** Stable phone-local AA proxy port used for WPP bootstrap. */
+    const val WPP_PROXY_PORT = 5280
+
     /**
      * Identity probe port. Single-purpose: the car opens a short connection,
      * sends `IDENTITY_PROBE_REQUEST`, the companion replies with

--- a/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
+++ b/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
@@ -168,30 +168,14 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * mid-session; publishing on every discovery keeps it current rather than
      * pinning a value that was right a minute ago.
      */
-    private fun publishPhoneAddress(host: String) {
+    private fun publishPhoneAddress(host: String, reportedProxyPort: Int? = null) {
         val bt = com.openautolink.app.transport.bluetooth.AaWirelessBtControl
         bt.lastKnownPhoneIp = host
-        // Learning the companion's address late is the whole cause of the ~40s
-        // stall. The handshake fires promptly (median 3s from publishing the SDP
-        // record), but if the scan inside it finds nothing we advertise the
-        // car's own address — which cannot work through the car's access point —
-        // and then wait for the phone to retry on its own:
-        //
-        //     15:33:13  Phone dialled back                    (2.6s — fast)
-        //     15:33:18  No companion on any local subnet
-        //     15:33:31  preferred sweep complete: 1 phone(s)  (we knew it HERE)
-        //     15:33:50  Phone dialled back again              (37.8s wasted)
-        //
-        // Discovery had the answer 19s before the phone tried again. Bouncing the
-        // SDP record now makes the phone re-handshake immediately: measured
-        // republish-to-dial-back is 0-4s, median 0.5s.
-        // Deliberately NOT gated on the address having changed. lastKnownPhoneIp
-        // lives in a singleton and survives sessions, so after any previous run
-        // the address is already correct and "changed" is false forever — the
-        // stall is that the HANDSHAKE could not reach the companion, not that we
-        // learned something new. Measured: discovery reported the phone eight
-        // times over two minutes and this never fired once.
-        bt.readvertiseForNewCompanionAddress(host)
+        // During an attempt-owned WPP bootstrap, pass through the proxy port the
+        // identity response actually reported. Port 5280 completes the current
+        // exchange; an older companion's dynamic port triggers one compatibility
+        // re-advertise after the current handshake exits.
+        bt.readvertiseForNewCompanionAddress(host, reportedProxyPort)
     }
 
     private val _isDiscovering = MutableStateFlow(false)
@@ -571,7 +555,7 @@ class PhoneDiscovery private constructor(private val context: Context) {
                         if (ident != null) {
                             // Remember where the companion lives so the Bluetooth
                             // advertiser can ask it for its AA proxy port.
-                            publishPhoneAddress(ip)
+                            publishPhoneAddress(ip, ident.wppProxyPort)
                             addOrUpdate(
                                 phoneId = ident.phoneId,
                                 friendlyName = ident.friendlyName,
@@ -618,8 +602,8 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * Reads the optional "wpp=<port>" field from an identity response.
      *
      * Absent on older companions, so a missing or malformed value is not an
-     * error — it simply means no local proxy, and the caller falls back to
-     * advertising the car's own address.
+     * error — callers either keep the attempt-owned reserved bootstrap port or
+     * perform one compatibility re-advertise after a positive identity reply.
      */
     private fun parseWppPort(parts: List<String>): Int =
         parts.firstOrNull { it.startsWith("wpp=") }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -12,6 +12,7 @@ import com.openautolink.app.transport.usb.UsbConnectionManager
 import com.openautolink.app.video.VideoFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,6 +46,7 @@ class AasdkSession(
 
     companion object {
         private const val TAG = "AasdkSession"
+        private const val FORCE_RECONNECT_GUARD_MS = 3_000L
 
         /** Process-wide native onError coalescer.
          *
@@ -150,6 +152,7 @@ class AasdkSession(
     @Volatile
     private var reconnectJob: kotlinx.coroutines.Job? = null
     private val reconnectLock = Any()
+    private val forceReconnectGate = ReconnectSingleFlightGate()
 
     private fun cancelPendingReconnect(why: String) {
         synchronized(reconnectLock) {
@@ -216,21 +219,11 @@ class AasdkSession(
             OalLog.i(TAG, "WPP restart with a known companion at $known — dialling " +
                     "rather than waiting for a handshake that is not coming")
             startTcp(manualIp = known)
-            // Dialling the companion is only half the connection.
-            //
-            // The TCP link to the companion comes up fine, but nothing has told
-            // Android Auto which loopback port to attach to — that instruction is
-            // carried by the Bluetooth handshake, and a reconnect does not run
-            // one. Worse, the companion opens a NEW proxy port whenever its
-            // bridge closes, so any port AA still remembers is already wrong:
-            //
-            //     00:36:25.538  Proxy listening on localhost:43053   (was 36943)
-            //     00:36:41.924  Connected to companion               (car side, fine)
-            //     00:36:33-49   AA didn't connect to proxy — retry #1 #2 #3
-            //     00:36:56.938  Session abort: handshake timeout
-            //
-            // Both halves waiting, neither wrong on its own. Re-advertising makes
-            // the phone re-dial, and that handshake hands AA the current port.
+            // Dialling the companion is only half the connection. Android Auto's
+            // previous localhost socket belonged to the bridge that just ended;
+            // reconnecting the car socket does not by itself make AA open a new
+            // one, even though the reserved loopback port is now stable. Re-run
+            // the Bluetooth exchange to provoke that fresh AA attach.
             com.openautolink.app.transport.bluetooth.AaWirelessBtControl.readvertise()
             return
         }
@@ -492,40 +485,52 @@ class AasdkSession(
      * is restarted.
      */
     fun forceReconnect(reason: String) {
-        OalLog.w(TAG, "Force reconnect: $reason")
-        // Treat the upcoming nativeStopSession() as an explicit stop so the
-        // onSessionStopped handler doesn't schedule its own auto-reconnect 3s
-        // later — we're doing the restart ourselves immediately. Without this
-        // both reconnects race and one fails with "Native session start failed".
-        explicitStop = true
-        cancelPendingReconnect("force reconnect")
-        _tcpConnector?.stop()
-        _tcpConnector = null
-        _wppServer?.stop()
-        _wppServer = null
-        _usbConnectionManager?.stop()
-        _usbConnectionManager = null
-        AasdkNative.nativeStopSession()
-        transportPipe?.close()
-        transportPipe = null
-        _connectionState.value = ConnectionState.DISCONNECTED
-        // Now clear the explicitStop flag so the freshly-started session can
-        // auto-reconnect normally if its connection later dies.
-        explicitStop = false
-        // Restart transport.
-        when (transportMode) {
-            "usb" -> startUsb()
-            "wpp" -> startWpp()
-            else -> {
-                // Same reason as the retry path: without the known address this
-                // falls through to the gateway heuristic and dials the house
-                // router. Measured after a background/resume:
-                //     Connecting to 192.168.0.1:5277 (gateway)   — repeatedly
-                // while the phone re-handshook 90 times in 90 seconds waiting for
-                // a car-side connection that was never going to arrive.
-                val known = com.openautolink.app.transport.bluetooth
-                    .AaWirelessBtControl.lastKnownPhoneIp
-                startTcp(manualIp = known)
+        if (!forceReconnectGate.tryStart()) {
+            OalLog.i(TAG, "Force reconnect already in flight — ignoring duplicate: $reason")
+            return
+        }
+        try {
+            OalLog.w(TAG, "Force reconnect: $reason")
+            // Treat the upcoming nativeStopSession() as an explicit stop so the
+            // onSessionStopped handler doesn't schedule its own auto-reconnect 3s
+            // later — we're doing the restart ourselves immediately. Without this
+            // both reconnects race and one fails with "Native session start failed".
+            explicitStop = true
+            cancelPendingReconnect("force reconnect")
+            _tcpConnector?.stop()
+            _tcpConnector = null
+            _wppServer?.stop()
+            _wppServer = null
+            _usbConnectionManager?.stop()
+            _usbConnectionManager = null
+            AasdkNative.nativeStopSession()
+            transportPipe?.close()
+            transportPipe = null
+            _connectionState.value = ConnectionState.DISCONNECTED
+            // Now clear the explicitStop flag so the freshly-started session can
+            // auto-reconnect normally if its connection later dies.
+            explicitStop = false
+            // Restart transport.
+            when (transportMode) {
+                "usb" -> startUsb()
+                "wpp" -> startWpp()
+                else -> {
+                    // Same reason as the retry path: without the known address this
+                    // falls through to the gateway heuristic and dials the house
+                    // router.
+                    val known = com.openautolink.app.transport.bluetooth
+                        .AaWirelessBtControl.lastKnownPhoneIp
+                    startTcp(manualIp = known)
+                }
+            }
+        } finally {
+            explicitStop = false
+            // Keep the gate through the native teardown/start overlap, then allow
+            // a genuinely later recovery request. This also prevents a surface,
+            // wake and stall trigger from stacking synchronous native restarts.
+            scope.launch {
+                delay(FORCE_RECONNECT_GUARD_MS)
+                forceReconnectGate.finish()
             }
         }
     }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/ReconnectSingleFlightGate.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/ReconnectSingleFlightGate.kt
@@ -1,0 +1,14 @@
+package com.openautolink.app.transport.aasdk
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Prevents two recovery triggers from tearing down the same native session. */
+class ReconnectSingleFlightGate {
+    private val running = AtomicBoolean(false)
+
+    fun tryStart(): Boolean = running.compareAndSet(false, true)
+
+    fun finish() {
+        running.set(false)
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.openautolink.app.diagnostics.OalLog
+import com.openautolink.app.transport.OalProtocol
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -64,23 +65,6 @@ object AaWirelessBtControl {
     private const val CLAIM_TIMEOUT_MS = 120_000L
 
     /**
-     * Minimum spacing between discovery-triggered re-advertisements.
-     *
-     * Discovery reports on every sweep, so without this a companion whose
-     * address flaps would bounce the SDP record repeatedly and prevent the
-     * handshake it is trying to provoke.
-     */
-    private const val READVERTISE_MIN_INTERVAL_MS = 20_000L
-
-    /**
-     * Probe attempts before falling back to a blind scan.
-     *
-     * The phone is reachable within roughly 8s of associating, but not at 1-3s,
-     * which is when this probe runs. Six attempts at 2s spacing covers that.
-     */
-    private const val COMPANION_PROBE_ATTEMPTS = 6
-
-    /**
      * Remembered addresses to try before scanning.
      *
      * Kept low because MAC randomisation (Android's default) invalidates them
@@ -89,20 +73,8 @@ object AaWirelessBtControl {
      */
     private const val MAX_PRESCAN_PROBES = 2
 
-    /**
-     * How long a confirmed proxy port stays trustworthy.
-     *
-     * Long enough to ride out a probe that fails transiently mid-session, short
-     * enough that a companion restart — which always changes the port — is not
-     * papered over with a stale one.
-     */
-    private const val PROXY_PORT_TRUST_MS = 90_000L
-
     /** A handshake older than this has finished, whatever the flag says. */
     private const val HANDSHAKE_MAX_MS = 30_000L
-
-    /** Spacing between background probe attempts after a failed handshake. */
-    private const val COMPANION_PROBE_INTERVAL_MS = 2_000L
 
     /** Reserved MACs gearhead rejects outright — see pev.smali validation. */
     private const val ZERO_MAC = "00:00:00:00:00:00"
@@ -356,164 +328,147 @@ object AaWirelessBtControl {
     }
 
     /**
-     * Re-advertise because discovery just learned the companion's address.
+     * Attempt-owned AP bootstrap discovery.
      *
-     * Only useful when the last handshake could NOT find the companion and
-     * therefore advertised the car's own address, which the car's access point
-     * will not accept inbound. In that state the phone is waiting out its own
-     * retry timer — up to 40s — while we already know where to point it.
-     *
-     * Heavily guarded, because re-advertising during a healthy session would
-     * tear down a working connection:
-     *   - only when the last endpoint was the unusable car-direct one
-     *   - never while a handshake is in flight
-     *   - never more than once every 20s
+     * WPP intentionally disables the UI's periodic PhoneDiscovery. This scanner is
+     * narrower: it runs only after the first Bluetooth exchange has moved the
+     * selected phone onto the car AP, scans even with an empty cache, and expires
+     * before the companion proxy's 30-second car-socket waiter.
      */
-    /**
-     * Keeps probing known addresses after a handshake failed to reach any.
-     *
-     * On success it re-advertises, which makes the phone re-handshake within a
-     * second or two rather than waiting out its own ~40s retry timer. Without
-     * this the car sits on an endpoint the access point will not accept until
-     * the phone happens to try again.
-     */
-    private fun startBackgroundCompanionProbe(candidates: List<String>) {
-        if (candidates.isEmpty()) return
-        // Self-expiring for the same reason as ensureInFlight: a `finally` is not
-        // a guarantee. A probe that is cancelled at its delay() never clears the
-        // flag, and every later probe is refused for the life of the process.
-        val probeStarted = backgroundProbeSince
-        if (probeStarted != 0L && System.currentTimeMillis() - probeStarted > PROBE_MAX_MS) {
-            OalLog.w(TAG, "Background probe has been 'running' for " +
-                    "${(System.currentTimeMillis() - probeStarted) / 1000}s — assuming it died")
-            backgroundProbeRunning.set(false)
-            backgroundProbeSince = 0L
-        }
-        if (!backgroundProbeRunning.compareAndSet(false, true)) return
-        backgroundProbeSince = System.currentTimeMillis()
+    private fun startBootstrapCompanionDiscovery(
+        attempt: BootstrapAttempt,
+        candidates: List<String>,
+        manualIp: String?,
+    ) {
         scope.launch {
-            try {
-                for (attempt in 1..COMPANION_PROBE_ATTEMPTS) {
-                    kotlinx.coroutines.delay(COMPANION_PROBE_INTERVAL_MS)
-                    if (sessionIsStreaming?.invoke() == true) return@launch
-                    for (ip in candidates) {
-                        val port = askCompanion(ip, connectTimeoutMs = 2500)
-                        if (port != null) {
-                            OalLog.i(TAG, "Companion at $ip answered on attempt $attempt " +
-                                    "(proxy port $port) — re-advertising so the phone " +
-                                    "retries now instead of waiting out its own timer")
-                            lastKnownPhoneIp = ip
-                            // Deliberately does NOT reset the cooldown.
-                            //
-                            // It used to, on the reasoning that this probe only
-                            // runs after a failure so its success is worth acting
-                            // on immediately. But that let this re-advertise and a
-                            // discovery-driven one both fire for the same
-                            // recovery, 29s apart, and the phone dialled back for
-                            // each. The car ended up dialling the companion for
-                            // one connection while Android Auto attached to the
-                            // other: seed IDR arrived, then the picture froze
-                            // with both halves crossed.
-                            //
-                            // One endpoint change at a time. If the cooldown is
-                            // active a re-advertise has already been issued, and
-                            // a second one can only confuse the phone.
-                            readvertiseForNewCompanionAddress(ip)
-                            return@launch
-                        }
+            val deadline = System.currentTimeMillis() + WppBootstrapPolicy.DISCOVERY_DEADLINE_MS
+            var scanAttempt = 0
+            while (System.currentTimeMillis() < deadline) {
+                // A newer Bluetooth dial-back owns a different attempt. Let this
+                // scanner die without consuming or dialling on its behalf.
+                if (bootstrapAttempt.get() !== attempt || sessionIsStreaming?.invoke() == true) {
+                    return@launch
+                }
+                scanAttempt++
+                var found: Pair<String, Int>? = null
+                for (ip in candidates.take(MAX_PRESCAN_PROBES)) {
+                    val proxyPort = askCompanion(ip, connectTimeoutMs = 800)
+                    if (proxyPort != null) {
+                        found = ip to proxyPort
+                        break
                     }
                 }
-                OalLog.w(TAG, "Companion still unreachable after $COMPANION_PROBE_ATTEMPTS " +
-                        "attempts at ${candidates.joinToString()}")
-            } finally {
-                backgroundProbeRunning.set(false)
-                backgroundProbeSince = 0L
+                if (found == null) {
+                    val remainingMs = (deadline - System.currentTimeMillis())
+                        .coerceIn(1L, 5_000L)
+                        .toInt()
+                    found = findCompanionOnAnySubnet(manualIp, remainingMs)
+                }
+                if (found != null) {
+                    val (ip, proxyPort) = found
+                    OalLog.i(TAG, "Bootstrap discovery found companion at $ip " +
+                            "on attempt $scanAttempt (proxy port $proxyPort)")
+                    readvertiseForNewCompanionAddress(ip, proxyPort, attempt)
+                    return@launch
+                }
+                kotlinx.coroutines.delay(750)
+            }
+            OalLog.w(TAG, "Bootstrap companion discovery timed out after " +
+                    "${WppBootstrapPolicy.DISCOVERY_DEADLINE_MS / 1000}s")
+        }
+    }
+
+    /** Run a legacy companion re-advertise once the current handshake exits. */
+    fun flushPendingReadvertise() {
+        val (pending, admissionToken) = synchronized(handshakeStateLock) {
+            if (activeHandshakeCount.get() > 0 || handshakeAdmissionBlocked) return
+            val candidate = pendingLegacyReadvertise.get() ?: return
+            if (bootstrapAttempt.get() !== candidate.attempt) {
+                pendingLegacyReadvertise.compareAndSet(candidate, null)
+                return
+            }
+            if (!bootstrapAttempt.compareAndSet(candidate.attempt, null)) return
+            pendingLegacyReadvertise.compareAndSet(candidate, null)
+            val token = handshakeAdmissionSequence.incrementAndGet()
+            handshakeAdmissionBlocked = true
+            handshakeAdmissionToken = token
+            candidate to token
+        }
+        lastKnownPhoneIp = pending.host
+        lastAddressByPhone[pending.attempt.phoneBtAddress] = pending.host
+        OalLog.i(TAG, "Handshakes finished — re-advertising legacy companion " +
+                "${pending.host}:${pending.proxyPort}")
+        readvertise(admissionToken)
+    }
+
+    fun readvertiseForNewCompanionAddress(host: String, reportedProxyPort: Int? = null) {
+        readvertiseForNewCompanionAddress(host, reportedProxyPort, null)
+    }
+
+    private fun readvertiseForNewCompanionAddress(
+        host: String,
+        reportedProxyPort: Int? = null,
+        expectedAttempt: BootstrapAttempt? = null,
+    ) {
+        val proxyPort = reportedProxyPort ?: askCompanion(host, connectTimeoutMs = 800) ?: return
+        val attempt = expectedAttempt ?: bootstrapAttempt.get()
+        if (expectedAttempt != null && bootstrapAttempt.get() !== expectedAttempt) return
+        when (WppBootstrapPolicy.onCompanionReachable(
+            bootstrapLoopbackPending = attempt != null,
+            usesReservedProxyPort = proxyPort == OalProtocol.WPP_PROXY_PORT,
+            handshakeInFlight = handshakeInFlight,
+            sessionStreaming = sessionIsStreaming?.invoke() == true,
+        )) {
+            LateCompanionAction.DIAL_COMPANION -> {
+                // Atomic consumption makes concurrent TCP-scan and cached-address
+                // results one event. Only the Bluetooth phone that opened this
+                // attempt owns the right to complete it.
+                if (attempt == null || !bootstrapAttempt.compareAndSet(attempt, null)) return
+                lastKnownPhoneIp = host
+                lastAddressByPhone[attempt.phoneBtAddress] = host
+                activePhoneCompanionIp = host
+                OalLog.i(TAG, "Companion became reachable at $host after AP association — " +
+                        "dialling it into reserved loopback port $proxyPort; no second WPP exchange")
+                onCompanionSelected?.invoke(host)
+            }
+            LateCompanionAction.QUEUE_READVERTISE -> {
+                OalLog.i(TAG, "Older companion at $host uses dynamic proxy port $proxyPort; " +
+                        "queueing one compatibility re-advertise after this handshake")
+                synchronized(handshakeStateLock) {
+                    if (attempt == null || bootstrapAttempt.get() !== attempt) return
+                    pendingLegacyReadvertise.set(
+                        PendingLegacyReadvertise(host, proxyPort, attempt),
+                    )
+                }
+                // Close the race where the final handshake ended between the
+                // policy read and publishing this queue entry.
+                flushPendingReadvertise()
+            }
+            LateCompanionAction.READVERTISE -> {
+                OalLog.i(TAG, "Older companion at $host uses dynamic proxy port $proxyPort — " +
+                        "reserving one compatibility re-advertise")
+                synchronized(handshakeStateLock) {
+                    if (attempt == null || bootstrapAttempt.get() !== attempt) return
+                    pendingLegacyReadvertise.set(
+                        PendingLegacyReadvertise(host, proxyPort, attempt),
+                    )
+                }
+                flushPendingReadvertise()
+            }
+            LateCompanionAction.IGNORE -> {
+                if (sessionIsStreaming?.invoke() == true) bootstrapAttempt.set(null)
             }
         }
     }
 
-    private val backgroundProbeRunning = java.util.concurrent.atomic.AtomicBoolean(false)
+    private data class BootstrapAttempt(
+        val phoneBtAddress: String,
+        val generation: Long,
+    )
 
-    /** When the current background probe began, so the guard cannot latch. */
-    @Volatile
-    private var backgroundProbeSince = 0L
-
-    /** Longest a probe sweep can plausibly take before it is presumed dead. */
-    private const val PROBE_MAX_MS = 120_000L
-
-    /**
-     * Run a re-advertise that was requested while a handshake was in flight.
-     *
-     * Called once the handshake completes. Only acts if the endpoint that
-     * handshake settled on is still the unreachable one — if it managed to find
-     * the companion itself, there is nothing to repair.
-     */
-    fun flushPendingReadvertise() {
-        val host = pendingReadvertiseHost ?: return
-        pendingReadvertiseHost = null
-        if (!lastEndpointWasCarDirect) {
-            OalLog.i(TAG, "Handshake found the companion itself — dropping the " +
-                    "queued re-advertise for $host")
-            return
-        }
-        OalLog.i(TAG, "Handshake finished — running the queued re-advertise for $host")
-        readvertiseForNewCompanionAddress(host)
-    }
-
-    fun readvertiseForNewCompanionAddress(host: String) {
-        if (!lastEndpointWasCarDirect) return
-        if (handshakeInFlight) {
-            // Queue it instead of dropping it.
-            //
-            // The handshake that advertised the bad endpoint is usually still
-            // finishing when the probe succeeds — measured at 2s apart — so this
-            // guard threw away the very answer it was waiting for and the
-            // connection then waited 26s for discovery to ask again. Restarting
-            // the advertiser mid-handshake genuinely does destroy the socket the
-            // phone is about to use, so we still must not act now; we just have
-            // to remember.
-            OalLog.i(TAG, "Companion found at $host while a handshake is in " +
-                    "flight — queued, will re-advertise as soon as it finishes")
-            pendingReadvertiseHost = host
-            return
-        }
-        // Only a session that is actually CARRYING DATA counts as "working".
-        //
-        // The previous check was `sessionState != IDLE`, which is true the
-        // instant a session object exists — including while it sits listening
-        // for a phone that will never arrive. That is precisely the stall this
-        // function exists to break, so the guard blocked the only case it was
-        // meant to help: discovery reported the phone eight times across two
-        // minutes and no re-advertise ever fired.
-        if (sessionIsStreaming?.invoke() == true) return
-        val now = System.currentTimeMillis()
-        // The cooldown exists to stop two re-advertises racing and crossing the
-        // phone's connections. It must not apply when the endpoint we are
-        // currently advertising is known to be unreachable: that re-advertise is
-        // not a duplicate, it is the repair, and delaying it costs half a minute.
-        if (!lastEndpointWasCarDirect &&
-            now - lastReadvertiseAtMs < READVERTISE_MIN_INTERVAL_MS
-        ) {
-            // Say so rather than returning silently. This cooldown swallowed the
-            // recovery once already: a republish at 20:53:14 started the clock,
-            // discovery reported the phone 10.7s later, and the re-advertise that
-            // would have fixed an unreachable endpoint was dropped without trace.
-            // Info, not debug: the uploaded file log only captures I and above,
-            // so at debug level this "explanation" was invisible in exactly the
-            // logs used to diagnose the problem it explains.
-            OalLog.i(TAG, "Skipping re-advertise for $host — only " +
-                    "${(now - lastReadvertiseAtMs) / 1000}s since the last one")
-            return
-        }
-        lastReadvertiseAtMs = now
-        OalLog.i(TAG, "Discovery found the companion at $host after we advertised an " +
-                "unreachable endpoint — re-advertising so the phone retries now " +
-                "instead of waiting out its own timer")
-        readvertise()
-    }
-
-    @Volatile
-    private var lastEndpointWasCarDirect = false
+    private val bootstrapAttemptSequence = java.util.concurrent.atomic.AtomicLong(0)
+    private val bootstrapAttempt =
+        java.util.concurrent.atomic.AtomicReference<BootstrapAttempt?>(null)
 
     /**
      * Reports whether projection is actually running.
@@ -524,17 +479,30 @@ object AaWirelessBtControl {
     @Volatile
     var sessionIsStreaming: (() -> Boolean)? = null
 
-    @Volatile
-    private var lastReadvertiseAtMs = 0L
+    /** A legacy dynamic endpoint tied to the exact attempt that discovered it. */
+    private data class PendingLegacyReadvertise(
+        val host: String,
+        val proxyPort: Int,
+        val attempt: BootstrapAttempt,
+    )
 
-    /** A re-advertise asked for during a handshake, to run when it completes. */
-    @Volatile
-    private var pendingReadvertiseHost: String? = null
+    private val pendingLegacyReadvertise =
+        java.util.concurrent.atomic.AtomicReference<PendingLegacyReadvertise?>(null)
 
-    fun readvertise() {
+    private fun releaseHandshakeAdmission(admissionToken: Long?) = synchronized(handshakeStateLock) {
+        if (admissionToken != null && handshakeAdmissionToken == admissionToken) {
+            handshakeAdmissionBlocked = false
+            handshakeAdmissionToken = 0L
+        }
+    }
+
+    fun readvertise() = readvertise(null)
+
+    private fun readvertise(admissionToken: Long?) {
         val ctx = appContext
         if (ctx == null) {
             OalLog.w(TAG, "Cannot re-advertise — no context yet")
+            releaseHandshakeAdmission(admissionToken)
             return
         }
         // NonCancellable: this is stop-then-start, and the stop used to cancel
@@ -542,45 +510,30 @@ object AaWirelessBtControl {
         // said why. The advertiser must come back even if something cancels us
         // mid-sequence.
         scope.launch(kotlinx.coroutines.NonCancellable) {
-            runCatching {
-                OalLog.i(TAG, "Re-advertising: stopping the current SDP record")
-                btServer?.stop()
-                btServer = null
-                kotlinx.coroutines.delay(1_000)
-                startFromPreferences(ctx)
-                if (btServer?.isRunning == true) {
-                    OalLog.i(TAG, "Re-advertise complete — SDP record is live again")
-                } else {
-                    OalLog.w(TAG, "Re-advertise ran but no advertiser is running")
-                }
-            }.onFailure { OalLog.w(TAG, "Re-advertise failed: ${it.message}") }
+            try {
+                runCatching {
+                    OalLog.i(TAG, "Re-advertising: stopping the current SDP record")
+                    btServer?.stop()
+                    btServer = null
+                    kotlinx.coroutines.delay(1_000)
+                    startFromPreferences(ctx)
+                    if (btServer?.isRunning == true) {
+                        OalLog.i(TAG, "Re-advertise complete — SDP record is live again")
+                    } else {
+                        OalLog.w(TAG, "Re-advertise ran but no advertiser is running")
+                    }
+                }.onFailure { OalLog.w(TAG, "Re-advertise failed: ${it.message}") }
+            } finally {
+                releaseHandshakeAdmission(admissionToken)
+            }
         }
     }
 
     @Volatile
     private var appContext: Context? = null
 
-    /**
-     * Proxy port from the last successful companion lookup.
-     *
-     * Used to keep advertising the loopback endpoint through a transient lookup
-     * failure. The port is stable across reconnects — the companion keeps its
-     * proxy — whereas its IP is not.
-     */
-    /**
-     * Proxy port from the last successful lookup, PER PHONE (keyed by BT address).
-     *
-     * A single shared value silently mixes two phones up: 127.0.0.1:<port> only
-     * resolves on the device whose companion opened that port, so reusing phone
-     * A's port for phone B points B's Android Auto at a closed socket.
-     */
-    private val lastGoodProxyPortByPhone = java.util.concurrent.ConcurrentHashMap<String, Int>()
-
     /** The address each phone's companion last answered on, keyed by BT MAC. */
     private val lastAddressByPhone = java.util.concurrent.ConcurrentHashMap<String, String>()
-
-    /** When each phone's proxy port was last confirmed by an actual reply. */
-    private val lastPortConfirmedAt = java.util.concurrent.ConcurrentHashMap<String, Long>()
 
     /**
      * The phone currently holding the projection session, by BT address.
@@ -598,6 +551,12 @@ object AaWirelessBtControl {
      */
     @Volatile
     private var handshakeStartedAtMs: Long = 0L
+    private val activeHandshakeCount = java.util.concurrent.atomic.AtomicInteger(0)
+    private val handshakeStateLock = Any()
+    private var handshakeEpoch = 0L
+    private val handshakeAdmissionSequence = java.util.concurrent.atomic.AtomicLong(0)
+    @Volatile private var handshakeAdmissionBlocked = false
+    @Volatile private var handshakeAdmissionToken = 0L
 
     /**
      * True while a Bluetooth handshake is genuinely running.
@@ -613,22 +572,45 @@ object AaWirelessBtControl {
      * A handshake takes 0-9s in every successful run, so anything older than 30s
      * is finished regardless of what set it.
      */
-    var handshakeInFlight: Boolean
-        get() {
+    val handshakeInFlight: Boolean
+        get() = synchronized(handshakeStateLock) {
+            if (activeHandshakeCount.get() <= 0) return false
             val started = handshakeStartedAtMs
-            if (started == 0L) return false
-            if (System.currentTimeMillis() - started > HANDSHAKE_MAX_MS) {
-                OalLog.w(TAG, "handshakeInFlight was still set from " +
-                        "${(System.currentTimeMillis() - started) / 1000}s ago — " +
-                        "treating it as finished")
+            if (started != 0L && System.currentTimeMillis() - started > HANDSHAKE_MAX_MS) {
+                OalLog.w(TAG, "handshakeInFlight still had ${activeHandshakeCount.get()} " +
+                        "owner(s) from ${(System.currentTimeMillis() - started) / 1000}s ago — " +
+                        "treating them as finished")
+                activeHandshakeCount.set(0)
                 handshakeStartedAtMs = 0L
+                handshakeEpoch++
                 return false
             }
-            return true
+            true
         }
-        set(value) {
-            handshakeStartedAtMs = if (value) System.currentTimeMillis() else 0L
+
+    class HandshakeLease internal constructor(private val leaseEpoch: Long) {
+        private val finished = java.util.concurrent.atomic.AtomicBoolean(false)
+
+        fun finish() {
+            if (finished.compareAndSet(false, true)) {
+                AaWirelessBtControl.endHandshake(leaseEpoch)
+            }
         }
+    }
+
+    fun beginHandshake(): HandshakeLease? = synchronized(handshakeStateLock) {
+        if (handshakeAdmissionBlocked) return null
+        if (activeHandshakeCount.incrementAndGet() == 1) {
+            handshakeStartedAtMs = System.currentTimeMillis()
+        }
+        HandshakeLease(handshakeEpoch)
+    }
+
+    private fun endHandshake(leaseEpoch: Long) = synchronized(handshakeStateLock) {
+        if (leaseEpoch != handshakeEpoch) return
+        val remaining = activeHandshakeCount.updateAndGet { (it - 1).coerceAtLeast(0) }
+        if (remaining == 0) handshakeStartedAtMs = 0L
+    }
 
     @Volatile
     var activePhoneBt: String? = null
@@ -638,18 +620,15 @@ object AaWirelessBtControl {
     private var activePhoneClaimedAt: Long = 0L
 
     /**
-     * Forget everything learned about where the phone was, on ignition off.
+     * Reset attempt ownership on ignition off while retaining address hints.
      *
-     * The telematics module reassigns its AP a new subnet on every ignition
-     * cycle, so every cached address is guaranteed stale by the next start —
-     * one session held 10.2.110.109, 10.2.110.125 and 10.2.110.82, all dead.
-     * Carrying them over costs a probe round-trip each before the scan that was
-     * always going to be needed, right at the moment the car is trying to
-     * connect quickly.
+     * Address hints are retained because the AP is stable across ordinary ignition
+     * cycles and stale hints cost only a bounded probe before the attempt-owned
+     * scan. The subnet can still change across longer epochs, so every hint is
+     * filtered against the interfaces the car holds now.
      *
-     * Proxy ports go too: the companion opens a fresh listener on a new port
-     * each time its service starts, so a remembered port is not just stale, it
-     * would be advertised to Android Auto as a live endpoint.
+     * The companion proxy port is reserved and stable; reset only attempt-owned
+     * endpoint state while retaining address hints for the next ignition.
      */
     fun resetForNextIgnition() {
         // Snapshot the addresses BEFORE clearing them — the notify is async and
@@ -660,21 +639,22 @@ object AaWirelessBtControl {
         }.distinct()
         notifyCompanionOfShutdown(targets)
         releaseActivePhone()
-        // Keep the addresses. Only the PORT is reliably stale.
-        //
-        // Clearing them made every reconnect start blind, and a blind scan is
-        // exactly what fails on this car: at 20:53:14 the reconnect had no
-        // cached address, scanned for 5.3s, found nothing, and advertised the
-        // car's own unreachable address — Error 21 — while the companion sat at
-        // the same address it had used 90 seconds earlier and discovery found it
-        // three times over the next minute.
-        //
-        // The phone's address on the car AP is usually unchanged across an
-        // ignition cycle. If it has moved, a stale entry costs one probe; having
-        // no entry costs a full blind scan and a failed connection.
-        lastGoodProxyPortByPhone.clear()
-        handshakeInFlight = false
-        OalLog.i(TAG, "Cleared cached proxy ports, keeping known addresses " +
+        // Keep address hints across ignition. A stale address costs one bounded
+        // probe before the attempt-owned scan; clearing every address forces every
+        // restart to begin with a full blind /24 scan. Proxy ports are no longer
+        // cached: current companions reserve 5280, while an older companion's
+        // dynamic value is accepted only from a live identity reply.
+        bootstrapAttempt.set(null)
+        pendingLegacyReadvertise.set(null)
+        synchronized(handshakeStateLock) {
+            activeHandshakeCount.set(0)
+            handshakeStartedAtMs = 0L
+            handshakeEpoch++
+            // Do not clear an owned compatibility admission barrier here. Its
+            // re-advertise job is NonCancellable and only its generation token
+            // may reopen handshakes after the listener replacement completes.
+        }
+        OalLog.i(TAG, "Reset WPP attempt state, keeping known addresses " +
                 "(${(listOfNotNull(lastKnownPhoneIp) + recentPhoneIps).distinct().joinToString()})")
     }
 
@@ -1025,18 +1005,24 @@ object AaWirelessBtControl {
      * arguably better, since the phone is the AP there and the telematics module's
      * filtering is bypassed completely.
      */
-    private fun findCompanionOnAnySubnet(manualIp: String?): Pair<String, Int>? {
+    private fun findCompanionOnAnySubnet(
+        manualIp: String?,
+        overallTimeoutMs: Int = 20_000,
+    ): Pair<String, Int>? {
         val localIps = buildList {
             manualIp?.takeIf { it.isNotBlank() }?.let { add(it) }
             addAll(allLocalIpv4())
         }.distinct()
         if (localIps.isEmpty()) return null
 
+        val deadline = System.currentTimeMillis() + overallTimeoutMs
         for (ip in localIps) {
             val prefix = ip.substringBeforeLast('.', "")
             if (prefix.isEmpty()) continue
+            val remainingMs = (deadline - System.currentTimeMillis()).coerceAtLeast(1L).toInt()
             OalLog.i(TAG, "Scanning $prefix.0/24 for the companion")
-            scanSubnet(prefix, ip)?.let { return it }
+            scanSubnet(prefix, ip, remainingMs)?.let { return it }
+            if (System.currentTimeMillis() >= deadline) break
         }
         OalLog.w(TAG, "No companion on any local subnet (${localIps.joinToString()})")
         return null
@@ -1072,7 +1058,11 @@ object AaWirelessBtControl {
      * bridge is simply slow. With 128 threads a /24 still completes in about 2s
      * even when every address times out.
      */
-    private fun scanSubnet(prefix: String, ourIp: String): Pair<String, Int>? {
+    private fun scanSubnet(
+        prefix: String,
+        ourIp: String,
+        overallTimeoutMs: Int = 20_000,
+    ): Pair<String, Int>? {
         val pool = java.util.concurrent.Executors.newFixedThreadPool(128)
         return try {
             val tasks = (1..254)
@@ -1094,7 +1084,11 @@ object AaWirelessBtControl {
             // 3s cap cut a sweep off at 2.47s and reported "no companion" for one
             // the car had connected to 0.85s earlier. 20s leaves real headroom
             // and still returns immediately on the first hit.
-            pool.invokeAll(tasks, 20, java.util.concurrent.TimeUnit.SECONDS)
+            pool.invokeAll(
+                tasks,
+                overallTimeoutMs.toLong(),
+                java.util.concurrent.TimeUnit.MILLISECONDS,
+            )
                 .asSequence()
                 .mapNotNull { runCatching { it.get() }.getOrNull() }
                 .firstOrNull()
@@ -1206,9 +1200,9 @@ object AaWirelessBtControl {
                 .thenBy { if (isPrivate(it.addr)) 0 else 1 }
         ).first()
 
-        // Always log, not just when ambiguous: the car's AP subnet is reassigned
-        // by the telematics module on every restart, so the advertised address
-        // legitimately changes run to run and must be traceable in the logs.
+        // Always log, not just when ambiguous: the car AP has used several
+        // different subnets across multi-week epochs, so the value used by each
+        // handshake must remain visible even though it is usually stable per cycle.
         run {
             OalLog.i(TAG, "Local address candidates: " +
                     candidates.joinToString { "${it.name}=${it.addr}" } +
@@ -1257,9 +1251,9 @@ object AaWirelessBtControl {
         // stated plainly in the log, not inferred later from the phone's silence.
         val canAdvertise = bt.canAdvertise()
         OalLog.i(TAG, "SDP advertise capability: $canAdvertise")
-        // Re-resolve the address on every handshake rather than reusing the value
-        // captured here: the car's AP is given a new subnet on each ignition
-        // cycle, so this snapshot goes stale as soon as the car is restarted.
+        // Re-resolve on every handshake. The AP is usually stable across ignition
+        // cycles but has changed across longer epochs, so no cached address is a
+        // permanent source of truth.
         // Honour a manual override if one is set, otherwise look it up live.
         bt.setAddressResolver { manualIp ?: localIpv4Address(apInterface) }
 
@@ -1452,12 +1446,10 @@ object AaWirelessBtControl {
                     // companionIp. Guarded anyway, and loudly, because silently
                     // skipping the dial is the failure this caused — the car
                     // listened forever while the phone waited for a car socket.
-                    lastGoodProxyPortByPhone[phoneBtAddress] = proxyPort!!
-                    lastPortConfirmedAt[phoneBtAddress] = System.currentTimeMillis()
                     // Remember which companion belongs to the Bluetooth-connected
                     // phone so the UI can mark it in the discovery list.
                     activePhoneCompanionIp = companionIp
-                    lastEndpointWasCarDirect = false
+                    bootstrapAttempt.set(null)
                     OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy " +
                             "127.0.0.1:$proxyPort via companion at $companionIp " +
                             "phone=$phoneBtAddress — this is the working path")
@@ -1470,78 +1462,23 @@ object AaWirelessBtControl {
                     }
                     AaWirelessBtServer.Endpoint.PhoneLoopback(proxyPort)
                 }
-                // A companion WAS working a moment ago, so a single failed lookup
-                // is far more likely to be a transient network state than a real
-                // absence — the phone rejoining the AP takes seconds and its
-                // address changes. Falling back to CarDirect here locks in an
-                // endpoint the phone cannot reach through the car's AP, and every
-                // later attempt inherits it. Keep the loopback endpoint and let
-                // the next handshake resolve the new address.
-                // Only reuse a remembered port while it is plausibly still open.
-                //
-                // The companion picks a fresh ephemeral port every time its
-                // service restarts, so the port is the one value guaranteed to be
-                // wrong afterwards. Reusing it advertised 127.0.0.1:38485 when the
-                // companion had moved to 40715, and the phone got Error 21 dialling
-                // a port nothing was listening on.
-                //
-                // The branch is still right for what it was written for — a probe
-                // that blips mid-session, where falling back to the car-direct
-                // endpoint would be worse. That case resolves in seconds. A port
-                // that has not been confirmed for minutes is a different thing, and
-                // guessing wrong costs a failed connection rather than a slow one.
-                lastGoodProxyPortByPhone[phoneBtAddress] != null &&
-                        System.currentTimeMillis() - (lastPortConfirmedAt[phoneBtAddress] ?: 0L)
-                        < PROXY_PORT_TRUST_MS -> {
-                    lastEndpointWasCarDirect = false
-                    OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy (remembered " +
-                            "port) phone=$phoneBtAddress — companion did not answer this " +
-                            "time but its port is stable across reconnects")
-                    val port = lastGoodProxyPortByPhone.getValue(phoneBtAddress)
-                    OalLog.i(TAG, "Companion for $phoneBtAddress not found this time, " +
-                            "but it was on port $port — keeping the loopback endpoint " +
-                            "rather than falling back to an unreachable one")
-                    AaWirelessBtServer.Endpoint.PhoneLoopback(port)
-                }
                 else -> {
-                    // One line that says what this attempt decided and why, so a
-                    // failure is legible without reconstructing it from three
-                    // hundred scattered lines. Both of the last two bugs hid in
-                    // the gap between logging intent and logging outcome.
-                    OalLog.w(TAG, "CONNECT SUMMARY: endpoint=car-direct (UNREACHABLE " +
-                            "through the car's AP) phone=$phoneBtAddress " +
+                    // The phone is not on the car AP yet, so the companion cannot
+                    // answer. Use the port both new apps reserve in advance. WPP
+                    // moves the phone onto the AP, Android Auto can attach to its
+                    // local proxy immediately, and discovery then supplies the
+                    // car-side socket to that same waiting bridge.
+                    val attempt = BootstrapAttempt(phoneBtAddress,
+                        bootstrapAttemptSequence.incrementAndGet(),
+                    )
+                    bootstrapAttempt.set(attempt)
+                    OalLog.i(TAG, "CONNECT SUMMARY: endpoint=bootstrap-loopback " +
+                            "127.0.0.1:${OalProtocol.WPP_PROXY_PORT} phone=$phoneBtAddress " +
                             "knownAddrs=${allKnown.joinToString().ifEmpty { "none" }} " +
-                            "usable=${candidates.joinToString().ifEmpty { "none" }} " +
-                            "— projection will not start until the companion is found")
-                    // This is the endpoint the car's AP will not accept inbound.
-                    // Flagged so discovery can trigger a re-advertise the moment
-                    // it learns where the companion actually is.
-                    lastEndpointWasCarDirect = true
-                    // Keep probing in the background. The handshake itself must
-                    // stay fast — it completes in 0-9s in every successful run —
-                    // so it cannot sit and retry. But the reason it failed is
-                    // usually that it asked too early: this probe runs 1-3s after
-                    // the phone associated, and the AP bridge is not carrying
-                    // traffic for it yet. Measured, the same address answers
-                    // discovery reliably about 8s later.
-                    startBackgroundCompanionProbe(candidates)
-                    // No companion: advertise our own address, and pick the one on
-                    // the SAME network as the phone. The head unit has two radios
-                    // on different networks (telematics AP vs its own wlan0), so
-                    // "our IP" is ambiguous — naming the wrong one sends the phone
-                    // somewhere it cannot route to.
-                    val ip = manualIp
-                        ?: lastKnownPhoneIp?.let { phone ->
-                            val phonePrefix = phone.substringBeforeLast('.', "")
-                            allLocalIpv4().firstOrNull {
-                                it.substringBeforeLast('.', "") == phonePrefix
-                            }?.also {
-                                OalLog.i(TAG, "Advertising $it — same subnet as the phone ($phone)")
-                            }
-                        }
-                        ?: localIpv4Address(apInterface)
-                    if (ip.isNullOrBlank()) null
-                    else AaWirelessBtServer.Endpoint.CarDirect(ip, 5277)
+                            "usable=${candidates.joinToString().ifEmpty { "none" }} — " +
+                            "waiting for companion discovery after AP association")
+                    startBootstrapCompanionDiscovery(attempt, candidates, manualIp)
+                    AaWirelessBtServer.Endpoint.PhoneLoopback(OalProtocol.WPP_PROXY_PORT)
                 }
             }
         }

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -344,19 +344,20 @@ class AaWirelessBtServer(
                 // Flag it here rather than inside handleHandshake: the window that
                 // matters starts the instant the phone dials, and the coroutine
                 // may not be scheduled for several milliseconds.
-                AaWirelessBtControl.handshakeInFlight = true
-                scope.launch(CoroutineName("AaWirelessBt-Handshake")) {
-                    try {
-                        handleHandshake(client, remote)
-                    } finally {
-                        AaWirelessBtControl.handshakeInFlight = false
-                        // Run anything that asked to re-advertise while we were
-                        // busy. The probe usually finds the companion seconds
-                        // after a handshake has already committed to the
-                        // unreachable car-direct endpoint, and dropping that
-                        // request left the connection waiting on discovery.
-                        AaWirelessBtControl.flushPendingReadvertise()
-                    }
+                val handshakeLease = AaWirelessBtControl.beginHandshake()
+                if (handshakeLease == null) {
+                    OalLog.i(TAG, "Rejecting dial-back while compatibility re-advertise replaces SDP")
+                    runCatching { client.close() }
+                    continue
+                }
+                val handshakeJob = scope.launch(CoroutineName("AaWirelessBt-Handshake")) {
+                    handleHandshake(client, remote, handshakeLease)
+                }
+                handshakeJob.invokeOnCompletion {
+                    // This also runs when the coroutine is cancelled before its
+                    // body starts, so accepted sockets cannot leak ownership.
+                    handshakeLease.finish()
+                    AaWirelessBtControl.flushPendingReadvertise()
                 }
                 continue
             }
@@ -405,11 +406,9 @@ class AaWirelessBtServer(
     /**
      * Resolves the head unit's current IPv4 at handshake time.
      *
-     * Not a stored value. The car's access point is reassigned a new subnet on
-     * every ignition cycle (observed: 10.2.110.x one session, a different /24 the
-     * next), so an address captured when the app started is stale by the time the
-     * phone actually connects — and the phone would be told to dial an address
-     * that no longer exists.
+     * Not a stored value. The car AP is stable across ordinary ignition cycles but
+     * has used multiple subnets across multi-week epochs, so resolve at the moment
+     * of use instead of treating any historical address as permanent.
      */
     fun interface AddressResolver {
         fun currentIpv4(): String?
@@ -448,9 +447,9 @@ class AaWirelessBtServer(
     /**
      * Supplies the endpoint at handshake time.
      *
-     * Resolved per handshake, not cached: the companion's proxy port changes
-     * every time it restarts, and the car's AP subnet changes every ignition
-     * cycle. A value captured at start-up is stale by the time the phone calls.
+     * Resolved per handshake rather than trusting a cached companion address: the
+     * phone's AP address can change even though the reserved loopback port is stable,
+     * and the car's AP subnet can change across ignition cycles.
      */
     fun interface EndpointResolver {
         /**
@@ -478,7 +477,11 @@ class AaWirelessBtServer(
         addressResolver = resolver
     }
 
-    private suspend fun handleHandshake(socket: BluetoothSocket, phoneBtAddress: String) {
+    private suspend fun handleHandshake(
+        socket: BluetoothSocket,
+        phoneBtAddress: String,
+        handshakeLease: AaWirelessBtControl.HandshakeLease,
+    ) {
         val stored = credentials
         if (stored == null) {
             OalLog.w(TAG, "Handshake attempted with no credentials set — closing. " +
@@ -657,7 +660,7 @@ class AaWirelessBtServer(
             //
             // The window the guard protects ends here: the phone has the endpoint
             // and is about to dial it.
-            AaWirelessBtControl.handshakeInFlight = false
+            handshakeLease.finish()
             AaWirelessBtControl.flushPendingReadvertise()
 
             // Hold the RFCOMM socket open. The phone keeps it as the control link

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicy.kt
@@ -1,0 +1,25 @@
+package com.openautolink.app.transport.bluetooth
+
+enum class LateCompanionAction {
+    DIAL_COMPANION,
+    QUEUE_READVERTISE,
+    READVERTISE,
+    IGNORE,
+}
+
+object WppBootstrapPolicy {
+    /** Must finish before AaProxy's 30-second pre-warm car-socket waiter. */
+    const val DISCOVERY_DEADLINE_MS = 20_000L
+
+    fun onCompanionReachable(
+        bootstrapLoopbackPending: Boolean,
+        usesReservedProxyPort: Boolean,
+        handshakeInFlight: Boolean,
+        sessionStreaming: Boolean,
+    ): LateCompanionAction = when {
+        sessionStreaming || !bootstrapLoopbackPending -> LateCompanionAction.IGNORE
+        usesReservedProxyPort -> LateCompanionAction.DIAL_COMPANION
+        handshakeInFlight -> LateCompanionAction.QUEUE_READVERTISE
+        else -> LateCompanionAction.READVERTISE
+    }
+}

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -391,7 +391,7 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
                 label = { Text("Head unit IP (optional)") },
                 singleLine = true,
                 supportingText = {
-                    Text("Leave blank — this is detected automatically each time. Only set it to diagnose a one-off problem, and clear it afterwards: the car's hotspot subnet changes on every restart, so a fixed value here will stop working.")
+                    Text("Leave blank — this is detected automatically each time. Only set it to diagnose a one-off problem, and clear it afterwards: the car's hotspot subnet is stable across ignition cycles but can change across multi-week epochs, so a fixed value will eventually stop working.")
                 },
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
             )

--- a/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
+++ b/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
@@ -27,7 +27,8 @@ import java.util.concurrent.atomic.AtomicLong
  */
 class MediaCodecDecoder(
     private val codecPreference: String = "h264",
-    private val scalingMode: String = "letterbox" // "letterbox" or "crop"
+    private val scalingMode: String = "letterbox", // "letterbox" or "crop"
+    private val onSessionRestartNeeded: (String) -> Unit = {},
 ) : VideoDecoder {
 
     companion object {
@@ -256,6 +257,11 @@ class MediaCodecDecoder(
     @Volatile private var outputFormatReceived = false
 
     override fun attach(surface: Surface, width: Int, height: Int) {
+        if (!surface.isValid) {
+            Log.w(TAG, "Ignoring invalid output surface ${width}x${height}")
+            DiagnosticLog.w("video", "Invalid output surface ignored: ${width}x${height}")
+            return
+        }
         val surfaceChanged = this.surface !== surface
         this.surface = surface
         this.surfaceWidth = width
@@ -275,19 +281,34 @@ class MediaCodecDecoder(
             // setOutputSurface throws on null and detach() sets the field null.
             val target = surface ?: return
             val swapped = runCatching { codec?.setOutputSurface(target) }.isSuccess
-            if (swapped) {
-                inputPaused = false
-                Log.i(TAG, "Swapped output surface on the live codec — no reconfigure needed")
-                DiagnosticLog.i("video", "Output surface swapped on live codec — video resumes immediately")
-                // The chain was never broken, so nothing to re-anchor.
-                awaitingFreshIdr = false
-                renderingEnabled = true
-                return
+            when (SurfaceRecoveryPolicy.afterSwap(
+                swapSucceeded = swapped,
+                hasCachedRealIdr = cachedIdrFrame != null,
+            )) {
+                SurfaceRecoveryAction.KEEP_LIVE_CODEC -> {
+                    inputPaused = false
+                    Log.i(TAG, "Swapped output surface on the live codec — no reconfigure needed")
+                    DiagnosticLog.i("video", "Output surface swapped on live codec — video resumes immediately")
+                    // The chain was never broken, so nothing to re-anchor.
+                    awaitingFreshIdr = false
+                    renderingEnabled = true
+                    return
+                }
+                SurfaceRecoveryAction.RESTART_SESSION -> {
+                    inputPaused = false
+                    Log.w(TAG, "setOutputSurface rejected with no cached real IDR — restarting the AA session")
+                    DiagnosticLog.w("video", "Output surface swap failed without cached IDR — restarting session")
+                    releaseCodec()
+                    onSessionRestartNeeded("surface swap rejected without cached IDR")
+                    return
+                }
+                SurfaceRecoveryAction.RECONFIGURE_WITH_CACHED_IDR -> {
+                    inputPaused = false
+                    Log.w(TAG, "setOutputSurface rejected — reconfiguring from the cached real IDR")
+                    DiagnosticLog.w("video", "setOutputSurface rejected — reconfiguring codec from cached IDR")
+                    releaseCodec()
+                }
             }
-            inputPaused = false
-            Log.w(TAG, "setOutputSurface rejected — falling back to a codec reconfigure")
-            DiagnosticLog.w("video", "setOutputSurface rejected — reconfiguring codec")
-            releaseCodec()
         }
 
         // Only reconfigure codec if the Surface object itself changed (e.g., after surfaceDestroyed).

--- a/app/src/main/java/com/openautolink/app/video/SurfaceRecoveryPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/video/SurfaceRecoveryPolicy.kt
@@ -1,0 +1,19 @@
+package com.openautolink.app.video
+
+enum class SurfaceRecoveryAction {
+    KEEP_LIVE_CODEC,
+    RECONFIGURE_WITH_CACHED_IDR,
+    RESTART_SESSION,
+}
+
+/** Chooses the least disruptive recovery that can produce a picture. */
+object SurfaceRecoveryPolicy {
+    fun afterSwap(
+        swapSucceeded: Boolean,
+        hasCachedRealIdr: Boolean,
+    ): SurfaceRecoveryAction = when {
+        swapSucceeded -> SurfaceRecoveryAction.KEEP_LIVE_CODEC
+        hasCachedRealIdr -> SurfaceRecoveryAction.RECONFIGURE_WITH_CACHED_IDR
+        else -> SurfaceRecoveryAction.RESTART_SESSION
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/WppProxyPortContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/WppProxyPortContractTest.kt
@@ -1,0 +1,11 @@
+package com.openautolink.app.transport
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WppProxyPortContractTest {
+    @Test
+    fun `car advertises the companion reserved loopback port`() {
+        assertEquals(5280, OalProtocol.WPP_PROXY_PORT)
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/ReconnectSingleFlightGateTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/ReconnectSingleFlightGateTest.kt
@@ -1,0 +1,53 @@
+package com.openautolink.app.transport.aasdk
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReconnectSingleFlightGateTest {
+
+    @Test
+    fun `first reconnect enters the gate`() {
+        val gate = ReconnectSingleFlightGate()
+        assertTrue(gate.tryStart())
+    }
+
+    @Test
+    fun `overlapping reconnect is rejected`() {
+        val gate = ReconnectSingleFlightGate()
+        assertTrue(gate.tryStart())
+        assertFalse(gate.tryStart())
+    }
+
+    @Test
+    fun `finished reconnect allows a later attempt`() {
+        val gate = ReconnectSingleFlightGate()
+        assertTrue(gate.tryStart())
+        gate.finish()
+        assertTrue(gate.tryStart())
+    }
+
+    @Test
+    fun `force reconnect is guarded and releases after the teardown window`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val function = source.substringAfter("fun forceReconnect(reason: String)")
+            .substringBefore("// -- Input forwarding")
+
+        assertTrue(function.contains("if (!forceReconnectGate.tryStart())"))
+        assertTrue(function.contains("delay(FORCE_RECONNECT_GUARD_MS)"))
+        assertTrue(function.contains("forceReconnectGate.finish()"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
@@ -1,0 +1,186 @@
+package com.openautolink.app.transport.bluetooth
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppBootstrapPolicyTest {
+
+    @Test
+    fun `reserved proxy dials immediately while WPP handshake runs`() {
+        assertEquals(
+            LateCompanionAction.DIAL_COMPANION,
+            WppBootstrapPolicy.onCompanionReachable(
+                bootstrapLoopbackPending = true,
+                usesReservedProxyPort = true,
+                handshakeInFlight = true,
+                sessionStreaming = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy dynamic proxy queues readvertise until handshake completes`() {
+        assertEquals(
+            LateCompanionAction.QUEUE_READVERTISE,
+            WppBootstrapPolicy.onCompanionReachable(
+                bootstrapLoopbackPending = true,
+                usesReservedProxyPort = false,
+                handshakeInFlight = true,
+                sessionStreaming = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy dynamic proxy readvertises after handshake`() {
+        assertEquals(
+            LateCompanionAction.READVERTISE,
+            WppBootstrapPolicy.onCompanionReachable(
+                bootstrapLoopbackPending = true,
+                usesReservedProxyPort = false,
+                handshakeInFlight = false,
+                sessionStreaming = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `late companion cannot replace a streaming session`() {
+        assertEquals(
+            LateCompanionAction.IGNORE,
+            WppBootstrapPolicy.onCompanionReachable(
+                bootstrapLoopbackPending = true,
+                usesReservedProxyPort = true,
+                handshakeInFlight = false,
+                sessionStreaming = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate discovery is ignored after bootstrap ownership is consumed`() {
+        assertEquals(
+            LateCompanionAction.IGNORE,
+            WppBootstrapPolicy.onCompanionReachable(
+                bootstrapLoopbackPending = false,
+                usesReservedProxyPort = true,
+                handshakeInFlight = false,
+                sessionStreaming = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `bootstrap discovery deadline fits inside companion waiter`() {
+        assertTrue(WppBootstrapPolicy.DISCOVERY_DEADLINE_MS < 30_000L)
+    }
+
+    @Test
+    fun `AP bootstrap advertises stable loopback instead of the blocked car address`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        assertTrue(source.contains("val attempt = BootstrapAttempt(phoneBtAddress"))
+        assertTrue(
+            source.contains(
+                "AaWirelessBtServer.Endpoint.PhoneLoopback(OalProtocol.WPP_PROXY_PORT)",
+            ),
+        )
+    }
+
+    @Test
+    fun `attempt owned scanner runs even with no cached candidates`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+        val scanner = source.substringAfter("private fun startBootstrapCompanionDiscovery(")
+            .substringBefore("private val backgroundProbeRunning")
+
+        assertTrue(scanner.contains("bootstrapAttempt.get() !== attempt"))
+        assertTrue(scanner.contains("val remainingMs = (deadline - System.currentTimeMillis())"))
+        assertTrue(scanner.contains("findCompanionOnAnySubnet(manualIp, remainingMs)"))
+        assertTrue(scanner.contains("WppBootstrapPolicy.DISCOVERY_DEADLINE_MS"))
+        assertTrue(scanner.contains("readvertiseForNewCompanionAddress(ip, proxyPort, attempt)"))
+    }
+
+    @Test
+    fun `bootstrap ownership is consumed atomically before dialing`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        assertTrue(source.contains("java.util.concurrent.atomic.AtomicReference<BootstrapAttempt?>"))
+        assertTrue(source.contains("bootstrapAttempt.compareAndSet(attempt, null)"))
+        assertTrue(source.contains("onCompanionSelected?.invoke(host)"))
+    }
+
+    @Test
+    fun `each Bluetooth handshake uses an idempotent ownership lease`() {
+        val server = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt",
+        ).readText()
+        val control = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        assertTrue(server.contains("val handshakeLease = AaWirelessBtControl.beginHandshake()"))
+        assertTrue(server.contains("if (handshakeLease == null)"))
+        assertTrue(server.contains("val handshakeJob = scope.launch"))
+        assertTrue(server.contains("handshakeJob.invokeOnCompletion"))
+        assertEquals(2, "handshakeLease.finish()".toRegex().findAll(server).count())
+        assertTrue(control.contains("finished.compareAndSet(false, true)"))
+        assertTrue(control.contains("private var handshakeEpoch = 0L"))
+        assertTrue(control.contains("HandshakeLease(handshakeEpoch)"))
+        assertTrue(control.contains("if (leaseEpoch != handshakeEpoch) return"))
+        assertTrue(control.contains("handshakeEpoch++"))
+        assertTrue(control.contains("activeHandshakeCount.incrementAndGet()"))
+    }
+
+    @Test
+    fun `legacy compatibility queue retains exact attempt ownership`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        assertTrue(source.contains("synchronized(handshakeStateLock)"))
+        assertTrue(source.contains("handshakeAdmissionBlocked = true"))
+        assertTrue(source.contains("handshakeAdmissionToken == admissionToken"))
+        assertTrue(source.contains("readvertise(admissionToken)"))
+        assertTrue(source.contains("handshakeAdmissionBlocked = false"))
+        assertTrue(source.contains("if (handshakeAdmissionBlocked) return null"))
+        assertTrue(source.contains("PendingLegacyReadvertise(host, proxyPort, attempt)"))
+        val queueBranch = source.substringAfter("LateCompanionAction.QUEUE_READVERTISE ->")
+            .substringBefore("LateCompanionAction.READVERTISE ->")
+        assertTrue(queueBranch.contains("flushPendingReadvertise()"))
+        assertTrue(source.contains("if (activeHandshakeCount.get() > 0 || handshakeAdmissionBlocked) return"))
+        assertTrue(source.contains("activeHandshakeCount.incrementAndGet()"))
+        assertTrue(
+            source.contains(
+                "bootstrapAttempt.compareAndSet(candidate.attempt, null)",
+            ),
+        )
+    }
+
+    @Test
+    fun `discovery preserves the companion reported proxy port`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
+        ).readText()
+
+        assertTrue(source.contains("publishPhoneAddress(ip, ident.wppProxyPort)"))
+        assertTrue(source.contains("readvertiseForNewCompanionAddress(host, reportedProxyPort)"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/video/SurfaceRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/video/SurfaceRecoveryPolicyTest.kt
@@ -1,0 +1,101 @@
+package com.openautolink.app.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SurfaceRecoveryPolicyTest {
+
+    @Test
+    fun `successful surface swap keeps the live session`() {
+        assertEquals(
+            SurfaceRecoveryAction.KEEP_LIVE_CODEC,
+            SurfaceRecoveryPolicy.afterSwap(
+                swapSucceeded = true,
+                hasCachedRealIdr = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `rejected swap with cached real IDR reconfigures locally`() {
+        assertEquals(
+            SurfaceRecoveryAction.RECONFIGURE_WITH_CACHED_IDR,
+            SurfaceRecoveryPolicy.afterSwap(
+                swapSucceeded = false,
+                hasCachedRealIdr = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `rejected swap without cached real IDR restarts the session`() {
+        assertEquals(
+            SurfaceRecoveryAction.RESTART_SESSION,
+            SurfaceRecoveryPolicy.afterSwap(
+                swapSucceeded = false,
+                hasCachedRealIdr = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `media decoder routes unrecoverable surface fallback to session restart`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt",
+        ).readText()
+        val attach = source.substringAfter("override fun attach(surface: Surface")
+            .substringBefore("override fun detach()")
+
+        assertTrue(attach.contains("SurfaceRecoveryPolicy.afterSwap("))
+        assertTrue(attach.contains("hasCachedRealIdr = cachedIdrFrame != null"))
+        assertTrue(attach.contains("SurfaceRecoveryAction.RESTART_SESSION"))
+        assertTrue(attach.contains("onSessionRestartNeeded("))
+    }
+
+    @Test
+    fun `session manager performs surface recovery restart off the main thread`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+
+        assertTrue(source.contains("onSessionRestartNeeded = { reason ->"))
+        assertTrue(source.contains("scope.launch(kotlinx.coroutines.Dispatchers.IO)"))
+        assertTrue(source.contains("targetSession.forceReconnect(reason)"))
+    }
+
+    @Test
+    fun `stale decoder callback cannot restart a replacement session`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+
+        assertTrue(source.contains("val decoderGeneration = videoDecoderGeneration.incrementAndGet()"))
+        assertTrue(source.contains("decoderGeneration != videoDecoderGeneration.get()"))
+        assertTrue(source.contains("aasdkSession !== targetSession"))
+    }
+
+    @Test
+    fun `invalid surfaces are never stored or attached`() {
+        val manager = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+        val decoder = projectFile(
+            "app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt",
+        ).readText()
+
+        assertTrue(manager.contains("surface?.takeIf { it.isValid"))
+        assertTrue(decoder.contains("if (!surface.isValid)"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt
@@ -3,6 +3,7 @@ package com.openautolink.companion.connection
 import com.openautolink.companion.diagnostics.CompanionLog
 import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.diagnostics.PhoneWppStage
+import com.openautolink.companion.service.TcpAdvertiser
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -67,7 +68,7 @@ class AaProxy(
      * bridge coroutine starts — including while it is parked in [awaitPendingCarSocket]
      * waiting for the car. Reporting "active" during that wait made
      * TcpAdvertiser.handleCarConnection() skip its socket-swap path and instead
-     * stop() the proxy and re-listen on a NEW port, tearing the socket out from under
+     * stop() the proxy and re-listen on a NEW socket, tearing the socket out from under
      * the AA reader that was already attached (gearhead: "ReaderThread: end of stream
      * received, dataReceived=false" -> FRAMER_READ_END_OF_STREAM_NO_DATA ->
      * PROTOCOL_IO_ERROR(3)/READER_CLOSE(52)). Observed 2026-07-25.
@@ -89,7 +90,7 @@ class AaProxy(
      * look identical at the socket level until something times out, and the
      * recovery for each is the opposite: a glitch wants the car socket kept for
      * reuse, a shutdown wants everything dropped so the next ignition starts
-     * clean on a new subnet, a new phone address and a new proxy port.
+     * clean on a new subnet and a new phone address.
      */
     @Volatile private var carGoneForGood: Boolean = false
 
@@ -137,9 +138,9 @@ class AaProxy(
     val isAccepting: Boolean
         get() = isRunning && serverSocket?.isClosed == false
 
-    /** Start the proxy server. Returns the localhost port AA should connect to. */
+    /** Start the proxy server. Returns the stable localhost port AA connects to. */
     fun start(): Int {
-        val server = ServerSocket(0)
+        val server = WppProxySocketBinder.bind()
         serverSocket = server
         isRunning = true
 
@@ -185,7 +186,7 @@ class AaProxy(
                 // socket is in hand: while parked below this proxy must still
                 // report "not active" so an arriving car socket is swapped in
                 // here instead of causing TcpAdvertiser to stop() us and rebind
-                // on a fresh port (which would EOF the AA reader attached above).
+                // a fresh socket (which would EOF the AA reader attached above).
                 carSocket = pendingCarSocket?.also { pendingCarSocket = null }
                     ?: preConnectedSocket
                     ?: awaitPendingCarSocket(PREWARM_CAR_WAIT_MS)

--- a/companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt
@@ -1,0 +1,21 @@
+package com.openautolink.companion.connection
+
+import com.openautolink.companion.service.TcpAdvertiser
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+
+/** Binds the phone-local endpoint Android Auto receives through WPP. */
+object WppProxySocketBinder {
+    fun bind(): ServerSocket {
+        val server = ServerSocket()
+        server.reuseAddress = true
+        server.bind(
+            InetSocketAddress(
+                InetAddress.getByName("127.0.0.1"),
+                TcpAdvertiser.WPP_PROXY_PORT,
+            ),
+        )
+        return server
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -43,6 +43,11 @@ class TcpAdvertiser(
         private const val TAG = "OAL_TcpAdv"
         const val PORT = 5277
         /**
+         * Reserved phone-local AA proxy endpoint advertised during AP-only bootstrap.
+         * The car mirrors this as OalProtocol.WPP_PROXY_PORT.
+         */
+        const val WPP_PROXY_PORT = 5280
+        /**
          * Dedicated single-purpose port for the identity probe. The companion
          * answers `OAL?\n` with `OAL!{phone_id}\t{friendly_name}\n`. Used by
          * the car's subnet sweep + last-known-IP fallback when mDNS is
@@ -201,8 +206,8 @@ class TcpAdvertiser(
                     }
                 },
             )
-            activeProxy = proxy
             val port = proxy.start()
+            activeProxy = proxy
             if (port > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
             CompanionLog.i(TAG, "Started proxy for WPP on localhost:$port")
             port
@@ -248,9 +253,9 @@ class TcpAdvertiser(
                         }
                     },
                 )
-                activeProxy = proxy
                 isLaunching = true
                 val localPort = proxy.start()
+                activeProxy = proxy
                 if (localPort > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
                 // Do NOT tell Android Auto to connect yet.
                 //
@@ -581,8 +586,8 @@ class TcpAdvertiser(
                         }
                     },
                 )
-                activeProxy = proxy
                 val localPort = proxy.start()
+                activeProxy = proxy
                 if (localPort > 0) PhoneWppDiagnostics.record(PhoneWppStage.WARM_PROXY_READY)
 
                 fireAaLaunchIntent(localPort)

--- a/companion/src/test/java/com/openautolink/companion/connection/WppProxyPortContractTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/connection/WppProxyPortContractTest.kt
@@ -1,0 +1,72 @@
+package com.openautolink.companion.connection
+
+import com.openautolink.companion.service.TcpAdvertiser
+import java.io.File
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppProxyPortContractTest {
+
+    @Test
+    fun `WPP proxy uses the reserved loopback port`() {
+        assertEquals(5280, TcpAdvertiser.WPP_PROXY_PORT)
+
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt",
+        ).readText()
+        assertTrue(source.contains("InetAddress.getByName(\"127.0.0.1\")"))
+        assertTrue(source.contains("TcpAdvertiser.WPP_PROXY_PORT"))
+        assertTrue(source.contains("server.bind("))
+    }
+
+    @Test
+    fun `proxy accepts an IPv4 loopback connection on the reserved port`() {
+        val server = WppProxySocketBinder.bind()
+        try {
+            val port = server.localPort
+            assertEquals(TcpAdvertiser.WPP_PROXY_PORT, port)
+            Socket().use { client ->
+                client.connect(
+                    InetSocketAddress(InetAddress.getByName("127.0.0.1"), port),
+                    1_000,
+                )
+                assertTrue(client.isConnected)
+            }
+        } finally {
+            server.close()
+        }
+    }
+
+    @Test
+    fun `failed bind cannot publish an unstarted active proxy`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+
+        val ensure = source.substringAfter("private fun ensureProxyForWpp(): Int")
+            .substringBefore("fun preWarmAaPipeline()")
+        assertTrue(ensure.indexOf("val port = proxy.start()") < ensure.indexOf("activeProxy = proxy"))
+
+        val prewarm = source.substringAfter("fun preWarmAaPipeline()")
+            .substringBefore("private fun startIdentityServer()")
+        assertTrue(prewarm.indexOf("val localPort = proxy.start()") < prewarm.indexOf("activeProxy = proxy"))
+
+        val launch = source.substringAfter("private fun launchAndroidAuto(carSocket: Socket)")
+            .substringBefore("private fun startAaConnectWatchdog")
+        assertTrue(launch.indexOf("val localPort = proxy.start()") < launch.indexOf("activeProxy = proxy"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+}


### PR DESCRIPTION
1|## Summary
2|
3|Fixes two defects found in the first 0.1.437 AP-only in-car test:
4|
5|- avoid the initial blocked car-direct WPP endpoint/Error 21 by reserving a stable phone-local proxy at `127.0.0.1:5280`, then completing the same attempt when the companion appears on the car AP;
6|- recover promptly when a background/foreground surface swap is rejected and no cached real IDR can re-anchor the decoder, rather than waiting for Gearhead's next periodic IDR.
7|
8|## AP-only evidence
9|
10|With car home Wi-Fi disconnected and phone hotspot off, the 0.1.437 restart:
11|
12|- advertised the blocked car-direct endpoint after 16.560s;
13|- found the companion 2.017s later, after WPP moved the phone onto the car AP;
14|- needed a second WPP exchange;
15|- reached native session at +25.310s and first frame at +28.426s.
16|
17|The revised design:
18|
19|- binds the companion proxy to IPv4 loopback port 5280;
20|- advertises that reserved endpoint on the first WPP exchange;
21|- runs an attempt-owned, 20-second bounded scanner even with an empty address cache;
22|- atomically consumes a unique phone+generation attempt before dialing;
23|- gives an older 0.1.437 companion one compatibility re-advertise using its reported dynamic port.
24|
25|## Surface recovery evidence
26|
27|During the same test:
28|
29|- the surface detached for 15.344s;
30|- the live Qualcomm codec entered an error state 44ms after detach;
31|- `setOutputSurface()` was rejected on return;
32|- local reconfiguration had no cached real IDR;
33|- frames continued, so the no-frame watchdog could not fire;
34|- video returned only when a 138,150-byte periodic IDR arrived 97.720s later.
35|
36|The fallback now restarts the AA session only when the swap is rejected and no cached real IDR exists. Successful swaps and cached-IDR recovery remain local. Decoder generation/session identity checks reject stale callbacks, invalid surfaces are ignored, and force-reconnect is single-flight.
37|
38|## Verification
39|
40|- app: 37 suites, 306 tests, 0 failures/errors/skips;
41|- companion: 3 suites, 35 tests, 0 failures/errors/skips;
42|- executable JVM test binds and connects to `127.0.0.1:5280`;
43|- app and companion debug APKs assembled from scratch;
44|- expected runtime markers and port constant found in APK DEX;
45|- `git diff --check` clean;
46|- added-line credential/process/world-bind scan clean.
47|
48|The code is build/test verified. AP-only first-attempt behavior and surface-return recovery remain pending the next in-car cycle.
49|