### PR TITLE
fix(companion): bind car-facing listeners to the WPP network

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt
+++ b/companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt
@@ -1,5 +1,6 @@
 package com.openautolink.companion.connection
 
+import com.openautolink.companion.network.ProcessNetworkBindingLock
 import com.openautolink.companion.service.TcpAdvertiser
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -7,7 +8,7 @@ import java.net.ServerSocket
 
 /** Binds the phone-local endpoint Android Auto receives through WPP. */
 object WppProxySocketBinder {
-    fun bind(): ServerSocket {
+    fun bind(): ServerSocket = ProcessNetworkBindingLock.withLock {
         val server = ServerSocket()
         server.reuseAddress = true
         server.bind(
@@ -16,6 +17,6 @@ object WppProxySocketBinder {
                 TcpAdvertiser.WPP_PROXY_PORT,
             ),
         )
-        return server
+        server
     }
 }

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
@@ -1,7 +1,9 @@
 package com.openautolink.companion.diagnostics
 
 import android.content.Context
+import android.net.ConnectivityManager
 import android.os.Build
+import com.openautolink.companion.network.ProcessNetworkBindingLock
 import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
@@ -103,7 +105,13 @@ class LogUploader(private val context: Context) {
         val origName = "oal_companion_$stamp.zip"
 
         return try {
-            val conn = (URL(url).openConnection() as HttpURLConnection).apply {
+            val endpoint = URL(url)
+            val connectivityManager = context.applicationContext
+                .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val defaultNetwork = ProcessNetworkBindingLock.withLock {
+                connectivityManager.activeNetwork
+            } ?: return UploadResult.Failure("no default network")
+            val conn = (defaultNetwork.openConnection(endpoint) as HttpURLConnection).apply {
                 requestMethod = "POST"
                 doOutput = true
                 connectTimeout = CONNECT_TIMEOUT_MS

--- a/companion/src/main/java/com/openautolink/companion/network/CarNetworkBindingPolicy.kt
+++ b/companion/src/main/java/com/openautolink/companion/network/CarNetworkBindingPolicy.kt
@@ -1,0 +1,105 @@
+package com.openautolink.companion.network
+
+/**
+ * Selects the Wi-Fi network that owns the car-facing listeners.
+ *
+ * A companion-requested network is authoritative because it came from the exact
+ * WifiNetworkSpecifier callback. Without that signal, WPP-owned association is
+ * accepted only after a local-only Wi-Fi network has been correlated with an
+ * active WPP startup attempt. Ordinary internet and unrelated local Wi-Fi are
+ * never guessed to be the car network.
+ */
+class CarNetworkSelector<T> {
+    private data class Candidate(
+        val hasInternet: Boolean,
+        val hasUsableIpv4: Boolean,
+        val correlatedWithWpp: Boolean,
+    )
+
+    private val candidates = linkedMapOf<T, Candidate>()
+    private var preferredNetwork: T? = null
+
+    var selectedNetwork: T? = null
+        private set
+
+    fun observe(
+        network: T,
+        hasInternet: Boolean,
+        hasUsableIpv4: Boolean,
+        correlatedWithWpp: Boolean,
+    ) {
+        candidates[network] = Candidate(
+            hasInternet = hasInternet,
+            hasUsableIpv4 = hasUsableIpv4,
+            correlatedWithWpp = correlatedWithWpp,
+        )
+        reconcile()
+    }
+
+    fun lost(network: T) {
+        candidates.remove(network)
+        reconcile()
+    }
+
+    fun prefer(network: T?) {
+        preferredNetwork = network
+        reconcile()
+    }
+
+    private fun reconcile() {
+        val preferred = preferredNetwork
+        if (preferred != null && candidates[preferred]?.hasUsableIpv4 == true) {
+            selectedNetwork = preferred
+            return
+        }
+
+        val current = selectedNetwork
+        if (current != null && candidates[current]?.isInferredCarNetwork == true) {
+            return
+        }
+
+        selectedNetwork = candidates.entries
+            .firstOrNull { it.value.isInferredCarNetwork }
+            ?.key
+    }
+
+    private val Candidate.isInferredCarNetwork: Boolean
+        get() = correlatedWithWpp && hasUsableIpv4 && !hasInternet
+}
+
+/** Generation token for asynchronous listener replacement. */
+data class ListenerBindingTicket<T>(
+    val generation: Long,
+    val target: T?,
+    val previousTarget: T?,
+)
+
+/**
+ * Makes listener replacement idempotent and prevents stale bind completions from
+ * publishing sockets after a newer network transition or final stop.
+ */
+class ListenerBindingGenerations<T> {
+    private var generation = 0L
+    private var initialized = false
+    private var target: T? = null
+
+    @Synchronized
+    fun replaceWith(newTarget: T?): ListenerBindingTicket<T>? {
+        if (initialized && newTarget == target) return null
+        val previousTarget = target
+        initialized = true
+        target = newTarget
+        generation += 1L
+        return ListenerBindingTicket(generation, newTarget, previousTarget)
+    }
+
+    @Synchronized
+    fun owns(ticket: ListenerBindingTicket<T>): Boolean =
+        ticket.generation == generation && ticket.target == target
+
+    @Synchronized
+    fun stop() {
+        generation += 1L
+        target = null
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/network/CarNetworkMonitor.kt
+++ b/companion/src/main/java/com/openautolink/companion/network/CarNetworkMonitor.kt
@@ -1,0 +1,152 @@
+package com.openautolink.companion.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
+import java.net.Inet4Address
+
+/**
+ * Observes Wi-Fi networks for the service lifetime and selects the network that
+ * should own the car-facing listeners.
+ *
+ * This observer is passive: Gearhead or CarWifiManager owns association. The
+ * exact CarWifiManager network may be supplied through [prefer]. Otherwise a
+ * local-only WifiNetworkSpecifier network observed during an active WPP startup
+ * attempt is retained as the WPP candidate; unrelated Wi-Fi is ignored.
+ */
+class CarNetworkMonitor(
+    context: Context,
+    private val onSelectedNetworkChanged: (Network?) -> Unit,
+) {
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val selector = CarNetworkSelector<Network>()
+    private val wppCorrelatedNetworks = mutableSetOf<Network>()
+    private var callback: ConnectivityManager.NetworkCallback? = null
+    private var started = false
+    private var publishedNetwork: Network? = null
+
+    @Synchronized
+    fun start() {
+        if (started) return
+        started = true
+        val networkCallback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) = refresh(network)
+
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities,
+            ) = refresh(network, networkCapabilities = networkCapabilities)
+
+            override fun onLinkPropertiesChanged(
+                network: Network,
+                linkProperties: LinkProperties,
+            ) = refresh(network, linkProperties = linkProperties)
+
+            override fun onLost(network: Network) {
+                synchronized(this@CarNetworkMonitor) {
+                    if (!started) return
+                    wppCorrelatedNetworks.remove(network)
+                    selector.lost(network)
+                    publishIfChanged()
+                }
+            }
+        }
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+        try {
+            connectivityManager.registerNetworkCallback(request, networkCallback)
+            callback = networkCallback
+            CompanionLog.d(TAG, "Passive car-network binding observer registered")
+        } catch (e: Exception) {
+            CompanionLog.w(TAG, "Car-network binding observer unavailable: ${e.message}")
+        }
+    }
+
+    @Synchronized
+    fun prefer(network: Network?) {
+        if (!started) return
+        if (network != null) refresh(network)
+        selector.prefer(network)
+        publishIfChanged()
+    }
+
+    @Synchronized
+    fun stop() {
+        started = false
+        callback?.let { networkCallback ->
+            try {
+                connectivityManager.unregisterNetworkCallback(networkCallback)
+            } catch (_: Exception) {
+            }
+        }
+        callback = null
+        CompanionLog.d(TAG, "Passive car-network binding observer stopped")
+    }
+
+    @Synchronized
+    private fun refresh(
+        network: Network,
+        networkCapabilities: NetworkCapabilities? = null,
+        linkProperties: LinkProperties? = null,
+    ) {
+        if (!started) return
+        val capabilities = networkCapabilities
+            ?: connectivityManager.getNetworkCapabilities(network)
+        val properties = linkProperties
+            ?: connectivityManager.getLinkProperties(network)
+        val isWifi = capabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+        if (!isWifi) {
+            selector.lost(network)
+            publishIfChanged()
+            return
+        }
+        val hasInternet = capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        val hasUsableIpv4 = properties?.linkAddresses?.any { linkAddress ->
+            val address = linkAddress.address
+            address is Inet4Address && !address.isLoopbackAddress && !address.isLinkLocalAddress
+        } == true
+        val hasWppSpecifier = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            runCatching {
+                capabilities.networkSpecifier is WifiNetworkSpecifier
+            }.getOrDefault(false)
+        if (PhoneWppDiagnostics.isActive && hasWppSpecifier) {
+            wppCorrelatedNetworks += network
+        }
+        selector.observe(
+            network = network,
+            hasInternet = hasInternet,
+            hasUsableIpv4 = hasUsableIpv4,
+            correlatedWithWpp = network in wppCorrelatedNetworks,
+        )
+        publishIfChanged()
+    }
+
+    private fun publishIfChanged() {
+        if (!started) return
+        val selected = selector.selectedNetwork
+        if (selected == publishedNetwork) return
+        publishedNetwork = selected
+        CompanionLog.i(
+            TAG,
+            if (selected != null) {
+                "Car WiFi network selected for listener binding"
+            } else {
+                "No car WiFi network selected; listeners use default routing"
+            },
+        )
+        onSelectedNetworkChanged(selected)
+    }
+
+    companion object {
+        private const val TAG = "OAL_CarNetBind"
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/network/ProcessNetworkBinding.kt
+++ b/companion/src/main/java/com/openautolink/companion/network/ProcessNetworkBinding.kt
@@ -1,0 +1,72 @@
+package com.openautolink.companion.network
+
+/**
+ * Serializes process-wide Android network binding around socket creation.
+ *
+ * Android's bindProcessToNetwork affects every socket created in the process, so
+ * known socket creators share this lock. Existing sockets are not migrated.
+ */
+object ProcessNetworkBindingLock {
+    private val lock = Any()
+
+    fun <R> withLock(block: () -> R): R = synchronized(lock, block)
+}
+
+class ProcessNetworkRestoreException(message: String) : IllegalStateException(message)
+
+class ProcessNetworkBinding<T>(
+    private val currentNetwork: () -> T?,
+    private val bindProcess: (T?) -> Boolean,
+    private val warning: (String) -> Unit,
+) {
+    fun <R> withNetwork(
+        targetNetwork: T?,
+        onUnrestored: (R) -> Unit = {},
+        block: () -> R,
+    ): R = ProcessNetworkBindingLock.withLock {
+        val previousNetwork = currentNetwork()
+        if (previousNetwork == targetNetwork) {
+            return@withLock block()
+        }
+
+        check(bindProcess(targetNetwork)) {
+            "Target network is no longer valid"
+        }
+
+        var result: Any? = null
+        var blockFailure: Throwable? = null
+        try {
+            result = block()
+        } catch (failure: Throwable) {
+            blockFailure = failure
+        }
+
+        val restoreResult = runCatching { bindProcess(previousNetwork) }
+        if (restoreResult.getOrDefault(false) != true) {
+            val clearResult = runCatching { bindProcess(null) }
+            val cleared = clearResult.getOrDefault(false) == true
+            val reason = restoreResult.exceptionOrNull()?.message
+                ?: "restore returned false"
+            val clearError = clearResult.exceptionOrNull()?.message
+                ?.let { ", clear error=$it" }
+                .orEmpty()
+            warning(
+                "Could not restore previous process network ($reason); " +
+                    "fallback clear attempted (cleared=$cleared$clearError)",
+            )
+            if (!cleared) {
+                @Suppress("UNCHECKED_CAST")
+                if (blockFailure == null) runCatching { onUnrestored(result as R) }
+                val failure = ProcessNetworkRestoreException(
+                    "Process network remained bound after listener creation",
+                )
+                blockFailure?.let(failure::addSuppressed)
+                throw failure
+            }
+        }
+
+        blockFailure?.let { throw it }
+        @Suppress("UNCHECKED_CAST")
+        result as R
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -41,6 +41,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
     private var tcpAdvertiser: TcpAdvertiser? = null
     private var carWifiManager: com.openautolink.companion.wifi.CarWifiManager? = null
+    private var carNetworkBindingJob: kotlinx.coroutines.Job? = null
     private var wakeLock: PowerManager.WakeLock? = null
     private var multicastLock: android.net.wifi.WifiManager.MulticastLock? = null
     private var fileLogger: CompanionFileLogger? = null
@@ -176,16 +177,24 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
      * phone joins the car's WiFi even when already connected to another network.
      */
     private fun startCarWifiIfConfigured() {
+        carNetworkBindingJob?.cancel()
+        carNetworkBindingJob = null
         carWifiManager?.stop()
         val prefs = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
         val entries = com.openautolink.companion.wifi.CarWifiEntry.loadAll(prefs)
         if (entries.isEmpty()) {
+            tcpAdvertiser?.updateCarNetwork(null)
             PhoneWppDiagnostics.associationOwner(WppAssociationOwner.WPP)
             CompanionLog.d(TAG, "No car WiFi entries configured, skipping CarWifiManager")
             return
         }
         val mgr = com.openautolink.companion.wifi.CarWifiManager(this)
         carWifiManager = mgr
+        carNetworkBindingJob = serviceScope.launch {
+            mgr.carNetwork.collect { network ->
+                tcpAdvertiser?.updateCarNetwork(network)
+            }
+        }
         mgr.start(entries)
     }
 
@@ -316,6 +325,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         PhoneWppDiagnostics.timeout()
         PhoneWppDiagnostics.setAttemptFinishedListener(null)
         stopWppNetworkObserver()
+        carNetworkBindingJob?.cancel()
+        carNetworkBindingJob = null
         carWifiManager?.stop()
         stopFileLogging()
         releaseWakeLock()

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -2,12 +2,19 @@ package com.openautolink.companion.service
 
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import com.openautolink.companion.connection.AaProxy
 import com.openautolink.companion.diagnostics.CompanionLog
 import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.diagnostics.PhoneWppStage
+import com.openautolink.companion.network.CarNetworkMonitor
+import com.openautolink.companion.network.ListenerBindingGenerations
+import com.openautolink.companion.network.ListenerBindingTicket
+import com.openautolink.companion.network.ProcessNetworkBinding
+import com.openautolink.companion.network.ProcessNetworkRestoreException
 import com.openautolink.companion.trigger.TransparentTriggerActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -88,6 +95,16 @@ class TcpAdvertiser(
     }
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val connectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    private val processNetworkBinding = ProcessNetworkBinding<Network>(
+        currentNetwork = connectivityManager::getBoundNetworkForProcess,
+        bindProcess = connectivityManager::bindProcessToNetwork,
+        warning = { message -> CompanionLog.e(TAG, message) },
+    )
+    private val listenerGenerations = ListenerBindingGenerations<Network>()
+    private val listenerPublicationLock = Any()
+    private var carNetworkMonitor: CarNetworkMonitor? = null
     private var serverSocket: ServerSocket? = null
     private var identityServerSocket: ServerSocket? = null
     private var udpDiscoverySocket: java.net.DatagramSocket? = null
@@ -117,39 +134,145 @@ class TcpAdvertiser(
         if (isRunning) return
         isRunning = true
         CompanionLog.i(TAG, "Starting TCP server on port $PORT")
+        replaceCarFacingListeners(null)
+        carNetworkMonitor = CarNetworkMonitor(
+            context = context,
+            onSelectedNetworkChanged = { network -> replaceCarFacingListeners(network) },
+        ).also { it.start() }
+    }
 
+    /** Supplies the exact network returned by CarWifiManager, or clears that preference. */
+    fun updateCarNetwork(network: Network?) {
+        carNetworkMonitor?.prefer(network)
+    }
+
+    /**
+     * Replaces only ports 5277-5279. The localhost proxy, accepted car socket,
+     * bridge, watchdogs, and recovery jobs deliberately remain owned by this
+     * TcpAdvertiser instance.
+     */
+    private fun replaceCarFacingListeners(
+        network: Network?,
+        rollbackOnFailure: Boolean = true,
+    ) {
+        val ticket = listenerGenerations.replaceWith(network) ?: return
+        synchronized(listenerPublicationLock) {
+            closeCarFacingListeners()
+            unregisterNsd()
+        }
         scope.launch {
-            var listenerBound = false
             try {
-                // Retry bind briefly to handle EADDRINUSE race when the service
-                // is restarted quickly (e.g. BT reconnect triggers start within
-                // milliseconds of the previous stop). The OS may not have released
-                // the port yet even though we called serverSocket.close().
-                val server = ServerSocket()
-                server.reuseAddress = true
-                var bindAttempt = 0
-                while (true) {
-                    try {
-                        server.bind(InetSocketAddress(PORT))
-                        break
-                    } catch (e: java.net.BindException) {
-                        bindAttempt++
-                        if (bindAttempt >= BIND_RETRY_MAX) throw e
-                        CompanionLog.w(TAG, "Port $PORT in use, retrying in ${BIND_RETRY_DELAY_MS}ms (attempt $bindAttempt/$BIND_RETRY_MAX)")
-                        delay(BIND_RETRY_DELAY_MS)
+                val listeners = createCarFacingListeners(ticket.target)
+                val published = synchronized(listenerPublicationLock) {
+                    if (!isRunning || !listenerGenerations.owns(ticket)) {
+                        false
+                    } else {
+                        serverSocket = listeners.main
+                        identityServerSocket = listeners.identity
+                        udpDiscoverySocket = listeners.discovery
+                        registerNsd(ticket.target)
+                        true
                     }
                 }
-                listenerBound = true
-                serverSocket = server
-                CompanionLog.i(TAG, "Listening on 0.0.0.0:$PORT")
+                if (!published) {
+                    listeners.close()
+                    return@launch
+                }
+                CompanionLog.i(
+                    TAG,
+                    if (ticket.target != null) {
+                        "Car-facing listeners bound to selected WiFi network"
+                    } else {
+                        "Car-facing listeners using default routing"
+                    },
+                )
                 PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTENING)
+                startMainServer(ticket, listeners.main)
+                startIdentityServer(ticket, listeners.identity)
+                startUdpDiscoveryServer(ticket, listeners.discovery)
+            } catch (e: Exception) {
+                if (isRunning && listenerGenerations.owns(ticket)) {
+                    PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)
+                    CompanionLog.e(TAG, "Car-facing listener bind failed: ${e.message}")
+                    if (rollbackOnFailure && e !is ProcessNetworkRestoreException &&
+                        ticket.previousTarget != ticket.target
+                    ) {
+                        CompanionLog.w(TAG, "Restoring previous car-facing listener binding")
+                        replaceCarFacingListeners(ticket.previousTarget, rollbackOnFailure = false)
+                    }
+                }
+            }
+        }
+    }
 
-                registerNsd()
-                startIdentityServer()
-                startUdpDiscoveryServer()
+    private fun closeCarFacingListeners() {
+        runCatching { serverSocket?.close() }
+        serverSocket = null
+        runCatching { identityServerSocket?.close() }
+        identityServerSocket = null
+        runCatching { udpDiscoverySocket?.close() }
+        udpDiscoverySocket = null
+    }
 
-                while (isRunning) {
+    private suspend fun createCarFacingListeners(network: Network?): CarFacingListeners {
+        var bindAttempt = 0
+        while (true) {
+            try {
+                return processNetworkBinding.withNetwork(
+                    targetNetwork = network,
+                    onUnrestored = CarFacingListeners::close,
+                ) {
+                    createCarFacingListenersOnce()
+                }
+            } catch (e: java.net.BindException) {
+                bindAttempt++
+                if (bindAttempt >= BIND_RETRY_MAX) throw e
+                CompanionLog.w(
+                    TAG,
+                    "Listener port in use, retrying in ${BIND_RETRY_DELAY_MS}ms " +
+                        "(attempt $bindAttempt/$BIND_RETRY_MAX)",
+                )
+                delay(BIND_RETRY_DELAY_MS)
+            }
+        }
+    }
+
+    private fun createCarFacingListenersOnce(): CarFacingListeners {
+        var main: ServerSocket? = null
+        var identity: ServerSocket? = null
+        var discovery: java.net.DatagramSocket? = null
+        try {
+            main = ServerSocket().apply {
+                reuseAddress = true
+                bind(InetSocketAddress(PORT))
+            }
+            identity = ServerSocket().apply {
+                reuseAddress = true
+                bind(InetSocketAddress(IDENTITY_PORT))
+            }
+            discovery = java.net.DatagramSocket(null).apply {
+                reuseAddress = true
+                broadcast = true
+                bind(InetSocketAddress(UDP_DISCOVERY_PORT))
+            }
+            return CarFacingListeners(main, identity, discovery)
+        } catch (e: Exception) {
+            runCatching { main?.close() }
+            runCatching { identity?.close() }
+            runCatching { discovery?.close() }
+            throw e
+        }
+    }
+
+    private fun startMainServer(ticket: ListenerBindingTicket<Network>, server: ServerSocket) {
+        scope.launch {
+            try {
+                while (isRunning && listenerGenerations.owns(ticket)) {
                     val carSocket = server.accept()
+                    if (!listenerGenerations.owns(ticket)) {
+                        runCatching { carSocket.close() }
+                        break
+                    }
                     PhoneWppDiagnostics.record(PhoneWppStage.CAR_SOCKET)
                     val remoteIp = carSocket.inetAddress?.hostAddress ?: "unknown"
                     CompanionLog.i(TAG, "Car connected from $remoteIp")
@@ -157,13 +280,22 @@ class TcpAdvertiser(
                     handleCarConnection(carSocket)
                 }
             } catch (e: Exception) {
-                if (isRunning) {
-                    if (!listenerBound) {
-                        PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)
-                    }
+                if (isRunning && listenerGenerations.owns(ticket)) {
                     CompanionLog.e(TAG, "TCP server error: ${e.message}")
                 }
             }
+        }
+    }
+
+    private data class CarFacingListeners(
+        val main: ServerSocket,
+        val identity: ServerSocket,
+        val discovery: java.net.DatagramSocket,
+    ) {
+        fun close() {
+            runCatching { main.close() }
+            runCatching { identity.close() }
+            runCatching { discovery.close() }
         }
     }
 
@@ -286,16 +418,18 @@ class TcpAdvertiser(
      * carries AA traffic. Used by the car-side subnet sweep + last-known-IP
      * verification when mDNS is unavailable.
      */
-    private fun startIdentityServer() {
+    private fun startIdentityServer(
+        ticket: ListenerBindingTicket<Network>,
+        server: ServerSocket,
+    ) {
         scope.launch {
             try {
-                val server = ServerSocket()
-                server.reuseAddress = true
-                server.bind(InetSocketAddress(IDENTITY_PORT))
-                identityServerSocket = server
-                CompanionLog.i(TAG, "Identity probe server listening on 0.0.0.0:$IDENTITY_PORT")
-                while (isRunning) {
+                while (isRunning && listenerGenerations.owns(ticket)) {
                     val client = server.accept()
+                    if (!listenerGenerations.owns(ticket)) {
+                        runCatching { client.close() }
+                        break
+                    }
                     val remoteIp = client.inetAddress?.hostAddress ?: "unknown"
                     // Bound the entire probe lifecycle (including the write
                     // back) so a tarpitted peer can't pin a coroutine forever.
@@ -309,7 +443,9 @@ class TcpAdvertiser(
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) CompanionLog.w(TAG, "Identity server error: ${e.message}")
+                if (isRunning && listenerGenerations.owns(ticket)) {
+                    CompanionLog.w(TAG, "Identity server error: ${e.message}")
+                }
             }
         }
     }
@@ -409,26 +545,23 @@ class TcpAdvertiser(
      * car has to find this phone, used when mDNS is broken (AAOS 12/13
      * NSD often returns IPv6 link-local only).
      */
-    private fun startUdpDiscoveryServer() {
+    private fun startUdpDiscoveryServer(
+        ticket: ListenerBindingTicket<Network>,
+        socket: java.net.DatagramSocket,
+    ) {
         scope.launch {
             try {
-                val socket = java.net.DatagramSocket(null).apply {
-                    reuseAddress = true
-                    broadcast = true
-                    bind(InetSocketAddress(UDP_DISCOVERY_PORT))
-                }
-                udpDiscoverySocket = socket
-                CompanionLog.i(TAG, "UDP discovery server listening on 0.0.0.0:$UDP_DISCOVERY_PORT")
                 val recvBuf = ByteArray(64)
-                while (isRunning) {
+                while (isRunning && listenerGenerations.owns(ticket)) {
                     val packet = java.net.DatagramPacket(recvBuf, recvBuf.size)
                     try {
                         socket.receive(packet)
                     } catch (e: Exception) {
-                        if (!isRunning) break
+                        if (!isRunning || !listenerGenerations.owns(ticket)) break
                         CompanionLog.d(TAG, "UDP receive: ${e.message}")
                         continue
                     }
+                    if (!listenerGenerations.owns(ticket)) break
                     val remoteIp = packet.address?.hostAddress ?: continue
                     val text = String(packet.data, packet.offset, packet.length, Charsets.UTF_8)
                         .trimEnd('\n', '\r')
@@ -455,7 +588,9 @@ class TcpAdvertiser(
                     }
                 }
             } catch (e: Exception) {
-                if (isRunning) CompanionLog.w(TAG, "UDP discovery server error: ${e.message}")
+                if (isRunning && listenerGenerations.owns(ticket)) {
+                    CompanionLog.w(TAG, "UDP discovery server error: ${e.message}")
+                }
             }
         }
     }
@@ -748,26 +883,26 @@ class TcpAdvertiser(
     fun stop() {
         CompanionLog.i(TAG, "Stopping TCP server")
         isRunning = false
+        carNetworkMonitor?.stop()
+        carNetworkMonitor = null
+        listenerGenerations.stop()
+        synchronized(listenerPublicationLock) {
+            closeCarFacingListeners()
+            unregisterNsd()
+        }
         aaConnectWatchdog?.cancel()
         aaConnectWatchdog = null
         bridgeRelaunchJob?.cancel()
         bridgeRelaunchJob = null
         bridgeRelaunchAttempts = 0
-        unregisterNsd()
         activeProxy?.stop()
         activeProxy = null
         activeCarSocket?.let { runCatching { it.close() } }
         activeCarSocket = null
-        runCatching { serverSocket?.close() }
-        serverSocket = null
-        runCatching { identityServerSocket?.close() }
-        identityServerSocket = null
-        runCatching { udpDiscoverySocket?.close() }
-        udpDiscoverySocket = null
         scope.cancel()
     }
 
-    private fun registerNsd() {
+    private fun registerNsd(network: Network?) {
         try {
             nsdManager = context.getSystemService(Context.NSD_SERVICE) as? NsdManager
             val prefs = context.getSharedPreferences(
@@ -785,6 +920,9 @@ class TcpAdvertiser(
                 serviceName = uniqueServiceName
                 serviceType = NSD_SERVICE_TYPE
                 port = PORT
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                    setNetwork(network)
+                }
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
                     setAttribute("phone_id", phoneId)
                     setAttribute("friendly_name", friendlyName)

--- a/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
+++ b/companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt
@@ -53,8 +53,12 @@ class CarWifiManager(private val context: Context) {
     private val _state = MutableStateFlow<State>(State.Idle)
     val state: StateFlow<State> = _state
 
+    private val _carNetwork = MutableStateFlow<Network?>(null)
+    val carNetwork: StateFlow<Network?> = _carNetwork
+
     private var entries: List<CarWifiEntry> = emptyList()
     private var currentCallback: ConnectivityManager.NetworkCallback? = null
+    @Volatile private var requestGeneration = 0L
     private var attempt = 0
     private var running = false
     private var retryRunnable: Runnable? = null
@@ -137,6 +141,7 @@ class CarWifiManager(private val context: Context) {
         CompanionLog.i(TAG, "Attempt $attempt/$MAX_ATTEMPTS: requesting \"${entry.ssid}\"")
 
         releaseCallback()
+        val generation = requestGeneration
 
         val specifier = WifiNetworkSpecifier.Builder()
             .setSsid(entry.ssid)
@@ -150,7 +155,8 @@ class CarWifiManager(private val context: Context) {
 
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
-                if (!running) return
+                if (!ownsRequest(generation)) return
+                _carNetwork.value = network
                 CompanionLog.i(TAG, "Connected to \"${entry.ssid}\" on attempt $attempt")
                 _state.value = State.Connected(entry.ssid)
                 attempt = 0
@@ -161,13 +167,17 @@ class CarWifiManager(private val context: Context) {
             }
 
             override fun onUnavailable() {
-                if (!running) return
+                if (!ownsRequest(generation)) return
+                _carNetwork.value = null
                 CompanionLog.w(TAG, "Attempt $attempt failed (SSID not in range yet)")
                 scheduleRetry()
             }
 
             override fun onLost(network: Network) {
-                if (!running) return
+                if (!ownsRequest(generation)) return
+                if (_carNetwork.value == network) {
+                    _carNetwork.value = null
+                }
                 CompanionLog.w(TAG, "Car WiFi \"${entry.ssid}\" lost")
                 _state.value = State.Scanning(attempt, MAX_ATTEMPTS)
                 scheduleRetry(LOST_RETRY_DELAY_MS)
@@ -190,7 +200,12 @@ class CarWifiManager(private val context: Context) {
         retryRunnable = null
     }
 
+    private fun ownsRequest(generation: Long): Boolean =
+        running && requestGeneration == generation
+
     private fun releaseCallback() {
+        requestGeneration += 1L
+        _carNetwork.value = null
         currentCallback?.let {
             try { connectivityManager.unregisterNetworkCallback(it) } catch (_: Exception) {}
         }

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/WppStartupIntegrationPolicyTest.kt
@@ -249,19 +249,18 @@ class WppStartupIntegrationPolicyTest {
     }
 
     @Test
-    fun `tcp listen failure is reported only before the listener binds`() {
+    fun `tcp listen failure is owned by the listener bundle bind`() {
         val source = projectFile(
             "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
         ).readText()
+        val replaceFunction = source.substringAfter("private fun replaceCarFacingListeners(")
+            .substringBefore("private fun closeCarFacingListeners(")
+        val bindCatch = replaceFunction.substringAfter("} catch (e: Exception) {")
 
-        assertTrue(source.contains("var listenerBound = false"))
-        assertTrue(source.contains("listenerBound = true"))
-        assertTrue(
-            source.contains(
-                "if (!listenerBound) {\n" +
-                    "                        PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)",
-            ),
-        )
+        assertEquals(1, "TCP_LISTEN_FAILED".toRegex().findAll(source).count())
+        assertTrue(replaceFunction.contains("val listeners = createCarFacingListeners(ticket.target)"))
+        assertTrue(bindCatch.contains("PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTEN_FAILED)"))
+        assertTrue(replaceFunction.contains("PhoneWppDiagnostics.record(PhoneWppStage.TCP_LISTENING)"))
     }
 
     @Test

--- a/companion/src/test/java/com/openautolink/companion/network/CarNetworkBindingPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/network/CarNetworkBindingPolicyTest.kt
@@ -1,0 +1,124 @@
+package com.openautolink.companion.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CarNetworkBindingPolicyTest {
+
+    @Test
+    fun `explicit companion network wins even when it advertises internet`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("home", hasInternet = true, hasUsableIpv4 = true, correlatedWithWpp = false)
+        selector.observe("wpp-local", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+        selector.observe("configured-car", hasInternet = true, hasUsableIpv4 = true, correlatedWithWpp = false)
+
+        selector.prefer("configured-car")
+
+        assertEquals("configured-car", selector.selectedNetwork)
+    }
+
+    @Test
+    fun `wpp correlated local only wifi is selected without configured car entries`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("home", hasInternet = true, hasUsableIpv4 = true, correlatedWithWpp = false)
+        selector.observe("wpp-local", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+
+        assertEquals("wpp-local", selector.selectedNetwork)
+    }
+
+    @Test
+    fun `internet wifi and unaddressed wifi are not inferred as the car network`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("home", hasInternet = true, hasUsableIpv4 = true, correlatedWithWpp = false)
+        selector.observe("not-addressed-yet", hasInternet = false, hasUsableIpv4 = false, correlatedWithWpp = true)
+
+        assertNull(selector.selectedNetwork)
+    }
+
+    @Test
+    fun `unrelated local only wifi is not inferred as WPP`() {
+        val selector = CarNetworkSelector<String>()
+
+        selector.observe(
+            "wifi-direct",
+            hasInternet = false,
+            hasUsableIpv4 = true,
+            correlatedWithWpp = false,
+        )
+
+        assertNull(selector.selectedNetwork)
+    }
+
+    @Test
+    fun `current eligible network remains stable when another local network appears`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("first", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+        selector.observe("second", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+
+        assertEquals("first", selector.selectedNetwork)
+    }
+
+    @Test
+    fun `losing the selected network falls through to another eligible network`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("first", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+        selector.observe("second", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+
+        selector.lost("first")
+
+        assertEquals("second", selector.selectedNetwork)
+    }
+
+    @Test
+    fun `clearing an explicit preference falls back to local only discovery`() {
+        val selector = CarNetworkSelector<String>()
+        selector.observe("wpp-local", hasInternet = false, hasUsableIpv4 = true, correlatedWithWpp = true)
+        selector.observe("configured-car", hasInternet = true, hasUsableIpv4 = true, correlatedWithWpp = false)
+        selector.prefer("configured-car")
+
+        selector.prefer(null)
+
+        assertEquals("wpp-local", selector.selectedNetwork)
+    }
+
+    @Test
+    fun `initial unbound listener receives a binding generation`() {
+        val generations = ListenerBindingGenerations<String>()
+
+        val initial = generations.replaceWith(null)
+
+        assertEquals(1L, initial?.generation)
+        assertTrue(generations.owns(requireNotNull(initial)))
+    }
+
+    @Test
+    fun `listener generations ignore duplicates and reject stale completion`() {
+        val generations = ListenerBindingGenerations<String>()
+
+        val first = generations.replaceWith("wpp-local")
+        val duplicate = generations.replaceWith("wpp-local")
+        val second = generations.replaceWith("configured-car")
+
+        assertEquals(1L, first?.generation)
+        assertNull(first?.previousTarget)
+        assertNull(duplicate)
+        assertEquals(2L, second?.generation)
+        assertEquals("wpp-local", second?.previousTarget)
+        assertFalse(generations.owns(requireNotNull(first)))
+        assertTrue(generations.owns(requireNotNull(second)))
+    }
+
+    @Test
+    fun `listener stop invalidates in flight binding without requesting another bind`() {
+        val generations = ListenerBindingGenerations<String>()
+        val active = requireNotNull(generations.replaceWith("wpp-local"))
+
+        generations.stop()
+
+        assertFalse(generations.owns(active))
+        assertNull(generations.replaceWith(null))
+    }
+}

--- a/companion/src/test/java/com/openautolink/companion/network/ProcessNetworkBindingTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/network/ProcessNetworkBindingTest.kt
@@ -1,0 +1,269 @@
+package com.openautolink.companion.network
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ProcessNetworkBindingTest {
+
+    @Test
+    fun `temporary process binding is restored after socket creation`() {
+        var current: String? = null
+        val transitions = mutableListOf<String?>()
+        val binding = ProcessNetworkBinding(
+            currentNetwork = { current },
+            bindProcess = { network ->
+                transitions += network
+                current = network
+                true
+            },
+            warning = {},
+        )
+
+        val result = binding.withNetwork("car") {
+            assertEquals("car", current)
+            "created"
+        }
+
+        assertEquals("created", result)
+        assertEquals(listOf("car", null), transitions)
+        assertEquals(null, current)
+    }
+
+    @Test
+    fun `failed target binding does not create an unscoped listener`() {
+        var blockRan = false
+        val binding = ProcessNetworkBinding<String>(
+            currentNetwork = { null },
+            bindProcess = { false },
+            warning = {},
+        )
+
+        try {
+            binding.withNetwork("stale") {
+                blockRan = true
+            }
+            fail("Expected target bind failure")
+        } catch (_: IllegalStateException) {
+        }
+
+        assertFalse(blockRan)
+    }
+
+    @Test
+    fun `failed restore and failed clear close the result and fail closed`() {
+        var cleaned = false
+        val binding = ProcessNetworkBinding<String>(
+            currentNetwork = { "home" },
+            bindProcess = { network -> network == "car" },
+            warning = {},
+        )
+
+        try {
+            binding.withNetwork(
+                targetNetwork = "car",
+                onUnrestored = { cleaned = true },
+            ) { "created" }
+            fail("Expected process restore failure")
+        } catch (_: ProcessNetworkRestoreException) {
+        }
+
+        assertTrue(cleaned)
+    }
+
+    @Test
+    fun `restore exception is contained and process binding is cleared`() {
+        var current: String? = "home"
+        val transitions = mutableListOf<String?>()
+        val warnings = mutableListOf<String>()
+        val binding = ProcessNetworkBinding(
+            currentNetwork = { current },
+            bindProcess = { network ->
+                transitions += network
+                when (network) {
+                    "car" -> {
+                        current = network
+                        true
+                    }
+                    "home" -> throw SecurityException("restore denied")
+                    null -> {
+                        current = null
+                        true
+                    }
+                    else -> false
+                }
+            },
+            warning = warnings::add,
+        )
+
+        val result = binding.withNetwork("car") { "created" }
+
+        assertEquals("created", result)
+        assertEquals(listOf("car", "home", null), transitions)
+        assertEquals(null, current)
+        assertTrue(warnings.single().contains("restore denied"))
+        assertTrue(warnings.single().contains("cleared=true"))
+    }
+
+    @Test
+    fun `failed restoration clears process binding and reports both outcomes`() {
+        var current: String? = "home"
+        val transitions = mutableListOf<String?>()
+        val warnings = mutableListOf<String>()
+        val binding = ProcessNetworkBinding(
+            currentNetwork = { current },
+            bindProcess = { network ->
+                transitions += network
+                when (network) {
+                    "car" -> {
+                        current = network
+                        true
+                    }
+                    "home" -> false
+                    null -> {
+                        current = null
+                        true
+                    }
+                    else -> false
+                }
+            },
+            warning = warnings::add,
+        )
+
+        binding.withNetwork("car") { Unit }
+
+        assertEquals(listOf("car", "home", null), transitions)
+        assertEquals(null, current)
+        assertTrue(warnings.single().contains("restore"))
+        assertTrue(warnings.single().contains("cleared=true"))
+    }
+}
+
+class CarNetworkBindingIntegrationTest {
+
+    @Test
+    fun `service forwards exact companion network without restarting advertiser`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        val carWifiFunction = source.substringAfter("private fun startCarWifiIfConfigured()")
+            .substringBefore("fun restartCarWifi()")
+
+        assertTrue(carWifiFunction.contains("mgr.carNetwork.collect"))
+        assertTrue(carWifiFunction.contains("tcpAdvertiser?.updateCarNetwork(network)"))
+        assertFalse(carWifiFunction.contains("tcpAdvertiser?.stop()"))
+    }
+
+    @Test
+    fun `listener rebind leaves proxy bridge and recovery ownership untouched`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+        val rebind = source.substringAfter("private fun replaceCarFacingListeners(")
+            .substringBefore("private fun closeCarFacingListeners(")
+
+        assertTrue(rebind.contains("listenerGenerations.replaceWith"))
+        assertFalse(rebind.contains("activeProxy?.stop()"))
+        assertFalse(rebind.contains("activeCarSocket?.close()"))
+        assertFalse(rebind.contains("scope.cancel()"))
+    }
+
+    @Test
+    fun `failed replacement attempts one rollback to the previous listener network`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+        val rebind = source.substringAfter("private fun replaceCarFacingListeners(")
+            .substringBefore("private fun closeCarFacingListeners(")
+
+        assertTrue(
+            rebind.contains(
+                "rollbackOnFailure && e !is ProcessNetworkRestoreException",
+            ),
+        )
+        assertTrue(
+            rebind.contains(
+                "replaceCarFacingListeners(ticket.previousTarget, rollbackOnFailure = false)",
+            ),
+        )
+    }
+
+    @Test
+    fun `accepted work is rechecked against its listener generation`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+        val mainLoop = source.substringAfter("private fun startMainServer(")
+            .substringBefore("private data class CarFacingListeners")
+        val identityLoop = source.substringAfter("private fun startIdentityServer(")
+            .substringBefore("private fun respondIdentityProbe(")
+        val udpLoop = source.substringAfter("private fun startUdpDiscoveryServer(")
+            .substringBefore("private fun handleCarConnection(")
+
+        assertTrue(
+            mainLoop.substringAfter("val carSocket = server.accept()")
+                .substringBefore("PhoneWppDiagnostics.record(PhoneWppStage.CAR_SOCKET)")
+                .contains("listenerGenerations.owns(ticket)"),
+        )
+        assertTrue(
+            identityLoop.substringAfter("val client = server.accept()")
+                .substringBefore("val remoteIp")
+                .contains("listenerGenerations.owns(ticket)"),
+        )
+        assertTrue(
+            udpLoop.substringAfter("socket.receive(packet)")
+                .substringBefore("val remoteIp")
+                .contains("listenerGenerations.owns(ticket)"),
+        )
+    }
+
+    @Test
+    fun `stale CarWifiManager callbacks cannot clear a newer exact network`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt",
+        ).readText()
+        val callback = source.substringAfter("val callback = object : ConnectivityManager.NetworkCallback()")
+            .substringBefore("currentCallback = callback")
+
+        assertTrue(source.contains("val generation = requestGeneration"))
+        assertEquals(3, callback.windowed("if (!ownsRequest(generation)) return".length)
+            .count { it == "if (!ownsRequest(generation)) return" })
+    }
+
+    @Test
+    fun `other outbound sockets choose an explicit default network outside bind window`() {
+        val uploader = projectFile(
+            "companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt",
+        ).readText()
+
+        assertTrue(uploader.contains("ProcessNetworkBindingLock.withLock"))
+        assertTrue(uploader.contains("defaultNetwork.openConnection(endpoint)"))
+    }
+
+    @Test
+    fun `wpp network discovery is passive and loopback creation shares binding lock`() {
+        val monitor = projectFile(
+            "companion/src/main/java/com/openautolink/companion/network/CarNetworkMonitor.kt",
+        ).readText()
+        val loopback = projectFile(
+            "companion/src/main/java/com/openautolink/companion/connection/WppProxySocketBinder.kt",
+        ).readText()
+
+        assertTrue(monitor.contains("registerNetworkCallback("))
+        assertFalse(monitor.contains("requestNetwork("))
+        assertTrue(monitor.contains("capabilities.networkSpecifier is WifiNetworkSpecifier"))
+        assertTrue(monitor.contains("PhoneWppDiagnostics.isActive && hasWppSpecifier"))
+        assertTrue(loopback.contains("ProcessNetworkBindingLock.withLock"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+}


### PR DESCRIPTION
## Summary

- Supersedes #72 against current `main` and credits its VPN diagnosis and road test.
- Binds only the companion's car-facing listeners (TCP 5277/5278 and UDP 5279) to either the exact `CarWifiManager` network or a local-only `WifiNetworkSpecifier` correlated with an active WPP startup attempt.
- Keeps the stable localhost Gearhead proxy on 5280, accepted car socket, active bridge, watchdogs, and recovery jobs alive across listener-network changes.
- Generation-fences bind completion and accepted work, rolls a failed replacement back once, and fails closed if process-network restoration cannot be recovered.
- Keeps unrelated outbound traffic off the temporary car-network bind by explicitly opening log uploads on the default network.

## Credit

The original diagnosis and successful Pixel/Blazer VPN field test came from @metheos in #72. That finding is preserved; this PR replaces the now-conflicting lifecycle implementation.

## Verification

- `./gradlew test :companion:assembleDebug --rerun-tasks` — **passed**
- Test XML totals:
  - app debug: 306 passed
  - app release: 306 passed
  - companion debug: 57 passed
  - companion release: 57 passed
- Independent pre-commit concurrency/lifecycle review — **PASS** after fixing the reported blockers.
- Debug APK DEX contains the new listener-bound, passive-monitor, and fail-closed restoration markers.
- `:companion:lintDebug` matches the unchanged-main baseline: 1 existing error / 31 warnings; no new lint findings. The existing error is `WifiJobService.kt:189` (`scanResults` permission handling), outside this diff.

## Runtime acceptance

This is compiled and structurally verified, **not yet road-verified on current main**. A VPN-on drive must show:

1. `Car WiFi network selected for listener binding`
2. `Car-facing listeners bound to selected WiFi network`
3. `Bridge established: AA <-> Car`
4. Actual sustained projection after the bridge—not merely a connected/listening status

The same capture should contain no process-network restore/clear failure and no listener rollback loop.

Supersedes #72.
