### PR TITLE
fix(input): capture steering keys in remap dialog

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -1750,8 +1750,15 @@ void JniSession::sendMultiTouchEvent(int action, int actionIndex,
 
 void JniSession::sendKeyEvent(int keyCode, bool isDown)
 {
-    if (!streaming_ || !inputChannel_) return;
-    ioService_->post([this, keyCode, isDown]() {
+    if (!streaming_ || !inputChannel_) {
+        nativeDiag(2, "input", "KeyEvent skipped: keycode=" + std::to_string(keyCode) +
+                   " down=" + (isDown ? "true" : "false") +
+                   " streaming=" + (streaming_ ? "true" : "false") +
+                   " inputChannel=" + (inputChannel_ ? "ready" : "null"));
+        return;
+    }
+    auto self = shared_from_this();
+    ioService_->post([self, keyCode, isDown]() {
         aap_protobuf::service::inputsource::message::InputReport report;
 
         auto now = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -1765,9 +1772,19 @@ void JniSession::sendKeyEvent(int keyCode, bool isDown)
         key->set_metastate(0);
         key->set_longpress(false);
 
-        auto promise = aasdk::channel::SendPromise::defer(*strand_);
-        promise->then([]() {}, [](const auto&) {});
-        inputChannel_->sendInputReport(report, std::move(promise));
+        auto promise = aasdk::channel::SendPromise::defer(*self->strand_);
+        promise->then(
+            [self, keyCode, isDown]() {
+                self->nativeDiag(1, "input", "KeyEvent send complete: keycode=" +
+                                 std::to_string(keyCode) + " down=" +
+                                 (isDown ? "true" : "false"));
+            },
+            [self, keyCode, isDown](const aasdk::error::Error& e) {
+                self->nativeDiag(3, "input", "KeyEvent send failed: keycode=" +
+                                 std::to_string(keyCode) + " down=" +
+                                 (isDown ? "true" : "false") + " error=" + e.what());
+            });
+        self->inputChannel_->sendInputReport(report, std::move(promise));
     });
 }
 

--- a/app/src/main/java/com/openautolink/app/input/DialogWindowProviderLookup.kt
+++ b/app/src/main/java/com/openautolink/app/input/DialogWindowProviderLookup.kt
@@ -1,0 +1,14 @@
+package com.openautolink.app.input
+
+import android.view.View
+import androidx.compose.ui.window.DialogWindowProvider
+
+/** Finds the Compose dialog window owner, including the dialog root itself. */
+internal fun findDialogWindowProvider(start: Any?): DialogWindowProvider? {
+    var node = start
+    while (node != null) {
+        if (node is DialogWindowProvider) return node
+        node = (node as? View)?.parent
+    }
+    return null
+}

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -603,18 +603,22 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
 
             // Load key remap from preferences
             val keyRemapJson = preferences.keyRemap.first()
-            if (keyRemapJson.isNotBlank()) {
+            val map: Map<Int, Int> = if (keyRemapJson.isBlank()) {
+                emptyMap()
+            } else {
                 try {
-                    val map = mutableMapOf<Int, Int>()
+                    val parsed = mutableMapOf<Int, Int>()
                     val json = org.json.JSONObject(keyRemapJson)
                     for (key in json.keys()) {
-                        map[key.toInt()] = json.getInt(key)
+                        parsed[key.toInt()] = json.getInt(key)
                     }
-                    steeringWheelController.customKeyMap = map
+                    parsed
                 } catch (_: Exception) {
-                    steeringWheelController.customKeyMap = emptyMap()
+                    emptyMap()
                 }
             }
+            steeringWheelController.customKeyMap = map
+            OalLog.i("input", "Loaded custom key map: count=${map.size}")
 
             // Load volume offsets
             val volMedia = preferences.volumeOffsetMedia.first()

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -2031,6 +2031,46 @@ private val mappableActions = listOf(
 )
 
 @Composable
+private fun DialogKeyCaptureWindowHook() {
+    val dialogView = androidx.compose.ui.platform.LocalView.current
+    DisposableEffect(dialogView) {
+        val provider = com.openautolink.app.input.findDialogWindowProvider(dialogView)
+        val window = provider?.window
+        val original = window?.callback
+        val callback = if (original != null) {
+            object : android.view.Window.Callback by original {
+                override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
+                    com.openautolink.app.diagnostics.OalLog.i(
+                        "KeyRemapDialog",
+                        "Dialog window dispatchKeyEvent: keycode=${event.keyCode} " +
+                            "(${android.view.KeyEvent.keyCodeToString(event.keyCode)}) " +
+                            "action=${event.action} source=0x${Integer.toHexString(event.source)}",
+                    )
+                    if (com.openautolink.app.input.KeyCaptureBus.handle(event)) return true
+                    return original.dispatchKeyEvent(event)
+                }
+            }
+        } else {
+            null
+        }
+        com.openautolink.app.diagnostics.OalLog.i(
+            "KeyRemapDialog",
+            "Window hook setup: providerFound=${provider != null} " +
+                "windowFound=${window != null} originalCallbackPresent=${original != null} " +
+                "installed=${callback != null}",
+        )
+        if (window != null && callback != null) {
+            window.callback = callback
+        }
+        onDispose {
+            if (window != null && callback != null && window.callback === callback) {
+                window.callback = original
+            }
+        }
+    }
+}
+
+@Composable
 private fun InputTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
     // Parse current key map from JSON
     val currentMap = remember(uiState.keyRemap) {
@@ -2174,50 +2214,12 @@ private fun InputTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
             }
         }
 
-        // Hook the dialog's own Window so steering-wheel keys delivered to
-        // the dialog window get routed into KeyCaptureBus.
-        val dialogView = androidx.compose.ui.platform.LocalView.current
-        DisposableEffect(target, dialogView) {
-            var node: android.view.ViewParent? = dialogView.parent
-            var provider: androidx.compose.ui.window.DialogWindowProvider? = null
-            while (node != null) {
-                if (node is androidx.compose.ui.window.DialogWindowProvider) {
-                    provider = node
-                    break
-                }
-                node = (node as? android.view.View)?.parent
-            }
-            val window = provider?.window
-            val original = window?.callback
-            com.openautolink.app.diagnostics.OalLog.i(
-                "KeyRemapDialog",
-                "Window hook setup: providerFound=${provider != null} " +
-                    "windowFound=${window != null} originalCallbackPresent=${original != null}",
-            )
-            if (window != null && original != null) {
-                window.callback = object : android.view.Window.Callback by original {
-                    override fun dispatchKeyEvent(event: android.view.KeyEvent): Boolean {
-                        com.openautolink.app.diagnostics.OalLog.i(
-                            "KeyRemapDialog",
-                            "Dialog window dispatchKeyEvent: keycode=${event.keyCode} " +
-                                "(${android.view.KeyEvent.keyCodeToString(event.keyCode)}) " +
-                                "action=${event.action} source=0x${Integer.toHexString(event.source)}",
-                        )
-                        if (com.openautolink.app.input.KeyCaptureBus.handle(event)) return true
-                        return original.dispatchKeyEvent(event)
-                    }
-                }
-            }
-            onDispose {
-                if (window != null && original != null) window.callback = original
-            }
-        }
-
         androidx.compose.material3.AlertDialog(
             onDismissRequest = { captureTarget = null; lastDetectedKey = null },
             title = { Text("Assign key to: ${target.label}") },
             text = {
                 Column {
+                    DialogKeyCaptureWindowHook()
                     Text("Press any physical button (steering wheel, remote, keyboard) now.")
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
@@ -2254,7 +2256,7 @@ private fun InputTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
                 }
             },
             dismissButton = {
-                Button(onClick = { captureTarget = null }) {
+                Button(onClick = { captureTarget = null; lastDetectedKey = null }) {
                     Text("Cancel")
                 }
             },

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -549,7 +549,18 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun updateKeyRemap(json: String) {
-        viewModelScope.launch { preferences.setKeyRemap(json) }
+        viewModelScope.launch {
+            preferences.setKeyRemap(json)
+            val count = if (json.isBlank()) {
+                0
+            } else {
+                runCatching { org.json.JSONObject(json).length() }.getOrDefault(0)
+            }
+            com.openautolink.app.diagnostics.OalLog.i(
+                "input",
+                "Key remap persisted: count=$count mappings=$json",
+            )
+        }
     }
 
     fun updateVolumeOffsetMedia(offset: Int) {

--- a/app/src/test/java/com/openautolink/app/input/DialogWindowProviderLookupTest.kt
+++ b/app/src/test/java/com/openautolink/app/input/DialogWindowProviderLookupTest.kt
@@ -1,0 +1,16 @@
+package com.openautolink.app.input
+
+import androidx.compose.ui.window.DialogWindowProvider
+import io.mockk.mockk
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class DialogWindowProviderLookupTest {
+
+    @Test
+    fun `dialog root provider is found before walking to its parent`() {
+        val provider = mockk<DialogWindowProvider>()
+
+        assertSame(provider, findDialogWindowProvider(provider))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/ui/settings/KeyRemapDialogContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/settings/KeyRemapDialogContractTest.kt
@@ -1,0 +1,82 @@
+package com.openautolink.app.ui.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class KeyRemapDialogContractTest {
+
+    @Test
+    fun `dialog installs key capture hook from inside its own composition`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+        ).readText()
+        val dialog = source.substringAfter("androidx.compose.material3.AlertDialog(")
+            .substringBefore("@Composable\nprivate fun AudioTab")
+        val textContent = dialog.substringAfter("text = {")
+            .substringBefore("confirmButton = {")
+        val hook = source.substringAfter("private fun DialogKeyCaptureWindowHook()")
+            .substringBefore("private fun InputTab")
+
+        assertTrue(textContent.contains("DialogKeyCaptureWindowHook()"))
+        assertTrue(hook.contains("val dialogView = androidx.compose.ui.platform.LocalView.current"))
+        assertTrue(hook.contains("findDialogWindowProvider(dialogView)"))
+        assertFalse(hook.contains("dialogView.parent"))
+    }
+
+    @Test
+    fun `cancel discards a detected key before the next assignment`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+        ).readText()
+        val dialog = source.substringAfter("androidx.compose.material3.AlertDialog(")
+            .substringBefore("@Composable\nprivate fun AudioTab")
+
+        assertTrue(
+            dialog.contains(
+                "Button(onClick = { captureTarget = null; lastDetectedKey = null })",
+            ),
+        )
+    }
+
+    @Test
+    fun `empty saved map actively clears the live steering controller`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
+        ).readText()
+        val load = source.substringAfter("// Load key remap from preferences")
+            .substringBefore("// Load volume offsets")
+
+        assertTrue(load.contains("steeringWheelController.customKeyMap = map"))
+        assertFalse(load.contains("if (keyRemapJson.isNotBlank())"))
+    }
+
+    @Test
+    fun `saved mappings and native send outcomes are observable`() {
+        val settings = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt",
+        ).readText()
+        val update = settings.substringAfter("fun updateKeyRemap(json: String)")
+            .substringBefore("fun updateVolumeOffsetMedia")
+        val native = projectFile(
+            "app/src/main/cpp/jni_session.cpp",
+        ).readText().substringAfter("void JniSession::sendKeyEvent")
+            .substringBefore("void JniSession::sendGpsLocation")
+
+        assertTrue(update.contains("Key remap persisted:"))
+        assertTrue(native.contains("KeyEvent skipped:"))
+        assertTrue(native.contains("KeyEvent send complete:"))
+        assertTrue(native.contains("KeyEvent send failed:"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+}


### PR DESCRIPTION
## Summary
- resolve the Compose `AlertDialog` window from inside the dialog composition and check the root `DialogWindowProvider` itself
- route steering-wheel `KeyEvent`s through `KeyCaptureBus` while the Assign Key dialog owns focus
- clear stale detected/live mappings on Cancel and Reset
- log persisted/loaded mappings and native key-send success, skip, or failure outcomes

## Root cause
The existing fix read `LocalView.current` outside the dialog and began its provider walk at `dialogView.parent`. Compose's dialog root is itself the `DialogWindowProvider`, so no dialog callback was installed and hardware keys bypassed `MainActivity.dispatchKeyEvent`.

## Verification
- TDD RED: lookup test failed on missing root-aware lookup
- TDD RED: dialog contract failed on the old outside-dialog hook
- TDD RED: Cancel/reset/outcome diagnostics tests failed on the old behavior
- Focused: 5 tests, 0 failures
- Full car unit suite: 311 tests, 0 failures
- `:app:externalNativeBuildDebug`: both configured ABIs compiled
- `git diff --check`: clean
- independent pre-commit review: APPROVE
- archive regression checker: unchanged historical baseline (206 attempts / 76 connected; existing historical failures remain)

Repository-wide `lintDebug` still reports the same pre-existing errors in unrelated privileged diagnostics and `automotive_app_desc.xml`; none are in this diff.

## Runtime status
Code/build verification is complete. Real AAOS verification still requires one stationary test on the car: open Settings → Input → Assign, press F7/F8, save, reconnect, and confirm `Listener fired`, `Key remap persisted`, `Loaded custom key map`, and `KeyEvent send complete` in the uploaded log.

Refs #19 — deliberately does not auto-close until that car-side positive test passes.
