### PR TITLE
fix(native): prevent transport teardown ANR

### DIFF
--- a/app/src/main/cpp/jni_transport.cpp
+++ b/app/src/main/cpp/jni_transport.cpp
@@ -33,6 +33,7 @@ JniTransport::JniTransport(boost::asio::io_service& ioService, JavaVM* jvm, jobj
         jclass cls = env->GetObjectClass(javaTransport_);
         readMethodId_ = env->GetMethodID(cls, "readBytes", "(I)[B");
         writeMethodId_ = env->GetMethodID(cls, "writeBytes", "([B)V");
+        closeMethodId_ = env->GetMethodID(cls, "close", "()V");
         env->DeleteLocalRef(cls);
     }
 
@@ -154,11 +155,38 @@ void JniTransport::stop()
 
     LOGI("JniTransport stopping");
 
-    // Wake up read thread
+    // readThread_ is blocked inside AasdkTransportPipe.readBytes(). Closing the
+    // Java pipe first closes the socket streams and releases that blocking read;
+    // joining before this call creates an unbreakable wait cycle.
+    JNIEnv* env = nullptr;
+    bool attached = false;
+    jint result = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (result == JNI_EDETACHED) {
+        result = jvm_->AttachCurrentThread(&env, nullptr);
+        attached = result == JNI_OK;
+        if (!attached) env = nullptr;
+    } else if (result != JNI_OK) {
+        env = nullptr;
+    }
+    if (env && closeMethodId_) {
+        env->CallVoidMethod(javaTransport_, closeMethodId_);
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            LOGW("Java transport pipe close threw before read-thread join");
+        } else {
+            LOGI("Java transport pipe closed before read-thread join");
+        }
+    } else {
+        LOGW("Cannot call Java transport close — relying on bounded read poll before join");
+    }
+    if (attached) jvm_->DetachCurrentThread();
+
     receiveCv_.notify_all();
 
     if (readThread_.joinable()) {
         readThread_.join();
+        LOGI("Read thread joined after transport close");
     }
 
     // Reject all pending receive promises

--- a/app/src/main/cpp/jni_transport.h
+++ b/app/src/main/cpp/jni_transport.h
@@ -80,6 +80,7 @@ private:
     // JNI method IDs (cached on construction)
     jmethodID readMethodId_ = nullptr;
     jmethodID writeMethodId_ = nullptr;
+    jmethodID closeMethodId_ = nullptr;
 };
 
 } // namespace openautolink::jni

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -422,6 +422,14 @@ class AasdkSession(
             }
         }
 
+        try {
+            socket.soTimeout = AasdkTransportPipe.READ_POLL_TIMEOUT_MS
+        } catch (e: Exception) {
+            OalLog.e(TAG, "Cannot bound TCP read for safe teardown: ${e.message}")
+            runCatching { socket.close() }
+            _connectionState.value = ConnectionState.DISCONNECTED
+            return
+        }
         val input = socket.getInputStream()
         val output = socket.getOutputStream()
 
@@ -472,9 +480,11 @@ class AasdkSession(
         _wppServer = null
         _usbConnectionManager?.stop()
         _usbConnectionManager = null
-        AasdkNative.nativeStopSession()
-        transportPipe?.close()
-        transportPipe = null
+        transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
+            OalLog.i(TAG, "Transport pipe closed — stopping native session")
+            AasdkNative.nativeStopSession()
+            OalLog.i(TAG, "Native session stop completed after transport close")
+        }
         _connectionState.value = ConnectionState.DISCONNECTED
     }
 
@@ -503,9 +513,11 @@ class AasdkSession(
             _wppServer = null
             _usbConnectionManager?.stop()
             _usbConnectionManager = null
-            AasdkNative.nativeStopSession()
-            transportPipe?.close()
-            transportPipe = null
+            transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
+                OalLog.i(TAG, "Transport pipe closed — stopping native session")
+                AasdkNative.nativeStopSession()
+                OalLog.i(TAG, "Native session stop completed after transport close")
+            }
             _connectionState.value = ConnectionState.DISCONNECTED
             // Now clear the explicitStop flag so the freshly-started session can
             // auto-reconnect normally if its connection later dies.

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkTransportPipe.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkTransportPipe.kt
@@ -2,6 +2,7 @@ package com.openautolink.app.transport.aasdk
 
 import java.io.InputStream
 import java.io.OutputStream
+import java.net.SocketTimeoutException
 
 /**
  * Bidirectional byte pipe that the native aasdk transport reads/writes through.
@@ -19,6 +20,10 @@ class AasdkTransportPipe(
     private val inputStream: InputStream,
     private val outputStream: OutputStream
 ) {
+    companion object {
+        const val READ_POLL_TIMEOUT_MS = 1000
+    }
+
     /**
      * Read up to [maxSize] bytes from the TCP input stream.
      * Called from native read thread — blocks until data is available.
@@ -28,10 +33,14 @@ class AasdkTransportPipe(
         val buffer = ByteArray(maxSize)
         val bytesRead = try {
             inputStream.read(buffer, 0, maxSize)
-        } catch (e: Exception) {
+        } catch (_: SocketTimeoutException) {
+            // A bounded socket poll keeps the native loop responsive to stop().
+            return ByteArray(0)
+        } catch (_: Exception) {
             return null
         }
-        if (bytesRead <= 0) return null
+        if (bytesRead < 0) return null
+        if (bytesRead == 0) return ByteArray(0)
         return if (bytesRead == maxSize) buffer else buffer.copyOf(bytesRead)
     }
 

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/NativeTransportTeardown.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/NativeTransportTeardown.kt
@@ -1,0 +1,16 @@
+package com.openautolink.app.transport.aasdk
+
+/**
+ * Orders transport teardown so the native read thread cannot be joined while it
+ * is still blocked in [AasdkTransportPipe.readBytes].
+ */
+internal object NativeTransportTeardown {
+    fun closePipeBeforeNativeStop(
+        pipe: AasdkTransportPipe?,
+        nativeStop: () -> Unit,
+    ): AasdkTransportPipe? {
+        pipe?.close()
+        nativeStop()
+        return null
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/usb/UsbTransportPipe.kt
+++ b/app/src/main/java/com/openautolink/app/transport/usb/UsbTransportPipe.kt
@@ -61,8 +61,10 @@ class UsbTransportPipe(
                     if (off > 0) System.arraycopy(buffer, 0, b, off, result)
                     return result
                 }
-                if (result < 0 && closed) throw IOException("USB pipe closed")
-                // result == 0 or timeout: retry
+                if (closed) throw IOException("USB pipe closed")
+                // A timeout/error is a bounded empty poll. Returning to JNI lets
+                // its stopped flag end teardown even if Java close is unavailable.
+                if (result <= 0) return 0
             }
             throw IOException("USB pipe closed")
         }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/NativeTransportTeardownTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/NativeTransportTeardownTest.kt
@@ -1,0 +1,155 @@
+package com.openautolink.app.transport.aasdk
+
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.SocketTimeoutException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeTransportTeardownTest {
+
+    @Test
+    fun `blocked transport read exits before native stop begins`() {
+        val input = CloseUnblocksInputStream()
+        val pipe = AasdkTransportPipe(input, OutputStream.nullOutputStream())
+        val readExited = CountDownLatch(1)
+        val reader = Thread {
+            pipe.readBytes(64)
+            readExited.countDown()
+        }
+
+        reader.start()
+        assertTrue("reader never entered the blocking read", input.readStarted.await(1, TimeUnit.SECONDS))
+
+        var nativeStopObservedReadExit = false
+        val remainingPipe = NativeTransportTeardown.closePipeBeforeNativeStop(pipe) {
+            nativeStopObservedReadExit = readExited.await(1, TimeUnit.SECONDS)
+        }
+
+        reader.join(1_000)
+        assertTrue("closing the pipe must unblock the native reader before join", nativeStopObservedReadExit)
+        assertTrue("reader thread remained blocked after pipe close", !reader.isAlive)
+        assertNull("the closed pipe must not remain reusable", remainingPipe)
+    }
+
+    @Test
+    fun `socket read timeout is a nonterminal empty poll`() {
+        val timeoutInput = object : InputStream() {
+            override fun read(): Int = throw SocketTimeoutException("poll timeout")
+            override fun read(buffer: ByteArray, offset: Int, length: Int): Int =
+                throw SocketTimeoutException("poll timeout")
+        }
+        val pipe = AasdkTransportPipe(timeoutInput, OutputStream.nullOutputStream())
+
+        val result = pipe.readBytes(64)
+
+        assertTrue("a read timeout must keep the native reader alive", result != null && result.isEmpty())
+    }
+
+    @Test
+    fun `zero-byte transport poll is nonterminal`() {
+        val zeroInput = object : InputStream() {
+            override fun read(): Int = 0
+            override fun read(buffer: ByteArray, offset: Int, length: Int): Int = 0
+        }
+        val pipe = AasdkTransportPipe(zeroInput, OutputStream.nullOutputStream())
+
+        val result = pipe.readBytes(64)
+
+        assertTrue("a bounded zero-byte poll must keep the native reader alive", result != null && result.isEmpty())
+    }
+
+    @Test
+    fun `USB bulk timeout returns control to native stop flag`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/usb/UsbTransportPipe.kt",
+        ).readText()
+        val read = source.substringAfter("override fun read(b: ByteArray, off: Int, len: Int): Int")
+            .substringBefore("override fun close()")
+
+        assertTrue("USB timeout must return an empty poll instead of looping internally", read.contains("if (result <= 0) return 0"))
+    }
+
+    @Test
+    fun `TCP socket read is bounded before streams reach native transport`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val handleConnection = source.substringAfter("private fun handleConnection(socket: Socket)")
+            .substringBefore("fun shutdownGracefully")
+        val timeout = handleConnection.indexOf("socket.soTimeout = AasdkTransportPipe.READ_POLL_TIMEOUT_MS")
+        val input = handleConnection.indexOf("socket.getInputStream()")
+
+        assertTrue("TCP timeout must be installed before native reader gets the stream", timeout >= 0 && input >= 0 && timeout < input)
+    }
+
+    @Test
+    fun `all session teardown paths close the pipe before native stop`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val explicitStop = source.substringAfter("fun stop()")
+            .substringBefore("fun forceReconnect(reason: String)")
+        val forceReconnect = source.substringAfter("fun forceReconnect(reason: String)")
+            .substringBefore("// -- Input forwarding")
+        val orderedCall = "transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe)"
+
+        assertTrue("explicit stop must use ordered transport teardown", explicitStop.contains(orderedCall))
+        assertTrue("forced reconnect must use ordered transport teardown", forceReconnect.contains(orderedCall))
+    }
+
+    @Test
+    fun `native transport closes Java pipe before joining read thread`() {
+        val header = projectFile("app/src/main/cpp/jni_transport.h").readText()
+        val source = projectFile("app/src/main/cpp/jni_transport.cpp").readText()
+        val constructor = source.substringAfter("JniTransport::JniTransport(")
+            .substringBefore("JniTransport::~JniTransport()")
+        val stop = source.substringAfter("void JniTransport::stop()")
+            .substringBefore("void JniTransport::onDataReceived")
+        val closeCall = stop.indexOf("CallVoidMethod(javaTransport_, closeMethodId_)")
+        val joinCall = stop.indexOf("readThread_.join()")
+
+        assertTrue("native transport must cache the Java close method", header.contains("jmethodID closeMethodId_"))
+        assertTrue("constructor must resolve AasdkTransportPipe.close", constructor.contains("GetMethodID(cls, \"close\", \"()V\")"))
+        assertTrue("native stop must call Java close", closeCall >= 0)
+        assertTrue("native stop must close the pipe before joining its reader", joinCall >= 0 && closeCall < joinCall)
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.exists()) return candidate
+            dir = dir.parentFile ?: error("Project root not found for: $path")
+        }
+        error("Project file not found: $path")
+    }
+
+    private class CloseUnblocksInputStream : InputStream() {
+        val readStarted = CountDownLatch(1)
+        private val closeCalled = CountDownLatch(1)
+        private val closed = AtomicBoolean(false)
+
+        override fun read(): Int {
+            readStarted.countDown()
+            closeCalled.await()
+            return if (closed.get()) -1 else 0
+        }
+
+        override fun read(buffer: ByteArray, offset: Int, length: Int): Int {
+            readStarted.countDown()
+            closeCalled.await()
+            return if (closed.get()) -1 else 0
+        }
+
+        override fun close() {
+            closed.set(true)
+            closeCalled.countDown()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- close the Java transport pipe before native teardown joins its read thread
- enforce the same ordering at the native transport boundary for C++-initiated stops
- add bounded TCP and USB read polls so teardown remains bounded if JNI close is unavailable
- add regression coverage for blocked reads, timeout polling, and both teardown entry points

## Incident evidence
- build: car app 0.1.441
- trigger: `Video stall 7075ms — forcing reconnect` at 2026-08-18 16:24:31.767
- hang boundary: `JniTransport stopping` with no `Read thread exiting`
- Android ANR: signal 3 at 16:24:43.664

## Verification
- strict RED/GREEN tests for the blocked-read cycle and TCP/USB poll wiring
- `:app:testDebugUnitTest`: 318 tests, 0 failures/errors/skips
- `:app:externalNativeBuildDebug`: arm64-v8a and x86_64 successful
- `:app:assembleDebug`: successful
- both native ABIs contain `Java transport pipe closed before read-thread join`
- debug APK contains the Kotlin teardown completion markers

## Runtime status
This is shipped code pending an in-vehicle stall/reconnect capture. The next log must show `Transport pipe closed — stopping native session`, `Read thread exiting`, `Read thread joined after transport close`, and `Native session stop completed after transport close`, followed by a replacement session and sustained `vflow`.
