### PR TITLE
chore: ignore renamed teardown corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,8 @@ secrets/
 app_v1/
 
 # Reverse engineering / teardown artifacts
-Gmaps_teardown/
+Gmaps_teardown/  # legacy name
+teardowns/       # current name
 recon_dump/
 
 # Temp files


### PR DESCRIPTION
## Summary
- ignore the current `teardowns/` reverse-engineering corpus
- retain the legacy `Gmaps_teardown/` ignore entry for older worktrees

## Why
The renamed corpus contains roughly 2.64 GiB across 280,000+ generated/decompiled files, including APKs, DEX files, native libraries, resources, Java, and smali. It is local interoperability evidence, not project source, and must not be accidentally committed.

## Scope
Ignore-rule correction only. No corpus files are added or removed.
