### PR TITLE
fix: make teardown ignore patterns effective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,10 @@ secrets/
 app_v1/
 
 # Reverse engineering / teardown artifacts
-Gmaps_teardown/  # legacy name
-teardowns/       # current name
+# Legacy name retained for older worktrees.
+Gmaps_teardown/
+# Current teardown corpus.
+teardowns/
 recon_dump/
 
 # Temp files


### PR DESCRIPTION
## Summary
- move explanatory comments onto their own lines
- make `Gmaps_teardown/` and `teardowns/` real Git ignore patterns

## Verification
- `git check-ignore -v teardowns teardowns/README.md` now resolves both paths to the tracked `teardowns/` rule
- the 2.64 GiB teardown corpus no longer appears in `git status`

## Correction
PR #84 used inline comments after the patterns. Git interpreted those comments as part of each pattern, so the rule was ineffective. This PR corrects that syntax error.
