### PR TITLE
docs: publish transport design and focus-bounce postmortem

### DIFF
--- a/docs/design-car-to-phone-log-shipping.md
+++ b/docs/design-car-to-phone-log-shipping.md
@@ -1,0 +1,73 @@
+# Design note: car→phone log shipping (phone-side upload)
+
+**Status:** idea / not built. Captured 2026-07-01.
+
+**Motivation:** the car head unit may not have internet connectivity, while the
+phone will often retain a mobile-data path. The phone is therefore a better
+candidate for uploading diagnostics; the car should not require its own internet
+connection.
+
+## Current behavior
+
+- Each app's `LogUploader` reads only that app's private log directory. The car
+  implementation is in `app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt`;
+  the phone implementation is in
+  `companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt`.
+  Android sandboxing and the device boundary prevent either app from directly
+  reading the other's files.
+- Consequently, the car uploads car logs and the companion uploads companion
+  logs. There is no cross-device log transfer today.
+- Both paths require the uploading device to have connectivity at upload time.
+  That is the weakness on a head unit without an internet path.
+
+## Proposed design
+
+Two possible shapes were considered:
+
+1. **Phone pulls car logs on demand.** This is a poor fit for the failures of
+   interest: if the car↔phone connection is already down, the phone cannot pull
+   the logs describing the drop.
+
+2. **Car ships logs to the phone opportunistically while connected**
+   (**recommended**).
+   - The car continues to keep its rolling on-disk logs as the source of truth.
+   - While the car↔phone link is healthy, the car sends log deltas to the
+     companion over a side channel or the existing OAL transport.
+   - The companion persists received car logs and uploads them later using its
+     own network path.
+   - Logs sent before a disconnect remain available on the phone. The car keeps
+     any unsent tail and catches up after a later reconnect.
+
+## Hard constraints and open questions
+
+- **Assume the link can drop at any time.** Shipping must be best-effort catch-up,
+  not the only copy of the logs.
+- **Transport:** reuse the existing companion connection with a new control
+  message, or add a separate socket. Reuse reduces connection management but log
+  traffic must be low priority so it cannot interfere with projection.
+- **Deduplication and ordering:** define stable source, session, file, offset, and
+  chunk identifiers. Both the companion and upload receiver must accept retries
+  and overlapping ranges without duplicating records. Do not depend on an
+  implementation-specific server deduplication rule.
+- **Source identity:** logs relayed by the phone must retain the car's source
+  identity rather than inheriting the phone's label. The upload format therefore
+  needs an explicit source-device field.
+- **Privacy and size:** diagnostics can contain sensitive device or location
+  data. Keep collection opt-in, authenticate uploads, bound the retained data,
+  and document what is collected before implementation.
+
+## Repository and distribution boundaries
+
+- Both applications are in this repository: the car app is the `app` module and
+  the phone app is the `companion` module.
+- Companion changes are built from this source tree and distributed through the
+  GitHub Actions companion workflow (`.github/workflows/build-companion.yml`).
+- Any upload-receiver changes are outside the Android modules and must be
+  designed alongside the message and upload formats; no existing private server
+  layout is assumed by this note.
+
+## Not doing now
+
+This is a design record, not an implemented feature. The shipped behavior remains
+independent, manually triggered uploads from each device until a cross-device
+protocol is designed, implemented, and tested.

--- a/docs/design-car-to-phone-log-shipping.md
+++ b/docs/design-car-to-phone-log-shipping.md
@@ -1,0 +1,75 @@
+# Design note: car→phone log shipping (phone-side upload)
+
+**Status:** idea / not built. Captured 2026-07-01.
+
+**Motivation:** the car head unit may not have internet connectivity, while the
+phone will often retain a mobile-data path. The phone is therefore a better
+candidate for uploading diagnostics; the car should not require its own internet
+connection.
+
+## Current behavior
+
+- Each app's `LogUploader` reads only that app's private log directory. The car
+  implementation is in `app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt`;
+  the phone implementation is in
+  `companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt`.
+  Android sandboxing and the device boundary prevent either app from directly
+  reading the other's files.
+- Consequently, the car uploads car logs and the companion uploads companion
+  logs. There is no cross-device log transfer today.
+- Both paths require the uploading device to have connectivity at upload time.
+  That is the weakness on a head unit without an internet path.
+
+## Proposed design
+
+Two possible shapes were considered:
+
+1. **Phone pulls car logs on demand.** This is a poor fit for the failures of
+   interest: if the car↔phone connection is already down, the phone cannot pull
+   the logs describing the drop.
+
+2. **Car ships logs to the phone opportunistically while connected**
+   (**recommended**).
+   - The car continues to keep its rolling on-disk logs as the source of truth.
+   - While the car↔phone link is healthy, the car sends log deltas to the
+     companion over a side channel or the existing OAL transport.
+   - The companion persists received car logs and uploads them later using its
+     own network path.
+   - Logs sent before a disconnect remain available on the phone. The car keeps
+     any unsent tail and catches up after a later reconnect.
+
+## Hard constraints and open questions
+
+- **Assume the link can drop at any time.** Shipping must be best-effort catch-up,
+  not the only copy of the logs.
+- **Transport:** reuse the existing companion connection with a new control
+  message, or add a separate socket. Reuse reduces connection management but log
+  traffic must be low priority so it cannot interfere with projection.
+- **Deduplication and ordering:** define stable source, session, file, offset, and
+  chunk identifiers. Both the companion and upload receiver must accept retries
+  and overlapping ranges without duplicating records. Do not depend on an
+  implementation-specific server deduplication rule.
+- **Source identity:** logs relayed by the phone must retain the car's source
+  identity rather than inheriting the phone's label. The upload format therefore
+  needs an explicit source-device field.
+- **Privacy and size:** diagnostics can contain sensitive device or location
+  data. Keep collection opt-in, authenticate uploads, bound the retained data,
+  and document what is collected before implementation.
+
+## Repository and distribution boundaries
+
+- Both applications are in this repository: the car app is the `app` module and
+  the phone app is the `companion` module.
+- Companion changes are built from this source tree and distributed through the
+  signed release workflow (`.github/workflows/release-apk.yml`). The separate
+  `.github/workflows/build-companion.yml` workflow produces a debug CI artifact;
+  it is not the release channel.
+- Any upload-receiver changes are outside the Android modules and must be
+  designed alongside the message and upload formats; no existing private server
+  layout is assumed by this note.
+
+## Not doing now
+
+This is a design record, not an implemented feature. The shipped behavior remains
+independent, manually triggered uploads from each device until a cross-device
+protocol is designed, implemented, and tested.

--- a/docs/focus-bounce-encoder-throttle-postmortem.md
+++ b/docs/focus-bounce-encoder-throttle-postmortem.md
@@ -1,0 +1,76 @@
+# Post-mortem: the #35 focus bounce starved projected video
+
+**Date:** 2026-07-16
+
+**Regressing build:** 0.1.361 (vc361), built from commit `3ec6cfec` on
+`fix/force-focus-keyframe-reimpl-35`. The test build was distributed, but the
+branch was not merged.
+
+**Rollback build:** 0.1.362 (vc362), built from `main` commit `d6afb55b`, the
+clean pre-#35 baseline.
+
+## Symptom
+
+On a cold connection with vc361, video appeared from the cached seed IDR and then
+froze for the drive. The captured stream metrics dropped to roughly 0–12 kbps
+about one second after the focus bounce; 104 of 140 bitrate samples were below
+60 kbps. The same test recorded no subsequent real IDRs, compared with 19 in the
+vc359 baseline on the same phone and car. Upload controls, vehicle data, and
+audio continued to work, isolating the regression to projected video.
+
+The regression was not left in the release line: vc362 restored the unmodified
+`main` behavior by removing the focus-bounce change.
+
+## Change that caused the regression
+
+The vc361 implementation tried to obtain a fresh IDR by sending two unsolicited
+video-focus notifications in immediate succession:
+
+1. `VIDEO_FOCUS_NATIVE_TRANSIENT`
+2. `VIDEO_FOCUS_PROJECTED`
+
+That assumption was wrong. `NATIVE_TRANSIENT` describes a temporary loss of
+projected focus; it is not a keyframe-request mechanism.
+
+## Phone-side behavior evidence
+
+The static analysis used the Android Auto package
+`com.google.android.projection.gearhead`, version
+`16.9.666314-release` (version code `169666314`). The artifact is proprietary and
+its decompiled symbols are obfuscated, so this document records the relevant
+behavior rather than depending on a local teardown path or unstable method name:
+
+- An incoming transition to `VIDEO_FOCUS_NATIVE_TRANSIENT` enters the same
+  video-focus-lost handler as `VIDEO_FOCUS_NATIVE`, with only the `transient`
+  flag changed.
+- That path logs `VideoFocus lost`, clears the projected-focus state, and queues
+  a transient focus-lost event for the video pipeline.
+- A transition back to `VIDEO_FOCUS_PROJECTED` enters a separate focus-gained
+  path. That path queues focus-gained work asynchronously and also has a
+  rejection path that logs `Video focus rejected` and `Relinquishing video
+  focus`.
+
+This static behavior explains why a rapid yield-and-reacquire is not equivalent
+to requesting an IDR. The timing from the vc361 drive supplies the behavioral
+link: bitrate collapsed immediately after the new bounce, real IDRs stopped, and
+the rollback removed the failure. The evidence supports the focus bounce as the
+cause of this regression; it does not establish that every Android Auto version
+or phone encoder reacts identically.
+
+## Why pre-flight review missed it
+
+Review checked that an outbound focus notification would not invoke the car
+app's own inbound `onVideoFocusRequest` teardown path. It did not check the
+phone's semantics for receiving `NATIVE_TRANSIENT`. Compilation and the absence
+of a local car-side teardown were therefore insufficient safety checks.
+
+## Rule and follow-up
+
+Do not use a video-focus transition—transient or otherwise—to provoke a
+keyframe. Any non-`PROJECTED` focus value tells the phone that projected video no
+longer owns the display.
+
+The slow-first-keyframe / seed-IDR stall remains open. A future approach must not
+change video focus; candidates include relying on the phone's natural GOP or a
+decoder-side recovery mechanism. Validate any replacement on a bench or short
+drive, and compare frame arrival, bitrate, and real-IDR counts before shipping.

--- a/docs/focus-bounce-encoder-throttle-postmortem.md
+++ b/docs/focus-bounce-encoder-throttle-postmortem.md
@@ -1,0 +1,79 @@
+# Post-mortem: the #35 focus bounce starved projected video
+
+**Date:** 2026-07-16
+
+**Regressing build:** 0.1.361 (vc361), built from commit `3ec6cfec` on
+`fix/force-focus-keyframe-reimpl-35`. The test build was distributed, but the
+branch was not merged.
+
+**Rollback build:** 0.1.362 (vc362), built from `main` commit `d6afb55b`, the
+clean pre-#35 baseline.
+
+## Symptom
+
+On a cold connection with vc361, video appeared from the cached seed IDR and then
+froze for the drive. The captured stream metrics dropped to roughly 0–12 kbps
+about one second after the focus bounce; 104 of 140 bitrate samples were below
+60 kbps. The same test recorded no subsequent real IDRs, compared with 19 in the
+vc359 baseline on the same phone and car. Upload controls, vehicle data, and
+audio continued to work, isolating the regression to projected video.
+
+The regression was not left in the release line: vc362 restored the unmodified
+`main` behavior by removing the focus-bounce change.
+
+## Change that caused the regression
+
+The vc361 implementation tried to obtain a fresh IDR by sending two unsolicited
+video-focus notifications in immediate succession:
+
+1. `VIDEO_FOCUS_NATIVE_TRANSIENT`
+2. `VIDEO_FOCUS_PROJECTED`
+
+That assumption was wrong. `NATIVE_TRANSIENT` describes a temporary loss of
+projected focus; it is not a keyframe-request mechanism.
+
+## Phone-side behavior evidence
+
+The static analysis used the Android Auto package
+`com.google.android.projection.gearhead`, version
+`16.9.666314-release` (version code `169666314`). The artifact is proprietary and
+its decompiled symbols are obfuscated, so this document records the relevant
+behavior rather than depending on a local teardown path or unstable method name:
+
+- An incoming transition to `VIDEO_FOCUS_NATIVE_TRANSIENT` enters the same
+  video-focus-lost handler as `VIDEO_FOCUS_NATIVE`, with only the `transient`
+  flag changed.
+- That path logs `VideoFocus lost`, clears the projected-focus state, and queues
+  a transient focus-lost event for the video pipeline.
+- A transition back to `VIDEO_FOCUS_PROJECTED` enters a separate focus-gained
+  path. That path queues focus-gained work asynchronously and also has a
+  rejection path that logs `Video focus rejected` and `Relinquishing video
+  focus`.
+
+This static behavior explains why a rapid yield-and-reacquire is not equivalent
+to requesting an IDR. The timing from the vc361 drive supplies the behavioral
+link: bitrate collapsed immediately after the new bounce, real IDRs stopped, and
+the rollback removed the failure. The evidence supports the focus bounce as the
+cause of this regression; it does not establish that every Android Auto version
+or phone encoder reacts identically.
+
+## Why pre-flight review missed it
+
+Review checked that an outbound focus notification would not invoke the car
+app's own inbound `onVideoFocusRequest` teardown path. It did not check the
+phone's semantics for receiving `NATIVE_TRANSIENT`. Compilation and the absence
+of a local car-side teardown were therefore insufficient safety checks.
+
+## Rule and follow-up
+
+Do not use `VIDEO_FOCUS_NATIVE` or `VIDEO_FOCUS_NATIVE_TRANSIENT` to provoke a
+keyframe. Those modes tell the phone that native UI—not projected video—owns the
+display. The protocol also defines `VIDEO_FOCUS_PROJECTED_NO_INPUT_FOCUS`; that
+mode remains projected but without input focus, and this investigation did not
+test it as a keyframe mechanism. No focus transition should be treated as a
+keyframe request without separate phone-side and runtime evidence.
+
+The slow-first-keyframe / seed-IDR stall remains open. A future approach must not
+change video focus; candidates include relying on the phone's natural GOP or a
+decoder-side recovery mechanism. Validate any replacement on a bench or short
+drive, and compare frame arrival, bitrate, and real-IDR counts before shipping.


### PR DESCRIPTION
## Summary
- publish the proposed car-to-phone diagnostic log shipping design
- publish the 0.1.361 focus-bounce encoder-throttle post-mortem
- preserve explicit status: log shipping is not built, and focus transitions must not be used as a keyframe request

## Public-safety cleanup
- removed private server/workspace paths and local teardown dependencies
- corrected repository/distribution boundaries for the companion module
- recorded the analyzed Android Auto package/version and the observable evidence directly in the post-mortem
- retained bounded language where behavior may vary by Android Auto version or encoder

## Verification
- referenced source files, workflow, and historical commits exist
- no private SSIDs, internal Kanban IDs, absolute workspace paths, or ignored-corpus citations remain
- documentation-only change
