### PR TITLE
docs: publish wireless MAC and display negotiation baselines

### DIFF
--- a/docs/oal-bt-mac-exchange-baseline.md
+++ b/docs/oal-bt-mac-exchange-baseline.md
@@ -1,0 +1,305 @@
+# OpenAutoLink — Bluetooth-MAC exchange in wireless Android Auto
+
+This document records the OpenAutoLink (OAL) behavior implemented by the current
+source tree. It is a baseline for comparing future phone-side Android Auto
+changes, not a proposal for new behavior.
+
+A phone-side audit that motivated this document found the flag
+`WirelessProjectionInGearhead__enable_wireless_bt_mac_fix` disabled in the build
+that was inspected. That is a **build-specific observation**, not a claim about
+later Android Auto releases or rollout state.
+
+---
+
+## 0. TL;DR
+
+OAL has three distinct Bluetooth/MAC-related paths that should not be conflated:
+
+1. **AA session SDR:** the car app may put the **car/head unit's Bluetooth MAC**
+   in
+   `ServiceDiscoveryResponse.channels[BLUETOOTH].bluetooth_service.car_address`.
+   This is sent car → phone inside the already-established Android Auto session.
+2. **WPP bootstrap:** when the optional `wpp` transport is selected,
+   `AaWirelessBtServer` publishes the Android Auto Wireless RFCOMM service and
+   exchanges the projection endpoint and Wi-Fi configuration before TCP starts.
+   Its protobuf payloads do **not** carry a separate car-MAC field. The accepted
+   RFCOMM socket identifies the **phone's** Bluetooth address, which OAL uses to
+   keep per-phone endpoint selection from crossing between phones.
+3. **Companion autostart:** `AUTO_START_BT_MACS` is a local set of paired-device
+   addresses used to start the companion after an ACL connection. Those values
+   are not sent to the car or to Android Auto.
+
+The SDR Bluetooth block is optional: an empty car MAC causes OAL to omit the
+block. OAL's AA-session Bluetooth channel does not create an Android bond or
+perform pairing. WPP instead assumes the phone is already paired to the head
+unit and uses that existing Bluetooth relationship for its pre-session RFCOMM
+exchange.
+
+---
+
+## 1. Car MAC in the AA Service Discovery Response
+
+### 1.1 Source resolution — `SessionManager.startSession`
+
+File:
+`app/src/main/java/com/openautolink/app/session/SessionManager.kt`
+
+`SessionManager.startSession` resolves `btMac` in this order:
+
+1. **User override:** `AppPreferences.btMacOverride` (DataStore key
+   `bt_mac_override`). `AppPreferences.setBtMacOverride` trims the value,
+   uppercases it, and converts hyphens to colons.
+2. **Secure setting:** `Settings.Secure["bluetooth_address"]`.
+3. **Adapter API:** `BluetoothAdapter.getDefaultAdapter().address`.
+
+At each applicable stage, an empty value, `02:00:00:00:00:00`, or `none`
+(case-insensitive) is treated as unavailable. The all-zero-looking privacy value
+is expected from `BluetoothAdapter.getAddress()` on many Android versions, and
+some AAOS builds expose `None` for a missing property.
+
+Only the user override is normalized. Values returned by the secure setting or
+adapter are otherwise passed through as returned. OAL does not perform a general
+hex/length validation before putting the value into the SDR.
+
+The selected value is logged as `BT MAC for SDR: ...` (or `(none)`) and passed to
+`AasdkSdrConfig(btMacAddress = btMac, ...)`.
+
+Override entry points:
+
+- `SettingsScreen` exposes the `btMacOverride` field and calls
+  `SettingsViewModel.updateBtMacOverride`.
+- `AppPreferences.setBtMacOverride` persists the normalized value; blank clears
+  it.
+- `SettingsReceiver` accepts the diagnostic key `bt_mac_override`.
+
+Relevant files:
+
+- `app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt`
+- `app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt`
+- `app/src/main/java/com/openautolink/app/data/AppPreferences.kt`
+- `app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt`
+
+### 1.2 Kotlin/JNI config contract
+
+`AasdkSdrConfig` declares:
+
+```kotlin
+/** Bluetooth MAC address of the car (for BT pairing service). */
+@JvmField val btMacAddress: String = "",
+```
+
+File:
+`app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt`
+
+`JniSession::start` reads `btMacAddress` into `sdrConfig_.btMac`. During pipeline
+construction it creates `aasdk::channel::bluetooth::BluetoothService` only when
+that string is non-empty.
+
+Files and symbols:
+
+- `app/src/main/cpp/jni_session.cpp` — `JniSession::start`
+- `app/src/main/cpp/jni_session.h` — `JniSession::SdrConfig::btMac`
+
+### 1.3 Wire representation — `JniSession::buildServiceDiscoveryResponse`
+
+The only place this car MAC is written to the Android Auto application protocol
+is the Bluetooth channel entry in the SDR:
+
+```cpp
+if (!sdrConfig_.btMac.empty()) {
+    auto* svc = response.add_channels();
+    svc->set_id(static_cast<int32_t>(aasdk::messenger::ChannelId::BLUETOOTH));
+    auto* bs = svc->mutable_bluetooth_service();
+    bs->set_car_address(sdrConfig_.btMac);
+    bs->add_supported_pairing_methods(BLUETOOTH_PAIRING_PIN);
+    bs->add_supported_pairing_methods(BLUETOOTH_PAIRING_NUMERIC_COMPARISON);
+}
+```
+
+The enum names above are namespace-qualified in source. If the MAC is empty, OAL
+adds no Bluetooth channel to the SDR.
+
+`JniSession::onServiceDiscoveryRequest` builds and returns this SDR after the
+version exchange and SSL setup. Therefore `car_address` is a car → phone
+application-layer protobuf field inside an established Android Auto transport;
+it is not itself an RFCOMM message, SDP property, or Bluetooth link-layer event.
+
+File:
+`app/src/main/cpp/jni_session.cpp`
+
+### 1.4 AA-session Bluetooth handler
+
+`JniBluetoothHandler`:
+
+- accepts the channel-open request with `STATUS_SUCCESS`;
+- logs `BluetoothPairingRequest` and resumes the receive loop without creating a
+  bond or executing a pairing method;
+- logs `BluetoothAuthenticationResult` and resumes the receive loop.
+
+Thus OAL advertises pairing methods and a car address, but the AA-session channel
+is not an implementation of Android Bluetooth pairing.
+
+File and symbol:
+`app/src/main/cpp/jni_channel_handlers.cpp` — `JniBluetoothHandler`
+
+### 1.5 Separate HFP-presence advertisement
+
+`HfpPresenceServer` publishes an RFCOMM service record on the Hands-Free Profile
+UUID `0000111e-0000-1000-8000-00805f9b34fb`. It accepts and closes an inbound
+connection but does not implement AT commands, SCO, or call audio.
+
+This is a presence hint for phones that gate wireless-AA discovery on seeing an
+HFP-capable device. It does not carry `car_address`. The broader WPP advertiser
+also has a presence-only HFP listener for environments where the platform does
+not already hold the Bluetooth link.
+
+Files and symbols:
+
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/HfpPresenceServer.kt`
+  — `HfpPresenceServer`
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt`
+  — `AaWirelessBtServer.hfpPresenceLoop`
+
+---
+
+## 2. WPP Bluetooth bootstrap is a different exchange
+
+The optional `wpp` transport follows the OEM-style pre-session direction: the
+car publishes the Android Auto Wireless SDP UUID, the paired phone dials the car
+over RFCOMM, and the car supplies enough information for the phone to open the
+projection TCP path.
+
+`AaWirelessBtServer.handleHandshake` exchanges:
+
+1. `WifiVersionRequest`, including `WifiProjectionProtocolInfo { ip_address,
+   port }`;
+2. the phone's `WifiVersionResponse`;
+3. `WifiStartRequest`, including the endpoint and `AccessPointInfo` (network
+   identifier, key, BSSID, security mode, and supported channels);
+4. the phone's `WifiInfoRequest`;
+5. `WifiInfoResponse` with the network security fields.
+
+No message in this implementation adds a separate car Bluetooth-MAC field. The
+car's Bluetooth identity is the bonded device/service the phone dialed. OAL does
+read `BluetoothSocket.remoteDevice.address`, which is the **phone's** address,
+and passes it to `EndpointResolver.currentEndpoint(phoneBtAddress)` so concurrent
+phones cannot receive each other's loopback endpoint.
+
+Two endpoint shapes are implemented:
+
+- `Endpoint.CarDirect`: the car listens and the phone opens TCP to the car.
+- `Endpoint.PhoneLoopback`: Android Auto connects to a companion-owned loopback
+  proxy on the same phone, while the car uses the companion-facing TCP path.
+
+The selected endpoint and Wi-Fi details are independent of the later SDR
+`bluetooth_service.car_address`. Once TCP is connected, native session setup and
+the SDR path in §1 proceed normally.
+
+Files and symbols:
+
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt`
+  — `AaWirelessBtServer`, `handleHandshake`, `Endpoint`, `EndpointResolver`
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt`
+  — `startAdvertising` and its per-phone endpoint resolver
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt`
+  — `startWpp`, `dialCompanion`
+- `app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt`
+  — inbound TCP listener for `CarDirect`
+
+---
+
+## 3. Companion behavior outside WPP
+
+In the companion-assisted TCP path, the companion can launch Android Auto toward
+a local proxy by supplying loopback as the host and the proxy's local port.
+`TcpAdvertiser.fireAaLaunchIntent` writes `127.0.0.1` to the host-address extras
+and the proxy port to the corresponding port extras.
+
+Car/companion discovery uses:
+
+- TCP stream port `5277`;
+- identity probe port `5278`;
+- UDP discovery port `5279`;
+- mDNS service type `_openautolink._tcp`.
+
+That companion launch path does not add a car Bluetooth MAC. The companion's
+`AUTO_START_BT_MACS` preference is only an ACL-connect autostart filter:
+`AutoStartReceiver` compares the connected `BluetoothDevice.address` with the
+locally stored set and starts the companion when it matches.
+
+Files and symbols:
+
+- `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt`
+  — `TcpAdvertiser.fireAaLaunchIntent` and port constants
+- `companion/src/main/java/com/openautolink/companion/autostart/AutoStartReceiver.kt`
+  — `AutoStartReceiver`
+- `companion/src/main/java/com/openautolink/companion/MainActivity.kt`
+  — `CompanionPrefs.AUTO_START_BT_MACS`
+- `companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt`
+  — preference UI
+
+---
+
+## 4. Current assumptions and bounded observations
+
+| Item | Current source behavior or observation |
+|---|---|
+| **Whose SDR MAC** | The car/head unit's Bluetooth MAC, not the phone's. |
+| **Normalization** | User override is trimmed, uppercased, and hyphens become colons. Platform-returned values are not generally normalized or validated. |
+| **Sentinels** | Empty, `02:00:00:00:00:00`, and `none` mean unavailable. |
+| **Optional SDR block** | Empty MAC omits the entire AA Bluetooth service block. Source allows the rest of SDR/session setup to continue; runtime compatibility still depends on phone behavior. |
+| **Pairing methods** | SDR advertises PIN and numeric comparison, but `JniBluetoothHandler` does not execute them. |
+| **Call audio** | `car_address` does not route calls. HFP presence listeners do not implement an Audio Gateway. |
+| **WPP phone identity** | The accepted RFCOMM socket supplies the phone Bluetooth address for per-phone endpoint ownership; this is not the SDR car MAC. |
+| **Vehicle-specific evidence** | Comments in the WPP implementation describe behavior measured on a particular GM AAOS setup, including AP direction constraints and Bluetooth-link behavior. Treat those as observations from that setup, not universal properties of every AAOS vehicle or access point. |
+
+---
+
+## 5. Checklist for a future phone-side BT-MAC behavior change
+
+For a fresh phone build and a clearly identified transport mode, compare:
+
+1. Does the phone accept an SDR with no Bluetooth service block?
+2. Does it reject malformed or non-canonical `car_address` values that OAL
+   currently passes through?
+3. Does it require `car_address` to match the Bluetooth device used for WPP or an
+   existing bond?
+4. Does it begin expecting an actual AA-channel pairing exchange rather than
+   tolerating OAL's logging-only `JniBluetoothHandler` path?
+5. Does HFP presence still affect admission, and does behavior differ between a
+   real AAOS head unit and a non-automotive test device?
+6. In WPP mode, does the pre-session RFCOMM exchange complete before TCP/SSL, and
+   is the selected phone address correlated with the endpoint it receives?
+
+Useful log anchors:
+
+- `BT MAC for SDR:`
+- `BT MAC override in use:`
+- `Bluetooth channel open`
+- `Bluetooth pairing request`
+- `Listening on Android Auto Wireless UUID`
+- `Phone dialled back on the AA Wireless UUID`
+- `Handshake: sending WifiVersionRequest`
+- `Handshake complete`
+- `HFP presence`
+
+---
+
+## 6. Source index
+
+| Concern | Current file / symbol |
+|---|---|
+| MAC resolution and SDR config assembly | `app/src/main/java/com/openautolink/app/session/SessionManager.kt` — `startSession` |
+| Override preference and normalization | `app/src/main/java/com/openautolink/app/data/AppPreferences.kt` — `BT_MAC_OVERRIDE`, `btMacOverride`, `setBtMacOverride` |
+| Override UI | `app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt` — `btMacOverride`; `SettingsViewModel.updateBtMacOverride` |
+| Diagnostic override | `app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt` — `bt_mac_override` branch |
+| SDR config field | `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt` — `btMacAddress` |
+| JNI read, channel creation, SDR emission | `app/src/main/cpp/jni_session.cpp` — `JniSession::start`, `buildServiceDiscoveryResponse`, `onServiceDiscoveryRequest` |
+| Native config storage | `app/src/main/cpp/jni_session.h` — `JniSession::SdrConfig::btMac` |
+| AA-channel no-pairing behavior | `app/src/main/cpp/jni_channel_handlers.cpp` — `JniBluetoothHandler` |
+| HFP presence | `app/src/main/java/com/openautolink/app/transport/bluetooth/HfpPresenceServer.kt` — `HfpPresenceServer` |
+| WPP RFCOMM exchange | `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt` — `handleHandshake` |
+| WPP endpoint ownership/configuration | `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt` — `startAdvertising` |
+| WPP TCP direction | `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt` — `startWpp`, `dialCompanion` |
+| Companion loopback launch | `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt` — `fireAaLaunchIntent` |
+| Companion local BT autostart filter | `companion/src/main/java/com/openautolink/companion/autostart/AutoStartReceiver.kt` — `AutoStartReceiver` |

--- a/docs/oal-resolution-negotiation-baseline.md
+++ b/docs/oal-resolution-negotiation-baseline.md
@@ -1,0 +1,340 @@
+# OpenAutoLink panel-geometry negotiation baseline
+
+This document records what the current OpenAutoLink (OAL) source advertises and
+negotiates for Android Auto video geometry. The 2914×1134 example is a
+**vehicle-specific observation** from a 2024 Chevrolet Blazer EV; it is not a
+claim about every AAOS display.
+
+---
+
+## TL;DR
+
+OAL does not advertise an arbitrary 2914×1134 codec resolution. The Android Auto
+video protocol used here exposes nine fixed landscape/portrait resolution enum
+values. OAL therefore:
+
+1. advertises an ordered ladder of standard tiers for one codec family (repository
+   default H.264 Baseline: 1920×1080, 1280×720, 800×480);
+2. computes a per-tier `width_margin` or `height_margin` so the codec frame's
+   inner content rectangle matches the live render rectangle's aspect ratio;
+3. reports density separately so Android Auto can choose an appropriate dp
+   layout; and
+4. makes the renderer use the same margin formula when scaling and clipping the
+   decoded frame.
+
+For a measured 2914×1134 render rectangle with the repository defaults, OAL's
+top H.264 tier is:
+
+- `VIDEO_1920x1080` at 60 fps;
+- `height_margin = 333`, yielding an inner 1920×747 rectangle;
+- `density = 131` when the runtime panel density is 200 dpi;
+- `pixel_aspect_ratio_e4 = 10000` (square pixels);
+- `viewing_distance = 700` and `decoder_additional_depth = 1`.
+
+The 2914×1134 dimensions are an input to margin/orientation/density math, not a
+codec resolution on the wire. If the renderer has not measured its rectangle at
+session creation, `SessionManager.startSession` falls back to window metrics for
+panel dimensions and to the saved manual DPI for density (repository default
+160); the 131 value is therefore conditional on the live 2914×1134/200-dpi
+measurement being available.
+
+---
+
+## 1. Two-stage path
+
+### Stage 1 — Kotlin assembles `AasdkSdrConfig`
+
+File and symbol:
+`app/src/main/java/com/openautolink/app/session/SessionManager.kt` —
+`SessionManager.startSession`
+
+#### Resolution preference → codec dimensions
+
+`aaResolution` maps to the Android Auto enum-compatible dimensions:
+
+- `480p` → 800×480
+- `720p` → 1280×720
+- `1080p` → 1920×1080
+- `1440p` → 2560×1440
+- `4k` → 3840×2160
+- `_p` variants → 720×1280, 1080×1920, 1440×2560, or 2160×3840
+
+`AppPreferences.DEFAULT_AA_RESOLUTION` is `1080p`. This selected size is the
+single tier in manual mode and is the base used by Kotlin's auto-DPI calculation.
+In auto-negotiate mode, C++ chooses the actual tier ladder.
+
+#### Live render rectangle
+
+`ProjectionScreen` measures the content region where the AA `SurfaceView` is
+placed and calls `ProjectionViewModel.setRenderRect`, which forwards it to
+`SessionManager.setRenderRect`. `startSession` sends that live rectangle as
+`panelWidth`/`panelHeight`; when unavailable, it falls back to
+`WindowManager.currentWindowMetrics.bounds`.
+
+The distinction matters:
+
+- `fullscreen_immersive` (the repository default) normally gives the full panel
+  rectangle;
+- `system_ui_visible` gives the smaller chrome-free content rectangle, so margin
+  and density calculations intentionally differ.
+
+The exact `system_ui_visible` height is runtime-derived and should not be treated
+as a vehicle-independent constant.
+
+Files and symbols:
+
+- `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt` —
+  render-rectangle measurement
+- `app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt` —
+  `setRenderRect`
+- `app/src/main/java/com/openautolink/app/session/SessionManager.kt` —
+  `setRenderRect`, `startSession`
+
+#### Pixel aspect ratio
+
+With `aaPixelAspect = -1` (auto), `startSession` sends
+`pixelAspectE4 = 10000`, meaning 1:1 square pixels. A positive value is an
+explicit override; zero omits the field. The current comments record that tested
+phone implementations ignored non-1.0 pixel-aspect values, so OAL uses margins
+and uniform rendering rather than depending on this field for aspect correction.
+
+#### Auto-DPI
+
+With `aaAutoDpi = true`, Kotlin mirrors the width-based GM formula:
+
+```text
+innerWidth = codecWidth - effectiveWidthMargin
+scale      = renderRectWidth / innerWidth
+density    = floor(panelDensityDpi / scale)
+```
+
+The implementation clamps the result to at least 96 dpi. If the render rectangle
+is unavailable, it uses the saved `aaDpi` value instead and logs the fallback.
+
+For a measured 2914-pixel-wide render rectangle, 1920-pixel inner width, and
+200-dpi panel:
+
+```text
+scale   = 2914 / 1920 ≈ 1.518
+ density = floor(200 / scale) = 131
+```
+
+`aaTargetLayoutWidthDp` is a separate override. In manual mode Kotlin computes
+DPI for the one selected tier. In auto-negotiate mode it passes the target to
+C++, which can compute a distinct density for each tier. Its repository default
+is zero, so this per-tier targeting is normally disabled.
+
+#### Config object
+
+`SessionManager.startSession` constructs `AasdkSdrConfig` with the selected base
+size, effective density, manual/automatic margin controls, live render rectangle,
+codec family, frame rate, pixel aspect, viewing distance, and decoder depth.
+
+`AasdkSdrConfig` itself defaults to 1920×1080, 60 fps, density 160,
+`autoMargins = true`, `autoNegotiate = true`, and codec `h265`; however,
+`SessionManager` supplies the user preference, whose repository default is
+`h264`.
+
+Files:
+
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt`
+- `app/src/main/java/com/openautolink/app/data/AppPreferences.kt`
+
+### Stage 2 — C++ emits the SDR video configurations
+
+File and symbol:
+`app/src/main/cpp/jni_session.cpp` —
+`JniSession::buildServiceDiscoveryResponse`
+
+`JniSession::start` reads the Kotlin DTO fields into `JniSession::SdrConfig`.
+`buildServiceDiscoveryResponse` then constructs the video channel.
+
+#### Fixed resolution table
+
+`kDims` maps the protocol's enum indices to codec dimensions:
+
+| Enum index | Dimensions |
+|---:|---:|
+| 1 | 800×480 |
+| 2 | 1280×720 |
+| 3 | 1920×1080 |
+| 4 | 2560×1440 |
+| 5 | 3840×2160 |
+| 6 | 720×1280 |
+| 7 | 1080×1920 |
+| 8 | 1440×2560 |
+| 9 | 2160×3840 |
+
+There is no 2914×1134 value. Supporting a new protocol enum would require source
+changes to this table and the tier selection logic.
+
+#### Orientation and tier ladders
+
+The source classifies a render rectangle as portrait only when
+`panelWidth < panelHeight`. Every wider-than-tall rectangle uses a landscape
+ladder; there is no separate ultrawide class.
+
+In auto-negotiate mode OAL advertises only the chosen codec family, largest first:
+
+- H.264 Baseline: landscape `[3, 2, 1]`, portrait `[7, 6]`;
+- H.265: landscape `[5, 4, 3, 2, 1]`, portrait `[9, 8, 7, 6]`.
+
+The source intentionally avoids mixing H.264 and H.265 in one SDR. H.264 is
+capped at 1080p; selecting H.265 enables 1440p and 4K tiers.
+
+#### Per-tier margins — `autoMargins` / `applyVideoConfig`
+
+For each advertised tier, the C++ `autoMargins` lambda mirrors
+`MarginAutoCalc.compute`:
+
+```text
+codecAR = codecWidth / codecHeight
+panelAR = panelWidth / panelHeight
+
+if relative difference < 0.5%:
+    widthMargin = heightMargin = 0
+else if codecAR > panelAR:
+    innerWidth  = round(codecHeight * panelAR)
+    widthMargin = codecWidth - innerWidth
+else:
+    innerHeight  = round(codecWidth / panelAR)
+    heightMargin = codecHeight - innerHeight
+```
+
+When a margin is nonzero, `applyVideoConfig` also splits it between the two sides
+in `UiConfig.margins`. For odd values, the second side receives the extra pixel.
+This is the SDR's centering hint.
+
+Current renderer code still anchors the inflated `SurfaceView` at the top-left.
+Its comment scopes the reason as a phone-specific observation: tested Pixel and
+Samsung implementations ignored the UI-margin hint and placed usable content at
+the top/left, with margin pixels at the bottom/right. This renderer choice should
+not be generalized to every phone without a new observation.
+
+Files and symbols:
+
+- `app/src/main/cpp/jni_session.cpp` — `autoMargins`, `applyVideoConfig`
+- `app/src/main/java/com/openautolink/app/video/MarginAutoCalc.kt` —
+  `MarginAutoCalc.compute`
+- `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt` —
+  crop-mode surface sizing, clipping, anchoring, and touch mapping
+
+#### Density and other fields
+
+`computeDensity` uses `targetLayoutWidthDp` when it is positive; otherwise every
+tier receives the single `videoDpi` computed by Kotlin. With the repository
+default target of zero, fallback tiers do **not** receive proportional DPI values.
+
+`applyVideoConfig` conditionally emits:
+
+- `pixel_aspect_ratio_e4` when positive;
+- `real_density` when positive (current `SessionManager` does not set it, so the
+  DTO default zero omits it);
+- `viewing_distance` when positive;
+- `decoder_additional_depth` when positive;
+- safe-area content insets when configured.
+
+#### Phone selection and OAL acceptance
+
+`JniSession::onMediaChannelSetupRequest` advertises acceptance of every emitted
+configuration index in auto mode. The phone communicates the selected index in
+`VideoStart.configuration_index`, handled by
+`JniSession::onMediaChannelStartIndication`.
+
+The ordered list makes index 0 the highest advertised tier. Selection is still a
+phone decision; source order alone is not proof that every phone chooses index 0.
+
+---
+
+## 2. Scoped 2914×1134 vehicle example
+
+The vehicle facts used here come from `docs/embedded-knowledge.md` and are scoped
+to a tested 2024 Chevrolet Blazer EV:
+
+- reported framebuffer: 2914×1134;
+- reported density: 200 dpi;
+- non-rectangular physical screen represented by display cutout insets.
+
+With a measured full-panel render rectangle and repository defaults
+(`videoAutoNegotiate = true`, codec `h264`, base resolution `1080p`,
+`aaAutoDpi = true`, `aaAutoMargins = true`, scaling `crop`, display mode
+`fullscreen_immersive`), C++ advertises:
+
+| idx | resolution | codec pixels | height margin | inner rectangle | density |
+|---:|---|---:|---:|---:|---:|
+| 0 | `VIDEO_1920x1080` | 1920×1080 | **333** | 1920×747 | **131** |
+| 1 | `VIDEO_1280x720` | 1280×720 | **222** | 1280×498 | **131** |
+| 2 | `VIDEO_800x480` | 800×480 | **169** | 800×311 | **131** |
+
+All three configurations also use H.264 Baseline, 60 fps,
+`pixel_aspect_ratio_e4 = 10000`, `viewing_distance = 700`, and
+`decoder_additional_depth = 1`. Width margin is zero because each codec frame is
+narrower than the 2.57:1 render rectangle and therefore needs top/bottom trimming.
+The SDR UI-margin splits are 166/167, 111/111, and 84/85 respectively.
+
+Because the default `targetLayoutWidthDp` is zero, density 131 is reused across
+tiers. Their approximate layout widths are therefore:
+
+- 1920 tier: 2345 dp;
+- 1280 tier: 1563 dp;
+- 800 tier: 977 dp.
+
+The Settings UI labels widths below 880 dp as Canonical, 880–1240 dp as
+Semi-widescreen, and above 1240 dp as Full widescreen. Those strings are an OAL
+informational hint, not part of the wire protocol.
+
+In the vehicle/phone captures that motivated this baseline, the phone selected
+configuration index 0. That is an observation from that setup, not a guarantee
+for other phones, versions, display modes, or saved settings.
+
+The source comment in `ProjectionScreen` that estimates a 358-pixel margin is a
+rough historical estimate. The shared current formula yields 333 for exactly
+2914×1134.
+
+---
+
+## 3. Assumptions and compatibility watch points
+
+1. **Fixed nine-value table.** OAL cannot emit arbitrary native panel geometry or
+   a future enum value without source changes.
+2. **Binary orientation test.** Width greater than or equal to height is treated
+   as landscape; ultrawide panels are margin-corrected landscape, not a distinct
+   class.
+3. **Hardcoded 0.5% tolerance.** The same threshold exists in C++ and Kotlin and
+   must remain synchronized.
+4. **One codec family per SDR.** H.264 is capped at 1080p; H.265 enables larger
+   tiers but is not mixed with H.264.
+5. **Width-based auto-DPI.** Kotlin derives density from render width and inner
+   codec width. A phone version that changes its layout breakpoint or uses a
+   different physical-size interpretation may render differently.
+6. **One default density for all tiers.** Unless `targetLayoutWidthDp` is set,
+   Kotlin's density for the selected base resolution is reused by every fallback
+   tier.
+7. **Runtime measurement race.** Before `ProjectionScreen` reports the render
+   rectangle, panel dimensions and density use fallback paths. A first session
+   can therefore differ from a later session without any setting change.
+8. **SDR margin hint vs observed phone placement.** C++ sends symmetric
+   `UiConfig.margins`, while the renderer's top-left anchor is based on scoped
+   phone observations. A phone-side change in margin placement can expose an
+   alignment mismatch.
+9. **Display-mode dependence.** `system_ui_visible` changes the render rectangle;
+   it is expected to produce different margins and density from full-screen mode.
+
+---
+
+## 4. Source index
+
+| Concern | Current file / symbol |
+|---|---|
+| Resolution mapping, auto-DPI, panel rectangle, SDR config | `app/src/main/java/com/openautolink/app/session/SessionManager.kt` — `startSession` |
+| Render-rectangle reporting | `app/src/main/java/com/openautolink/app/session/SessionManager.kt` — `setRenderRect`; `ProjectionViewModel.setRenderRect` |
+| Repository defaults | `app/src/main/java/com/openautolink/app/data/AppPreferences.kt` — `DEFAULT_VIDEO_AUTO_NEGOTIATE`, `DEFAULT_VIDEO_CODEC`, `DEFAULT_VIDEO_FPS`, `DEFAULT_DISPLAY_MODE`, `DEFAULT_AA_*` |
+| Kotlin SDR DTO | `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt` — `AasdkSdrConfig` |
+| JNI field reads | `app/src/main/cpp/jni_session.cpp` — `JniSession::start` |
+| Resolution table, tier ladders, margins, density, SDR emission | `app/src/main/cpp/jni_session.cpp` — `JniSession::buildServiceDiscoveryResponse`, `kDims`, `autoMargins`, `applyVideoConfig`, `computeDensity` |
+| Configuration acceptance | `app/src/main/cpp/jni_session.cpp` — `JniSession::onMediaChannelSetupRequest` |
+| Selected configuration log | `app/src/main/cpp/jni_session.cpp` — `JniSession::onMediaChannelStartIndication` |
+| Shared Kotlin margin formula | `app/src/main/java/com/openautolink/app/video/MarginAutoCalc.kt` — `MarginAutoCalc.compute` |
+| Crop renderer and phone-specific anchor observation | `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt` — crop-mode `SurfaceView` sizing and clipping |
+| Layout-bucket hint | `app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt` — AA layout width helper text |
+| Vehicle-scoped panel facts | `docs/embedded-knowledge.md` — `Car Hardware (GM Blazer EV, gminfo platform)` |


### PR DESCRIPTION
## Summary
- publish the current car Bluetooth-MAC exchange baseline across SDR, WPP, HFP presence, and companion autostart
- publish the current Android Auto panel-geometry negotiation baseline, including fixed resolution tiers, margins, density, renderer behavior, and the scoped 2914×1134 Blazer example

## Public-safety and durability cleanup
- removed internal Kanban/workspace references and dependencies on ignored recon corpora
- replaced fragile line-number-only citations with current repository files and symbols
- separated car MAC, phone MAC, WPP endpoint ownership, HFP presence, and companion autostart roles
- scoped all vehicle/phone-specific measurements rather than presenting them as universal AAOS behavior

## Verification
- every cited repository path exists on current `main`
- cited symbols, defaults, ports, codec ladders, and WPP flow were checked against current source
- 2914×1134 margin, density, split, and layout-width calculations were independently recomputed
- independent review: PASS with no blocking gaps
- documentation-only change
