### PR TITLE
fix(gps): honor forwarding toggle (#23)

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -248,6 +248,7 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     sdrConfig_.hideClock = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "hideClock", "Z"));
     sdrConfig_.hideSignal = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "hideSignal", "Z"));
     sdrConfig_.hideBattery = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "hideBattery", "Z"));
+    sdrConfig_.gpsForwarding = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "gpsForwarding", "Z"));
     sdrConfig_.autoNegotiate = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "autoNegotiate", "Z"));
     sdrConfig_.videoCodec = readString("videoCodec");
     sdrConfig_.realDensity = env->GetIntField(sdrConfig, env->GetFieldID(sdrClass, "realDensity", "I"));
@@ -1551,7 +1552,9 @@ void JniSession::buildServiceDiscoveryResponse(
       namespace ST = aap_protobuf::service::sensorsource::message;
       auto* ss = svc->mutable_sensor_source_service();
       ss->add_sensors()->set_sensor_type(ST::SENSOR_DRIVING_STATUS_DATA);
-      ss->add_sensors()->set_sensor_type(ST::SENSOR_LOCATION);
+      if (sdrConfig_.gpsForwarding) {
+          ss->add_sensors()->set_sensor_type(ST::SENSOR_LOCATION);
+      }
       ss->add_sensors()->set_sensor_type(ST::SENSOR_NIGHT_MODE);
       ss->add_sensors()->set_sensor_type(ST::SENSOR_SPEED);
       ss->add_sensors()->set_sensor_type(ST::SENSOR_GEAR);
@@ -1586,7 +1589,8 @@ void JniSession::buildServiceDiscoveryResponse(
               ss->add_supported_ev_connector_types(static_cast<FT::EvConnectorType>(ct));
           }
       }
-      LOGI("SDR sensor: %zu fuel types, %zu ev connectors",
+      LOGI("SDR sensor: location=%s, %zu fuel types, %zu ev connectors",
+           sdrConfig_.gpsForwarding ? "advertised" : "omitted",
            sdrConfig_.fuelTypes.empty() ? 1u : sdrConfig_.fuelTypes.size(),
            sdrConfig_.evConnectorTypes.empty() ? 2u : sdrConfig_.evConnectorTypes.size());
     }

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -355,6 +355,7 @@ private:
         bool hideClock = false;
         bool hideSignal = false;
         bool hideBattery = false;
+        bool gpsForwarding = true;
         bool autoNegotiate = true;
         std::string videoCodec = "h265";
         int realDensity = 0;

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -186,6 +186,7 @@ class SettingsReceiver : BroadcastReceiver() {
                     aaAutoMargins = prefs.aaAutoMargins.first(),
                     videoFps = prefs.videoFps.first(),
                     driveSide = prefs.driveSide.first(),
+                    gpsForwarding = prefs.gpsForwarding.first(),
                     manualIpAddress = if (prefs.manualIpEnabled.first())
                         prefs.manualIpAddress.first().takeIf { it.isNotBlank() } else null,
                 )

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -542,6 +542,7 @@ class SessionManager(
 
     // Direct mode location listener
     private var _directLocationListener: android.location.LocationListener? = null
+    private var gpsForwardingEnabled: Boolean = true
 
     // Navigation display
     private val _navigationDisplay: NavigationDisplay = NavigationDisplayImpl()
@@ -855,10 +856,12 @@ class SessionManager(
         safeAreaBottom: Int = 0,
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
+        gpsForwarding: Boolean = true,
     ) {
         // Cache for later reconnects that don't know the resolved IP (e.g.
         // Settings "Save & Reconnect" in Car Hotspot mode).
         if (!manualIpAddress.isNullOrBlank()) _lastManualIpAddress = manualIpAddress
+        gpsForwardingEnabled = gpsForwarding
         micSource = micSourcePreference
         observeJob?.cancel()
 
@@ -1133,7 +1136,8 @@ class SessionManager(
                 videoFps,
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
-                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight)
+                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+                gpsForwarding)
         }
 
         // Listen for system sleep so we can gracefully tear down before the
@@ -1156,6 +1160,7 @@ class SessionManager(
         scalingMode: String = "letterbox",
         manualIpAddress: String? = null,
         safeAreaTop: Int = 0, safeAreaBottom: Int = 0, safeAreaLeft: Int = 0, safeAreaRight: Int = 0,
+        gpsForwarding: Boolean = true,
     ) {
         aasdkSession?.stop()
         _transportMode.value = directTransport
@@ -1397,6 +1402,7 @@ class SessionManager(
             hideClock = hideClock,
             hideSignal = hideSignal,
             hideBattery = hideBattery,
+            gpsForwarding = gpsForwarding,
             autoNegotiate = videoAutoNegotiate,
             videoCodec = codec,
             // realDensity removed — interferes with pixel_aspect_ratio_e4 on some AA versions
@@ -1533,6 +1539,10 @@ class SessionManager(
     @android.annotation.SuppressLint("MissingPermission")
     private fun startLocationForwarding(session: AasdkSession) {
         stopDirectLocationForwarding()
+        if (!gpsForwardingEnabled) {
+            OalLog.i(TAG, "GPS forwarding disabled by setting — phone will use its own location")
+            return
+        }
         val ctx = context ?: return
         val lm = ctx.getSystemService(Context.LOCATION_SERVICE) as? android.location.LocationManager ?: return
         if (!lm.isProviderEnabled(android.location.LocationManager.GPS_PROVIDER)) {
@@ -1717,6 +1727,7 @@ class SessionManager(
         safeAreaBottom: Int = 0,
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
+        gpsForwarding: Boolean = true,
     ) {
         // "Save & Reconnect" from Settings doesn't know the resolved Car
         // Hotspot IP — fall back to the last value we successfully used so
@@ -1735,6 +1746,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery,
                 volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                 effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+                gpsForwarding,
             )
             return
         }
@@ -1773,6 +1785,7 @@ class SessionManager(
         }
         reconnectInProgress = true
         reconnectStartedAt = System.currentTimeMillis()
+        gpsForwardingEnabled = gpsForwarding
         OalLog.i(TAG, "Reconnecting AA session with new settings (minimal restart)")
         micSource = micSourcePreference
 
@@ -1815,6 +1828,7 @@ class SessionManager(
                     videoFps, driveSide, hideClock, hideSignal, hideBattery,
                     volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                     effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+                    gpsForwarding,
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
@@ -1840,6 +1854,7 @@ class SessionManager(
         volumeOffsetMedia: Int, volumeOffsetNavigation: Int, volumeOffsetAssistant: Int,
         manualIpAddress: String?,
         safeAreaTop: Int, safeAreaBottom: Int, safeAreaLeft: Int, safeAreaRight: Int,
+        gpsForwarding: Boolean,
     ) {
         observeJob = null
         decoderWatchJob = null
@@ -1900,7 +1915,8 @@ class SessionManager(
                 videoFps,
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
-                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight)
+                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+                gpsForwarding)
         }
 
         // 9. Re-establish cluster binding — GM Templates Host may have killed

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
@@ -62,6 +62,9 @@ class AasdkSdrConfig(
     /** Hide battery indicator in AA status bar. */
     @JvmField val hideBattery: Boolean = false,
 
+    /** Advertise and send the head unit's location to Android Auto. */
+    @JvmField val gpsForwarding: Boolean = true,
+
     /** Auto-negotiate video: true = send all resolutions/codecs, false = send only the configured one. */
     @JvmField val autoNegotiate: Boolean = true,
 

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -594,6 +594,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
             val hideBattery = preferences.hideBatteryLevel.first()
+            val gpsForwarding = preferences.gpsForwarding.first()
 
             // Safe area insets
             val saTop = preferences.safeAreaTop.first()
@@ -797,6 +798,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 safeAreaBottom = saBottom,
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
+                gpsForwarding = gpsForwarding,
             )
     }
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -620,6 +620,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
             val hideBattery = preferences.hideBatteryLevel.first()
+            val gpsForwarding = preferences.gpsForwarding.first()
             val volMedia = preferences.volumeOffsetMedia.first()
             val volNav = preferences.volumeOffsetNavigation.first()
             val volAssistant = preferences.volumeOffsetAssistant.first()
@@ -660,6 +661,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 safeAreaBottom = saBottom,
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
+                gpsForwarding = gpsForwarding,
             )
         }
     }

--- a/app/src/test/java/com/openautolink/app/session/GpsForwardingContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/GpsForwardingContractTest.kt
@@ -1,0 +1,54 @@
+package com.openautolink.app.session
+
+import com.openautolink.app.transport.aasdk.AasdkSdrConfig
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GpsForwardingContractTest {
+
+    @Test
+    fun `service discovery advertises vehicle location by default`() {
+        assertTrue(AasdkSdrConfig().gpsForwarding)
+    }
+
+    @Test
+    fun `service discovery can disable vehicle location`() {
+        assertFalse(AasdkSdrConfig(gpsForwarding = false).gpsForwarding)
+    }
+
+    @Test
+    fun `session manager gates location samples and passes setting to service discovery`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+        val forwarding = source.substringAfter("private fun startLocationForwarding")
+            .substringBefore("private fun stopDirectLocationForwarding")
+
+        assertTrue(forwarding.contains("if (!gpsForwardingEnabled)"))
+        assertTrue(forwarding.contains("GPS forwarding disabled by setting"))
+        assertTrue(source.contains("gpsForwardingEnabled = gpsForwarding"))
+        assertTrue(source.contains("gpsForwarding = gpsForwarding,"))
+    }
+
+    @Test
+    fun `native service discovery omits location capability when forwarding is off`() {
+        val source = projectFile("app/src/main/cpp/jni_session.cpp").readText()
+        val sensorBlock = source.substringAfter("// ---- Sensor channel ----")
+            .substringBefore("// ---- Input channel ----")
+
+        assertTrue(sensorBlock.contains("if (sdrConfig_.gpsForwarding)"))
+        assertTrue(sensorBlock.contains("set_sensor_type(ST::SENSOR_LOCATION)"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        var current = File(System.getProperty("user.dir")).canonicalFile
+        repeat(8) {
+            val candidate = File(current, relativePath)
+            if (candidate.exists()) return candidate
+            current = current.parentFile ?: return@repeat
+        }
+        error("Unable to locate project file: $relativePath")
+    }
+}


### PR DESCRIPTION
## Summary

- wire the existing **GPS Forwarding** setting into every session start/reconnect path
- stop registering and sending car `LocationManager` fixes when the setting is off
- omit `SENSOR_LOCATION` from Android Auto service discovery when off, allowing the phone to use its own GPS
- preserve the existing default-on behavior
- add truthful runtime outcomes for both sample forwarding and advertised capability

## Verification

- full car-app unit suite: **322 tests, 0 failures/errors**
- focused GPS contract after final rebase: **4 tests, 0 failures/errors**
- `:app:externalNativeBuildDebug --rerun-tasks`: passed for arm64-v8a and x86_64
- signed release AAB: signature verified
- actual 0.1.445 AAB contains `gpsForwarding` and `SDR sensor: location=%s` in both native ABIs
- independent review: PASS, no blockers

## Release

Shipped to Play `automotive:internal` as **0.1.445 / versionCode 445**, status `completed`.

This is shipped code pending an in-car confirmation. With GPS Forwarding off, the expected log outcomes are:

- `GPS forwarding disabled by setting — phone will use its own location`
- `SDR sensor: location=omitted`

Refs #23
