### PR TITLE
docs: publish AA-independent architecture research

### DIFF
--- a/docs/research/aa-replacement-aa-apk.md
+++ b/docs/research/aa-replacement-aa-apk.md
@@ -1,0 +1,315 @@
+# Android Auto 17.4 teardown: implications for an AA-independent OpenAutoLink
+
+**Build analyzed:** `com.google.android.projection.gearhead` 17.4.663004-release (`versionCode=174663004`)
+
+**Base APK SHA-256:** `28c0810a538001251f4707424216d1bbfc2628d1e522efb95eaac1c951e8e388`
+
+**Current-version check:** `apkeep -l -d apk-pure` on 2026-08-09 still ended at 17.4.663004-release.
+
+**Method:** a preserved signal inventory plus a fresh low-RAM decode. Apktool produced 27,854 smali files/resources under a 6 GB virtual-memory ceiling; JADX was restricted to 24 targeted classes. No full JADX retry was used. The decisive findings and artifact identity are summarized below so this document does not depend on an unpublished decode tree.
+
+## Executive result
+
+Android Auto on the phone is not merely the producer of one projected framebuffer. It is all of the following at once:
+
+1. a privileged package/app discovery and validation authority;
+2. a host for legacy Google car-projection services and Android for Cars App Library services;
+3. a compositor that owns multiple app/system windows and map/dashboard/rail/notification/assistant regions;
+4. a virtual/trusted-display manager;
+5. the central policy engine for distraction limits, template permissions, notification access, audio focus, calls, input, lifecycle, and assistant behavior;
+6. the AA protocol endpoint that converts the composed phone UI to the video/audio/input/sensor channels OAL already consumes.
+
+A clean-room OAL replacement can reproduce the shell and host **apps designed to trust it**, but a normally signed phone app cannot transparently host official projected Google Maps. The current Maps service separately confirms that its presentation path accepts only Google-signed callers or callers with signature-level `CAPTURE_VIDEO_OUTPUT`.
+
+## 1. The shipped package is a privileged multi-app host
+
+The preserved 17.4 signal snapshot found:
+
+- 1,136 feature flags;
+- 87 services;
+- 57 activities;
+- 86 permissions;
+- 26,074 Java files in the prior successful complete decode;
+- 762 layouts.
+
+The manifest/services include separate hosts for:
+
+- `TemplateService`
+- `TemplateNavigationService`
+- `TemplatePartialImmersiveService`
+- `TemplateFullScreenImmersiveService`
+- `TemplateAuxiliaryDisplayService`
+- `TemplateClusterService`
+- `MediaService`
+- `GhAppLauncherService`
+- `TelecomService`
+- `PhoneCarAppService`
+- `MessagingCarAppService`
+- `LauncherCarAppService`
+- `CarLocalMediaBrowserService`
+- rotary and touch input services
+- projection lifecycle/recovery services
+
+The APK's `automotive_app_desc.xml` declares these automotive roles:
+
+```xml
+<automotiveApp>
+    <uses name="service" />
+    <uses name="projection" />
+    <uses name="media" />
+    <uses name="template" />
+</automotiveApp>
+```
+
+This is a host runtime, not a single “Maps mirror.”
+
+## 2. App discovery is package- and certificate-controlled
+
+The targeted caller-validator class (`jjt` in this obfuscated build) does the following:
+
+1. gets `Binder.getCallingUid()`;
+2. enumerates every package for that UID;
+3. checks whether each package is Google-signed;
+4. checks whether the package is in an allowed-package set;
+5. accepts only when **both** are true;
+6. caches accepted UIDs.
+
+The surviving log text is explicit:
+
+```text
+Package %s for uid %d: isGoogleSigned = %b, isPackageAllowed = %b
+Call from UID %d is not allowed.
+```
+
+The semantic snapshot also contains:
+
+- `AppValidation__allowed_3p_installers`
+- `AppValidation__allowed_package_list`
+- `AppValidation__blocked_packages_by_installer`
+- `AppValidation__dhu_bypass_validation`
+- `AppValidation__should_bypass_validation`
+
+**Implication:** implementing Binder protocols is necessary but not sufficient. The host and/or app caller identity is a first-class security boundary. An OAL package cannot become Google-signed, and spoofing package/signature identity is not a distributable architecture.
+
+**Confidence:** high; current Java control flow and stable flags agree.
+
+## 3. Official Maps is a special, private projected service
+
+The targeted startup-map class (`ima` in this obfuscated build) hardcodes the official Maps primary component:
+
+```text
+com.google.android.apps.maps/
+  com.google.android.apps.gmm.car.GmmCarProjectionService
+```
+
+It places that service beside gearhead-owned components for launcher, media, telecom, templates, and assistant in the cold/warm/hot startup maps. Maps is therefore not “just another generic app Activity” inside AA.
+
+The service gate was separately reproduced in Google Maps 26.32.06.958047303 (`versionCode=1068717991`; XAPK SHA-256 `67b4f29201baa43aa04061d952ee6c3b3ecd5d1b92ab82bdece1c00b1cacbec3`; base APK SHA-256 `3d40ac68458ae0c573ce4d99e5082159d3d5369feb091b11700ba8064e535e0a`). The targeted inspection covered the manifest, projection-client gate, Google certificate verifier, and `ICarProjection` Binder implementation.
+
+Maps exports `GmmCarProjectionService`, and it returns an `ICarProjection` Binder. However, presentation calls enumerate caller packages and require either:
+
+- a positive GMS `GoogleCertificatesLookupQuery` result; or
+- `android.permission.CAPTURE_VIDEO_OUTPUT`.
+
+Otherwise Maps throws:
+
+```text
+projection client manager does not have permission:
+android.permission.CAPTURE_VIDEO_OUTPUT pid:<...> uid:<...>
+```
+
+`CAPTURE_VIDEO_OUTPUT` is not available to a normal Play-installed companion. This closes the apparent loophole created by the exported service.
+
+**Conclusion:** binding is possible; controlling/rendering the official projected Maps presentation is not possible for normally signed OAL on a stock phone.
+
+**Confidence:** very high; reproduced in the newest advertised Maps binary, not inferred from an old build.
+
+## 4. Car App Library hosting is real but does not unlock arbitrary official apps
+
+The 17.4 APK contains the Android for Cars App Library Binder/model stack and enforces template permissions. The targeted permission-check class (`ghd` in this obfuscated build) checks:
+
+- `androidx.car.app.MAP_TEMPLATES`
+- `androidx.car.app.NAVIGATION_TEMPLATES`
+- `androidx.car.app.MEDIA_TEMPLATES`
+- location permissions for map templates
+
+It handles templates including:
+
+- `MapWithContentTemplate`
+- `PlaceListMapTemplate`
+- `PlaceListNavigationTemplate`
+- `RoutePreviewNavigationTemplate`
+- `GridTemplate`
+- `ListTemplate`
+- `PaneTemplate`
+- `TabTemplate`
+- `SignInTemplate`
+
+The feature surface is extensive: 53 current `CarAppLibrary__*` flags cover package exceptions, refresh throttling, speedbumps, map-template input, theming, list limits, media style, and navigation behavior.
+
+A clean-room host can theoretically implement the public Binder/template model and host:
+
+- OAL-owned apps;
+- sample apps configured with `ALLOW_ALL_HOSTS_VALIDATOR`;
+- apps whose `HostValidator` explicitly includes OAL's package and signing digest.
+
+It cannot assume that arbitrary Play apps will trust an unknown host. Car App Library's own host validation accepts a caller only when one of these is true:
+
+- app allowlists the host package + signing digest;
+- caller is system UID;
+- caller holds `android.car.permission.TEMPLATE_RENDERER`;
+- app deliberately allows all hosts.
+
+OAL cannot obtain `TEMPLATE_RENDERER` as a normal phone or car app.
+
+**Conclusion:** a clean-room CAL host is a credible ecosystem experiment, not a route to official Maps parity.
+
+**Confidence:** high for the protocol/validator; app-by-app compatibility requires runtime tests.
+
+## 5. The shell is a compositor of named regions and windows
+
+The decoded `ProjectionRootActivity` creates a root `FrameLayout`, consumes negotiated usable width/height/margins/pixel-aspect geometry, and maintains a map of projected windows. Its diagnostics enumerate each window's:
+
+- ID/name;
+- bounds;
+- Z position;
+- composition order;
+- alpha;
+- attached package.
+
+The current `sys_ui_cielo_layout_narrow_portrait.xml` contains distinct regions for:
+
+- `map` and `map_compat`
+- `dashboard` and `cielo_dashboard`
+- `activity` and `activity_compat`
+- immersive and immersive toolbar
+- notification center and heads-up notification
+- demand surface
+- assistant partial/fullscreen surfaces
+- rail and demand rail
+- map IME and general IME
+- integrated overlay
+- fullscreen and rounded-corner mask
+
+The map is full-parent in the Cielo narrow-portrait layout, with dashboard/rail/activity regions layered above or constrained around it. This is a scene compositor, not a monolithic app screen.
+
+### New-layout evidence
+
+The current resource/flag set includes:
+
+- `SystemUi__narrow_portrait_enabled_kill_switch`
+- `SystemUi__wide_portrait_as_widescreen_enabled_kill_switch`
+- `SystemUi__hero_large_canonical_layout_enabled_kill_switch`
+- `SystemUi__vertical_rail_widget_enabled`
+- `SystemUi__use_compose_rail`
+- `CieloFeature__default_widgets_config`
+- `CieloFeature__earth_enabled`
+- `CieloFeature__earth_mini_dashboard_card_enabled`
+- `CieloFeature__earth_dashboard_widget_combo_enabled`
+- `CieloFeature__earth_tilt`
+- `ApolloFeature__expressive_enabled`
+
+Preserved layouts include narrow portrait, hero SOIP, projected-app, map-template, and media-playback structures.
+
+**What OAL may safely reproduce:** geometry classes, responsive behavior, rail/dashboard/widget concepts, drive-side adaptation, window insets, focus model, and original visual design inspired by observed behavior.
+
+**What OAL should not copy:** Google's source, exact assets, logos, strings, or a pixel-identical branded trade dress. Use clean-room Compose code and OAL design tokens.
+
+## 6. Virtual-display and protected-output dependence
+
+The targeted virtual-display class (`rab` in this obfuscated build) creates or attaches a `VirtualDisplay`, owns its `Surface`, swaps surfaces, and fails hard on `SecurityException`.
+
+The gearhead manifest declares privileges unavailable to OAL, including:
+
+- `android.permission.CREATE_VIRTUAL_DEVICE`
+- `android.permission.ADD_TRUSTED_DISPLAY`
+- `android.permission.ADD_ALWAYS_UNLOCKED_DISPLAY`
+- `android.permission.CAPTURE_SECURE_VIDEO_OUTPUT`
+- `android.permission.ACTIVITY_EMBEDDING`
+- `android.permission.QUERY_ALL_PACKAGES`
+- `android.permission.SYSTEM_ALERT_WINDOW`
+- automotive projection-control permissions
+
+Projection-window flags include secure-video detection/capture behavior.
+
+**Implication:** OAL can create ordinary virtual displays/surfaces that it owns, but it cannot reproduce gearhead's trusted/always-unlocked/secure-output environment as a stock app. This affects arbitrary Activity hosting, protected content, lock state, and secure surfaces.
+
+## 7. Media, Spotify, calls, notifications, and assistant are separate host subsystems
+
+AA does not obtain all app content through the AA wire protocol. It hosts local phone services and then projects the composed result.
+
+### Spotify/media
+
+The current Spotify 9.1.72.1891 targeted teardown shows:
+
+- enabled exported `SpotifyMediaBrowserService`;
+- disabled Car App Library `AndroidAutoService`;
+- enabled exported `AppProtocolRemoteService`.
+
+Spotify's MediaBrowser handler validates caller package, UID, signing certificate, and service identity against a baked list. Android Auto/gearhead is listed; OAL is not. Therefore OAL cannot simply connect as a generic media browser and inherit the AA catalog.
+
+Spotify App Remote is the viable supported seam: register OAL's app ID and signing fingerprint, obtain semantic playback/catalog state and controls, and render OAL's own UI. Audio should remain on the native Bluetooth/media route unless a separately licensed/capturable stream exists.
+
+### Calls
+
+AA owns call presentation/control services, but actual voice audio can remain on the vehicle's native HFP/SCO endpoint. An AA-free OAL shell should preserve that separation and not plan to capture telephony PCM.
+
+### Notifications
+
+Gearhead owns notification listener/filter/action services. A replacement needs its own user-granted `NotificationListenerService`, safety filtering, action allowlist, privacy behavior, and Play-policy review.
+
+### Assistant
+
+Gearhead integrates Google Assistant/Gemini through private services and callbacks. OAL cannot assume access to that stack. A successor needs either public assistant intents, `SpeechRecognizer`, or an OAL-owned voice-command system.
+
+## 8. Protocol channels remain useful only as an optional AA backend
+
+OAL already speaks the AA wire protocol and should retain that working backend during migration. The AA protocol delivers:
+
+- composed encoded video;
+- purpose-separated audio;
+- microphone requests;
+- input/touch;
+- sensor/GNSS/VHAL data;
+- navigation status;
+- media playback status;
+- phone status;
+- focus/lifecycle/ping/ByeBye.
+
+Removing gearhead removes the producer of those streams. A successor must define new OAL-owned semantic or media channels rather than pretending the existing AA protobufs are generic.
+
+Recommended split:
+
+```text
+OalContentBackend
+  ├─ AaBackend               current AASDK/JNI/WPP path
+  ├─ NativeHandoffBackend    launch installed AAOS apps as separate tasks
+  ├─ ApiDashboardBackend     public nav/media/notification integrations
+  └─ RemoteRendererBackend   OAL-owned phone renderer and protocol
+```
+
+## 9. Feasibility verdict by goal
+
+| Goal | Stock phone + Play-installed OAL | Why |
+|---|---:|---|
+| Keep current AA projection | Proven | Existing OAL/AASDK backend |
+| Build an OAL-owned responsive AA-like shell | Feasible | OAL owns Compose/layout/surfaces |
+| Host OAL-owned CAL apps | Feasible | App can trust OAL host |
+| Host arbitrary third-party CAL apps | Conditional | Each app's HostValidator decides |
+| Show official Spotify semantics/controls in OAL UI | Plausible | Supported App Remote route, registration required |
+| Embed official Spotify Activity UI | Not supported | Cross-app Activity/task embedding privilege wall |
+| Bind official projected Maps service | Yes | Service exported |
+| Render/control official projected Maps | No | Google certificate or `CAPTURE_VIDEO_OUTPUT` required |
+| Mirror arbitrary official apps | Demo-only at best | consent, secure surface, input, audio, policy limits |
+| Recreate gearhead's trusted display environment | No | signature/system privileges |
+| Do all of the above with OEM/platform signing | Technically plausible | OEM can grant task/display/SystemUI privileges |
+
+## 10. What should be built
+
+The app-only product should be framed honestly as:
+
+> **An OAL-owned automotive shell with native-app handoff, supported semantic integrations, optional OAL-owned remote rendering, and the existing Android Auto backend retained until AA-free parity is proven.**
+
+It should not be framed as “official Maps and Spotify embedded inside OAL,” because current binaries prove that requirement crosses certificate and platform privilege boundaries.
+
+The practical next step is the backend split above: preserve AA as a compatibility backend, validate native handoff and supported API integrations independently, and stop any experiment when its certificate, permission, policy, or licensing kill gate is reached.

--- a/docs/research/aa-replacement-aa-apk.md
+++ b/docs/research/aa-replacement-aa-apk.md
@@ -219,18 +219,28 @@ Preserved layouts include narrow portrait, hero SOIP, projected-app, map-templat
 
 The targeted virtual-display class (`rab` in this obfuscated build) creates or attaches a `VirtualDisplay`, owns its `Surface`, swaps surfaces, and fails hard on `SecurityException`.
 
-The gearhead manifest declares privileges unavailable to OAL, including:
+The gearhead manifest declares several capabilities that a normal OAL install does
+not receive. The load-bearing display/hosting restrictions include:
 
 - `android.permission.CREATE_VIRTUAL_DEVICE`
 - `android.permission.ADD_TRUSTED_DISPLAY`
 - `android.permission.ADD_ALWAYS_UNLOCKED_DISPLAY`
 - `android.permission.CAPTURE_SECURE_VIDEO_OUTPUT`
 - `android.permission.ACTIVITY_EMBEDDING`
-- `android.permission.QUERY_ALL_PACKAGES`
-- `android.permission.SYSTEM_ALERT_WINDOW`
 - automotive projection-control permissions
 
-Projection-window flags include secure-video detection/capture behavior.
+Two adjacent permissions have different boundaries and should not be described as
+signature-only:
+
+- `android.permission.QUERY_ALL_PACKAGES` is a normal manifest permission, but
+  Google Play restricts and reviews its use. It enables package visibility; it
+  does not grant task hosting, display capture, or caller trust.
+- `android.permission.SYSTEM_ALERT_WINDOW` is a special app-op that a user may
+  grant through system settings. It permits overlays within platform policy; it
+  does not grant secure-surface capture, trusted-display creation, or arbitrary
+  task embedding.
+
+Projection-window flags also include secure-video detection/capture behavior.
 
 **Implication:** OAL can create ordinary virtual displays/surfaces that it owns, but it cannot reproduce gearhead's trusted/always-unlocked/secure-output environment as a stock app. This affects arbitrary Activity hosting, protected content, lock state, and secure surfaces.
 

--- a/docs/research/aa-replacement-gm-maps-media.md
+++ b/docs/research/aa-replacement-gm-maps-media.md
@@ -2,13 +2,25 @@
 
 **Vehicle corpus:** GM Android 12 / SDK 32, build family `VCUSR5-163/239`
 
-**Templates Host APK:** `com.google.android.apps.automotive.templates.host` 1.007.893018827.00-arm64-v8a (`versionCode=18034`)
+**Load-bearing GM/AAOS artifacts:**
+
+| Package | Version | SHA-256 |
+|---|---|---|
+| `com.google.android.apps.automotive.templates.host` | `1.007.893018827.00-arm64-v8a` (`versionCode=18034`) | `0da77a8b895494839cb636c05f0557d15deb4b69d54c122c271f6d6be2fa31e8` |
+| `com.gm.homescreen` | `12` (`versionCode=32`) | `4845b12e4c0e8eb0dc332ae8ff5055cc5952034e95d5cb3709f2a1c79477ec4b` |
+| `com.android.systemui` | `12` (`versionCode=32`) | `61e1fe5cc6641e4fe4dc708aac9084eecab541ce7002982560a68357baee0b21` |
+| `com.gm.hmi.androidauto` | `1.0` (`versionCode=1`) | `d53e783bef22423c2160a216bd7cefa1b8cf15ca6106137197af4d3a0021401c` |
 
 **Phone Maps refreshed:** 26.32.06.958047303 (`versionCode=1068717991`; XAPK SHA-256 `67b4f29201baa43aa04061d952ee6c3b3ecd5d1b92ab82bdece1c00b1cacbec3`; base APK SHA-256 `3d40ac68458ae0c573ce4d99e5082159d3d5369feb091b11700ba8064e535e0a`)
 
 **Phone Spotify refreshed:** 9.1.72.1891 (`versionCode=144716725`; XAPK SHA-256 `db0cee9975c9599535dd3b5520e0e69e42284e12b9f7049d60e80e8f74db27dd`; base APK SHA-256 `946aa2b57107f1c9fd387512b8c80951a5f8af9843d86107babb635fcf67cc91`)
 
-**Method:** targeted inspection of the GM/AAOS packages, an in-car Maps build, current phone APK manifests, the current Maps presentation gate, and selected Spotify classes. The conclusions below summarize the decisive evidence and do not require access to local decompile output. Heavy decompilation was avoided.
+**Method:** targeted inspection of the identified GM/AAOS packages, current phone
+APK manifests, the current Maps presentation gate, and selected Spotify classes.
+A legacy in-car Maps Java corpus was used only as contextual corroboration; its
+original APK identity was not retained, so no load-bearing feasibility conclusion
+rests solely on it. The conclusions below summarize the decisive evidence and do
+not require access to local decompile output. Heavy decompilation was avoided.
 
 ## Executive conclusion
 
@@ -129,7 +141,12 @@ The verifier calls GMS `GoogleCertificatesLookupQuery`/`GoogleCertificatesLookup
 
 ## 5. Native AAOS Maps is a separate product
 
-The analyzed in-car Maps build is distinct from the phone APK. It contains Android for Cars App Library models plus EV-energy/navigation logic of the same kind used by OAL's battery/range integration.
+A legacy in-car Maps Java corpus—retained without its original APK identity—shows
+Android for Cars App Library models plus EV-energy/navigation logic of the same
+kind used by OAL's battery/range integration. Treat that corpus as contextual
+corroboration only. The load-bearing product boundary here comes from the
+identified GM homescreen/SystemUI artifacts: native apps run as separate tasks,
+while embedding/reparenting another app requires system task-organizer authority.
 
 Native AAOS Maps can be:
 

--- a/docs/research/aa-replacement-gm-maps-media.md
+++ b/docs/research/aa-replacement-gm-maps-media.md
@@ -1,0 +1,296 @@
+# GM/AAOS, Google Maps, and Spotify teardown findings for an AA-independent OAL
+
+**Vehicle corpus:** GM Android 12 / SDK 32, build family `VCUSR5-163/239`
+
+**Templates Host APK:** `com.google.android.apps.automotive.templates.host` 1.007.893018827.00-arm64-v8a (`versionCode=18034`)
+
+**Phone Maps refreshed:** 26.32.06.958047303 (`versionCode=1068717991`; XAPK SHA-256 `67b4f29201baa43aa04061d952ee6c3b3ecd5d1b92ab82bdece1c00b1cacbec3`; base APK SHA-256 `3d40ac68458ae0c573ce4d99e5082159d3d5369feb091b11700ba8064e535e0a`)
+
+**Phone Spotify refreshed:** 9.1.72.1891 (`versionCode=144716725`; XAPK SHA-256 `db0cee9975c9599535dd3b5520e0e69e42284e12b9f7049d60e80e8f74db27dd`; base APK SHA-256 `946aa2b57107f1c9fd387512b8c80951a5f8af9843d86107babb635fcf67cc91`)
+
+**Method:** targeted inspection of the GM/AAOS packages, an in-car Maps build, current phone APK manifests, the current Maps presentation gate, and selected Spotify classes. The conclusions below summarize the decisive evidence and do not require access to local decompile output. Heavy decompilation was avoided.
+
+## Executive conclusion
+
+There are three distinct things called “Maps in the car,” and they cannot be interchanged:
+
+1. **phone Maps projected through Android Auto** — private `GmmCarProjectionService` hosted by gearhead;
+2. **native AAOS Maps** — a separate app installed and run by the head unit;
+3. **a map rendered by OAL through a public SDK/provider** — OAL-owned UI/content, not the official Maps app.
+
+Under OAL's current Play-only, non-platform-signed deployment:
+
+- native AAOS Maps/Spotify can be launched as separate tasks if installed and visible;
+- OAL cannot embed those native tasks inside its own Compose layout;
+- OAL cannot control the official phone Maps projected surface because Maps requires a Google-signed caller or `CAPTURE_VIDEO_OUTPUT`;
+- OAL cannot use Spotify's direct MediaBrowser catalog unless Spotify has baked OAL's package/certificate into its caller allowlist;
+- OAL can plausibly use supported Spotify App Remote/App Protocol with a registered app ID/signing fingerprint and render its own media UI;
+- true official-app embedding is an OEM/platform integration project.
+
+## 1. GM's architecture separates privileged host, app, and projection roles
+
+### Google Automotive Templates Host
+
+The analyzed Templates Host APK declares:
+
+- `android.car.permission.TEMPLATE_RENDERER`
+- `android.permission.QUERY_ALL_PACKAGES`
+- `android.car.permission.CAR_NAVIGATION_MANAGER`
+- `android.car.permission.CAR_DISPLAY_IN_CLUSTER`
+- `android.permission.CONTROL_INCALL_EXPERIENCE`
+- automotive/templates-host system features
+
+Its `RendererService` is the system host that binds app `CarAppService`s, receives their structured templates, validates template/API rules, and renders host-owned UI.
+
+Its `SurfaceControlViewHostController` creates a `SurfaceControlViewHost`, sets host-owned views, and returns a `SurfacePackage` to `CarAppActivity`. This does **not** mean arbitrary applications can borrow Templates Host to embed another app's Activity. The host renders approved template models and app-owned map surfaces through its protocol.
+
+### App-side HostValidator
+
+`.../androidx/car/app/validation/HostValidator.java` accepts a host only when:
+
+- host package + signing digest is in the app's allowlist;
+- caller is system UID;
+- caller has `android.car.permission.TEMPLATE_RENDERER`; or
+- the app deliberately uses `ALLOW_ALL_HOSTS_VALIDATOR`.
+
+OAL's current cluster service uses `ALLOW_ALL_HOSTS_VALIDATOR`, which is why Google's privileged Templates Host can bind to OAL. The reverse does not follow: OAL does not gain Templates Host's permissions and cannot force other apps to trust OAL.
+
+### GM Android Auto HMI
+
+`com.gm.hmi.androidauto` holds privileges such as:
+
+- `android.permission.INTERNAL_SYSTEM_WINDOW`
+- `android.permission.SYSTEM_ALERT_WINDOW`
+- `android.permission.MEDIA_CONTENT_CONTROL`
+- cross-user permissions
+- GM projection-info permissions
+
+This is the OEM presentation layer, not a model a normal Play app can duplicate.
+
+## 2. Native task embedding is a system privilege
+
+The GM homescreen corpus includes Android WM Shell `TaskView` and task-organizer infrastructure. The enforcement path calls:
+
+```text
+android.permission.MANAGE_ACTIVITY_TASKS
+```
+
+before controller operations. The system launcher/WM Shell can therefore host or organize other apps' tasks inside surfaces. OAL cannot obtain this permission from Play.
+
+This produces a hard distinction:
+
+| Operation | Normal OAL | GM/SystemUI/OEM host |
+|---|---:|---:|
+| `startActivity()` native Maps/Spotify | Yes | Yes |
+| Show native app as separate foreground task | Yes | Yes |
+| Embed native app task into an OAL panel | No | Yes, with TaskView/task organizer |
+| Keep OAL chrome over arbitrary app | Not reliably/safely | Yes |
+| Reparent/crop other app surfaces | No | Yes |
+
+Activity Embedding's public rules do not provide a bypass: cross-app embedding depends on the target app opting in and platform rules; it is not a general-purpose task host.
+
+## 3. CarSystemUI controls other apps' full-screen policy
+
+The GM SystemUI teardown shows per-display bar visibility is reimposed on every focus change using `BarControlPolicy`. The controlling setting is:
+
+```text
+android.car.SYSTEM_BAR_VISIBILITY_OVERRIDE
+```
+
+A package not listed is forced back to the OEM bar policy. OAL can hide bars for its own Activity because it owns its theme/window. It cannot force native Maps to become OAL-style immersive.
+
+Changing another package's policy requires shell/system access. That is unavailable under the stated no-ADB/no-sideload, Play-installed model.
+
+## 4. Current phone Maps: exported Binder, closed presentation gate
+
+The targeted inspection of the Maps artifact identified above covered its manifest and the three classes implementing the projection-client gate, Google certificate verification, and `ICarProjection` Binder. The current manifest still exports:
+
+- `GmmCarProjectionService`
+- limited/secondary/auxiliary projected services
+- `CarNavigationProviderService`
+
+It also exports `GhostActivity` only behind:
+
+```text
+com.google.android.projection.gearhead.permission.START_PROJECTED_ACTIVITY
+```
+
+The main projected service returns `com.google.android.gms.car.ICarProjection`. An unknown app can bind, but the presentation path checks each package for the Binder caller UID using Google's certificate verifier. If no package passes, it requires:
+
+```text
+android.permission.CAPTURE_VIDEO_OUTPUT
+```
+
+and otherwise throws `SecurityException`.
+
+The verifier calls GMS `GoogleCertificatesLookupQuery`/`GoogleCertificatesLookupResponse`; this is not a configurable OAL allowlist.
+
+**Result:** a clean-room OAL host can learn the Binder shape but cannot use official projected Maps on a stock phone. Package-name spoofing does not solve certificate verification and is not a legitimate product plan.
+
+## 5. Native AAOS Maps is a separate product
+
+The analyzed in-car Maps build is distinct from the phone APK. It contains Android for Cars App Library models plus EV-energy/navigation logic of the same kind used by OAL's battery/range integration.
+
+Native AAOS Maps can be:
+
+- launched by intent as an installed car app;
+- hosted by the system Templates Host where its own declared services/models permit;
+- integrated with GM's privileged navigation/cluster services.
+
+A normal OAL app cannot:
+
+- inject itself as Maps' renderer host;
+- read Maps' private active-route state;
+- reparent Maps' Activity into OAL;
+- force Maps' system bars/layout;
+- copy Maps' map renderer or offline/account state.
+
+The useful product route is **handoff**: an OAL dashboard launches native Maps and accepts that Maps owns the full foreground task until the user returns.
+
+## 6. Current Spotify: supported semantic integration, not UI embedding
+
+### Manifest surfaces
+
+Spotify 9.1.72.1891 contains:
+
+- enabled/exported `SpotifyMediaBrowserService`;
+- disabled `SpotifyMediaLibraryService`;
+- disabled Car App Library `AndroidAutoService`;
+- enabled/exported `AppProtocolRemoteService`;
+- exported main Activity and media-button receiver.
+
+### Direct MediaBrowser path is allowlisted
+
+`java/p_n2z0.java` validates package + UID before returning a browser root. `java/p_mb3.java` verifies a single signing certificate and matches package, certificate, and service identity against a baked list.
+
+That list explicitly includes several Android Auto/gearhead certificate variants and named Google/OEM/partner integrations. It does not include `com.openautolink.companion`.
+
+Therefore a generic OAL `MediaBrowserCompat` client should be expected to receive no root unless Spotify formally adds OAL.
+
+### App Remote path remains viable
+
+`AppProtocolRemoteService` is the supported extensibility surface. It identifies the caller package/signature and consumes an `appid` as part of session setup. This aligns with Spotify's registered App Remote integration model.
+
+An OAL implementation should:
+
+1. register the companion package/app ID and release signing fingerprint;
+2. authenticate through the supported Spotify flow;
+3. receive playback metadata/state and issue supported controls;
+4. render an OAL-owned car UI;
+5. leave audio on native Bluetooth/A2DP or another supported audio route.
+
+This is **official Spotify integration**, but not the official Spotify Activity/UI embedded inside OAL.
+
+## 7. Maps + Spotify architecture choices
+
+### A. Native AAOS handoff dashboard — feasible now
+
+```text
+OAL dashboard
+  ├─ Maps tile -> start native AAOS Maps task
+  ├─ Spotify tile -> start native AAOS Spotify/media task
+  ├─ vehicle/charging/diagnostic cards
+  └─ return to OAL through launcher/back affordance
+```
+
+Benefits:
+
+- uses official installed apps;
+- no phone gearhead dependency for those apps;
+- stays within normal app permissions.
+
+Limits:
+
+- no simultaneous official-app UI inside OAL chrome;
+- native apps control their own layout and SystemUI policy;
+- OAL cannot reliably read their private state.
+
+### B. OAL-owned shell with public provider integrations — recommended long-term
+
+```text
+OAL car shell
+  ├─ OAL navigation provider (MapLibre/OSM or licensed SDK)
+  ├─ Spotify App Remote semantic connector
+  ├─ NotificationListener connector
+  ├─ native HFP call path
+  ├─ VHAL/EV/cluster integration
+  └─ optional phone remote renderer for OAL-owned surfaces
+```
+
+Benefits:
+
+- OAL owns layout/features;
+- Cielo-like responsive behavior is implementable cleanly;
+- no dependency on gearhead after parity.
+
+Limits:
+
+- navigation UI is not official Google Maps;
+- provider licensing/offline/traffic/routing must be solved;
+- voice/notifications require separate permissions and policy work.
+
+### C. OEM/platform integration — only route to true embedding
+
+Requires some combination of:
+
+- platform signing and priv-app placement;
+- TaskView/task-organizer access;
+- CarSystemUI policy changes;
+- direct cluster/navigation permissions;
+- package/host partnerships with Google and Spotify;
+- SELinux and firmware integration.
+
+This is technically plausible but incompatible with OAL's current Play-only distribution.
+
+## 8. Layout/UI replication
+
+AA 17.4's Cielo/hero resources prove the useful abstraction is a responsive scene with named regions, not a fixed screenshot. OAL should reproduce the behavior in original Compose code:
+
+- geometry tiers: compact, canonical, semi-wide, wide, narrow portrait, wide portrait;
+- drive-side-aware rail/dashboard placement;
+- map, primary activity, dashboard/widgets, rail, notifications, assistant, IME, and overlays as independent regions;
+- focus and distraction rules;
+- original OAL design tokens/assets.
+
+Do not copy Google assets, implementation code, logos, or a pixel-identical branded skin. A clean-room behavioral reimplementation also reduces update fragility.
+
+## 9. Bounded experiments and kill criteria
+
+| Experiment | Success signal | Kill signal |
+|---|---|---|
+| Native Maps/Spotify launch from OAL | resolves and starts on emulator/car | not installed/not distraction-optimized |
+| Maps projected Binder probe | presentation call accepted as OAL | expected certificate/`CAPTURE_VIDEO_OUTPUT` SecurityException |
+| Spotify MediaBrowser probe | browser root + token returned | package/certificate rejection |
+| Spotify App Remote probe | auth + metadata + play/pause/skip | partner/API/policy restriction |
+| OAL-owned CAL host | sample app accepts OAL host and renders template | host validator rejects; no app opt-in |
+| Cross-app TaskView prototype on stock AAOS | task renders inside OAL | expected `MANAGE_ACTIVITY_TASKS` denial |
+| OAL navigation provider spike | route + map + reroute + offline behavior acceptable | licensing, latency, or safety failure |
+
+Do not continue implementation of a route after its kill signal. In particular, the latest Maps certificate gate already kills the stock-phone official projected Maps host route.
+
+## 10. Legal/distribution constraints
+
+Before public release:
+
+- do not redistribute Google Maps or Spotify APKs;
+- do not ship copied decompiled code/resources;
+- use official SDKs/APIs under their current terms;
+- register required app IDs/signing fingerprints;
+- review Google Play automotive/distraction, notification, accessibility, background-service, and branding policies;
+- get legal review before presenting a reverse-engineered private protocol as a supported app ecosystem.
+
+The artifact identities and evidence summaries above are interoperability evidence only; no APK or decompiled output is a product dependency.
+
+## Verdict
+
+**AA-free OAL is possible. Official-app UI embedded inside OAL is not possible under the current privilege/distribution model.**
+
+The viable product is an OAL-owned shell with:
+
+- native official-app handoff;
+- supported semantic integrations (notably Spotify App Remote);
+- OAL-owned navigation/rendering;
+- current Templates Host cluster integration;
+- optional existing AA compatibility backend during migration.
+
+The bounded implementation sequence is: prove native app handoff first, validate supported semantic integrations separately, retain AA compatibility during migration, and reserve true task embedding for an OEM/platform track.

--- a/docs/research/aa-replacement-oal-architecture.md
+++ b/docs/research/aa-replacement-oal-architecture.md
@@ -1,0 +1,666 @@
+# Android-Auto-independent OpenAutoLink successor: architecture and feasibility audit
+
+**Audit baseline:** repository `mossyhub/openautolink`, `main` at `71244797` (2026-08-18, merge of PR #83).
+
+**Scope:** tracked car app, companion, native JNI/aasdk/protobuf, Templates Host/cluster, VHAL, media/audio, touch/input, transport, build/distribution, tests, and public repository documentation.
+
+**Excluded:** generated build trees, prebuilt third-party contents except their build/link boundary, external dependency internals except the pinned aasdk boundary, bulk reverse-engineering corpora, and SBC build outputs. Decisive reverse-engineering conclusions are summarized in this document rather than delegated to those local corpora.
+
+## Executive conclusion
+
+The requested end state combines three separate goals:
+
+1. no dependency on Google's phone-side Android Auto (`gearhead`);
+2. display the **official** Maps and Spotify app UIs;
+3. keep OpenAutoLink's shell, chrome, features, and layout in control.
+
+A normal Play-installed AAOS app cannot satisfy all three at once.
+
+- A normal app **can launch** installed native AAOS Maps or Spotify as separate tasks. It cannot embed their activities/surfaces inside its own Compose hierarchy, rearrange their internal UI, keep its own chrome reliably above them, or force their system-bar/cluster policy.
+- A normal app **can own the whole screen** and build a Maps/Spotify-like dashboard from public SDKs/APIs. That is not the official apps' UI and does not inherit all native app behavior, offline assets, account state, or private car integrations.
+- A normal app **can render a remote surface it owns** and forward touch/audio. It cannot turn arbitrary official phone apps into a seamless projection product without MediaProjection consent, app-specific audio-capture permission, input-injection/Accessibility constraints, secure-surface limitations, and substantial Play-policy risk.
+- A platform-signed/OEM app can host tasks with system windowing primitives, alter CarSystemUI policy, coordinate cluster/HFP/VHAL, and arbitrate other apps. That requires OEM platform keys, priv-app allowlists, SELinux integration, or root/custom firmware. Play installation, regardless of release track, does not grant those capabilities.
+
+**Therefore:** under the current no-ADB/no-sideload, Play-only, unprivileged deployment, the realistic AA-independent choices are either (a) an OpenAutoLink dashboard that hands off full-screen to official native apps, or (b) an OpenAutoLink-owned dashboard that uses public navigation/media APIs rather than embedding the official apps. The complete “official apps inside our shell” product is an OEM/partner architecture, not an app-only migration.
+
+## 1. Current architecture at a glance
+
+### 1.1 Runtime topology
+
+The current car app is an Android Auto head-unit implementation, not merely a generic renderer:
+
+```text
+Phone
+  Google Android Auto / gearhead
+       │ localhost AA socket
+       ▼
+  OAL companion proxy
+       │ TCP over shared Wi-Fi, normally car-dialled
+       ▼
+AAOS car app
+  AasdkSession.kt
+       │ InputStream / OutputStream
+       ▼ JNI
+  JniTransport → aasdk TLS/framing/multiplexing
+       ├─ video → MediaCodecDecoder → SurfaceView
+       ├─ audio → AudioPlayerImpl → AudioTrack purpose slots
+       ├─ nav/media/phone state → Kotlin domain flows
+       └─ touch/key/GPS/VHAL/mic → AA protobuf channels → phone
+```
+
+The core path is visible in:
+
+- `companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt`
+- `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt`
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt`
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkTransportPipe.kt`
+- `app/src/main/cpp/jni_transport.cpp`
+- `app/src/main/cpp/jni_session.cpp`
+- `app/src/main/cpp/jni_channel_handlers.cpp`
+
+`AasdkTransportPipe` is the narrow byte-stream boundary. Everything after it in native code is AA-specific; most rendering/playback code after the JNI callbacks is reusable.
+
+### 1.2 Wireless startup on AA 17.4+
+
+The active WPP path is more subtle than “the phone connects directly to the car”:
+
+1. `app/src/main/java/com/openautolink/app/OalApplication.kt` starts process-scoped `AaWirelessBtControl`.
+2. `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt` advertises Google's AA UUID and performs the WPP RFCOMM/protobuf exchange.
+3. The car probes the phone companion for its current local AA-proxy port through `PhoneDiscovery`/the companion identity service.
+4. The Bluetooth response normally advertises `127.0.0.1:<companion-proxy-port>` to gearhead.
+5. `AasdkSession.startWpp()` switches to a car-outbound dial when the chosen endpoint is phone loopback; the companion splices that car socket to gearhead's localhost socket.
+
+This is encoded in:
+
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt`
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt`
+- `app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt`
+- `app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt`
+- `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt`
+
+The companion remains required because the car's telematics AP does not provide a dependable phone-to-car inbound path. The top-level `README.md` correctly states this. The older class comment in `WppTcpServer.kt` saying the companion is not in the wireless path is stale relative to the current loopback endpoint selection.
+
+### 1.3 Car-side orchestration
+
+`app/src/main/java/com/openautolink/app/session/SessionManager.kt` is the current composition root. It constructs and wires:
+
+- `MediaCodecDecoder`
+- `AudioPlayerImpl`
+- `MicCaptureManager`
+- `VehicleDataForwarderImpl`
+- `ImuForwarder` and direct `LocationManager` forwarding
+- process-wide `OalMediaSessionManager`
+- `ClusterManager`
+- `AasdkSession`
+- diagnostics, watchdogs, reconnect, sleep/wake, and UI state
+
+It is effective but is also the largest migration hazard: backend-independent concerns and AA negotiation/state are interleaved in one 2,600+ line class. A successor should not add a second protocol directly into this class.
+
+## 2. Hard Android Auto dependencies
+
+### 2.1 Native protocol core — replace for an AA-independent successor
+
+The following are fundamentally an AA head-unit implementation:
+
+- `app/src/main/cpp/jni_session.cpp`
+  - AA version/TLS/auth/session lifecycle
+  - AA Service Discovery Response construction
+  - AA channel IDs and typed services
+  - AA video focus, audio focus, ping, ByeBye, media ACKs
+  - AA InputReport and SensorBatch sends
+- `app/src/main/cpp/jni_session.h`
+- `app/src/main/cpp/jni_channel_handlers.cpp`
+- `app/src/main/cpp/jni_channel_handlers.h`
+- `app/src/main/cpp/aasdk_jni.cpp`
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt`
+- `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt`
+- `external/opencardev-aasdk` and the prebuilt `libaasdk.a` link boundary in `app/src/main/cpp/CMakeLists.txt`
+
+The native SDR currently advertises AA services for main video, three audio sinks, microphone source, sensors, input, optional Bluetooth, navigation status, media playback status, and phone status. These are the source of Maps/Spotify/call metadata precisely because gearhead sends them; removing AA removes those feeds too.
+
+### 2.2 Protobuf schemas — compatibility assets, not a successor domain model
+
+Despite the `oal` package name, these files model Google's AA wire contract:
+
+- `app/src/main/proto/oal/control.proto`
+- `app/src/main/proto/oal/media.proto`
+- `app/src/main/proto/oal/input.proto`
+- `app/src/main/proto/oal/navigation.proto`
+- `app/src/main/proto/oal/playback.proto`
+- `app/src/main/proto/oal/sensors.proto`
+- `app/src/main/proto/oal/vehicle_energy_model.proto`
+- `app/src/main/proto/oal/wireless.proto`
+
+They are valuable reverse-engineering knowledge and should remain in an AA backend if compatibility is retained. They should not become the public protocol for an AA-independent successor. A successor protocol should use explicit OAL-owned messages and versioning, with adapters translating AA only inside an optional AA plugin.
+
+### 2.3 Companion AA coupling
+
+Hard dependencies:
+
+- `companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt` exists to splice gearhead's localhost socket to the car.
+- `TcpAdvertiser.fireAaLaunchIntent()` in `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt` targets `com.google.android.projection.gearhead` and its wireless startup receiver/activity.
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt` publishes Google's AA UUID and WPP protocol.
+
+Reusable scaffolding exists around those dependencies:
+
+- foreground-service lifecycle in `CompanionService.kt`
+- Bluetooth/Wi-Fi auto-start in `companion/src/main/java/com/openautolink/companion/autostart/`
+- Wi-Fi attachment in `companion/src/main/java/com/openautolink/companion/wifi/CarWifiManager.kt`
+- mDNS/TCP/UDP identity discovery in `TcpAdvertiser.kt` and car-side `PhoneDiscovery.kt`
+- logging/upload in both modules
+
+A custom successor companion could reuse those pieces while deleting the gearhead launch/proxy contract.
+
+### 2.4 AA-shaped assumptions above the protocol layer
+
+These components are reusable only after AA-specific behavior is isolated:
+
+- `MediaCodecDecoder.kt` contains generic MediaCodec logic but also gearhead-specific seed-IDR thresholds, expected GOP behavior, VideoFocus/keyframe limitations, and AA stream diagnostics.
+- `ControlMessage.kt` mixes useful domain objects with AA channel vocabulary and enum meanings.
+- `SteeringWheelController.kt` maps directly to AA keycodes.
+- `NavigationDisplayImpl.kt` assumes incoming AA `NavigationState`/turn events.
+- `OalMediaSessionManager.kt` assumes media metadata arrives from AA's media playback status channel.
+- `AudioPurposeCoordinator.kt` has a useful purpose model, but `AasdkSession.onAudioFrame()` defines how AA channel purpose numbers become those purposes.
+
+## 3. Reusable components and replacement seams
+
+### 3.1 Strong reuse candidates
+
+#### Shell and display composition
+
+- `app/src/main/java/com/openautolink/app/MainActivity.kt`
+- `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt`
+- `app/src/main/java/com/openautolink/app/ui/components/`
+- `app/src/main/java/com/openautolink/app/ui/settings/`
+- `app/src/main/res/values/themes.xml`
+
+`ProjectionScreen` already proves OAL can own a Compose shell around one `SurfaceView`, preserve that surface underneath settings/diagnostics overlays, calculate panel/render rectangles, and place independent controls/HUDs above the projected surface. This is an excellent shell foundation.
+
+The limitation is ownership: the surface must be produced by OAL or a backend OAL controls. A normal app cannot substitute “the Surface of native Google Maps” or “the Spotify Activity” into this `AndroidView`.
+
+#### Video
+
+- `app/src/main/java/com/openautolink/app/video/VideoDecoder.kt`
+- `app/src/main/java/com/openautolink/app/video/VideoFrame.kt`
+- `app/src/main/java/com/openautolink/app/video/CodecSelector.kt`
+- `app/src/main/java/com/openautolink/app/video/NalParser.kt`
+- `app/src/main/java/com/openautolink/app/video/MarginAutoCalc.kt`
+- `app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt`
+
+Reuse for a custom phone renderer or another owned video backend. Before reuse, move AA/gearhead policies out of `MediaCodecDecoder` into a stream policy/config object: keyframe classification, seed handling, expected IDR cadence, focus/request semantics, and reconnect diagnostics.
+
+#### Audio and microphone
+
+- `app/src/main/java/com/openautolink/app/audio/AudioPlayer.kt`
+- `AudioPlayerImpl.kt`
+- `AudioPurposeCoordinator.kt`
+- `AudioPurposeSlot.kt`
+- `AacDecoder.kt`
+- `MicCaptureManager.kt`
+
+The AudioTrack purpose routing and AudioAttributes are useful for any OAL-owned audio backend. HFP call audio is not provided by these classes; the native vehicle Bluetooth/audio stack remains the real call endpoint. `HfpPresenceServer` is a presence shim, not an HFP Audio Gateway.
+
+One documentation mismatch needs cleanup during migration: several comments/docs still describe an active 500 ms ring buffer, while current `AudioPurposeSlot.kt` writes on a per-purpose executor and exposes ring-buffer sizes as zero. Treat tests/code, not `docs/architecture.md` or old milestone prose, as current truth.
+
+#### Input and vehicle context
+
+- `app/src/main/java/com/openautolink/app/input/TouchForwarder.kt`
+- `TouchForwarderImpl.kt`
+- `TouchScaler.kt`
+- `KeyCaptureBus.kt`
+- `SteeringWheelController.kt` (after replacing AA keycode targets with backend actions)
+- `VehicleDataForwarder.kt`
+- `VehicleDataForwarderImpl.kt`
+- `IgnitionMonitor.kt`
+- `GnssForwarder.kt` / `GnssForwarderImpl.kt`
+- `ImuForwarder.kt`
+
+Touch scaling/multitouch are directly reusable for an OAL-owned surface. VHAL/GNSS/IMU are reusable as shell context providers or custom navigation inputs. The current VHAL layer is read-oriented and gracefully handles unavailable properties.
+
+#### Diagnostics, preferences, lifecycle knowledge
+
+- `app/src/main/java/com/openautolink/app/diagnostics/`
+- `companion/src/main/java/com/openautolink/companion/diagnostics/`
+- `app/src/main/java/com/openautolink/app/data/AppPreferences.kt`
+- `app/src/main/java/com/openautolink/app/OalApplication.kt`
+
+Crash persistence, uploaded logs, process-scoped services, ignition-cycle state reset, and explicit wake/reconnect diagnostics are highly reusable. Keep the learned lifecycle invariants even if AA is removed.
+
+### 3.2 Natural interface seam to create
+
+Introduce an OAL-owned backend contract above transport/protocol:
+
+```kotlin
+interface OalContentBackend {
+    val state: StateFlow<BackendState>
+    val video: Flow<EncodedVideoFrame>       // optional
+    val audio: Flow<PlaybackAudioFrame>      // optional
+    val navigation: StateFlow<NavigationSnapshot?>
+    val media: StateFlow<MediaSnapshot?>
+    val calls: StateFlow<CallSnapshot?>
+
+    suspend fun start(config: BackendConfig)
+    suspend fun stop(reason: StopReason)
+    fun attachInput(sink: InputEvents)
+    fun sendVehicleContext(context: VehicleContext)
+}
+```
+
+Then implement separate backends:
+
+- `AaBackend` wrapping current `AasdkSession`/JNI stack;
+- `NativeHandoffBackend` that launches native apps and exposes only shell-owned cards;
+- `ApiDashboardBackend` using public navigation/media APIs;
+- `RemoteRendererBackend` using a new OAL companion protocol.
+
+`SessionManager.kt` should become a backend-agnostic coordinator. AA SDR fields, keyframe watchdogs, WPP state, and gearhead-specific reconnect policy belong inside `AaBackend`, not the shared manager.
+
+## 4. Cluster and Templates Host
+
+### 4.1 What works unprivileged today
+
+The current cluster path is an important reusable success:
+
+- manifest declarations in `app/src/main/AndroidManifest.xml`
+- `app/src/main/res/xml/automotive_app_desc.xml`
+- `app/src/main/java/com/openautolink/app/cluster/OalClusterService.kt`
+- `ClusterManager.kt`
+- `ClusterMainSession.kt`
+- `OalClusterSession.kt`
+- `ClusterNavigationState.kt`
+- `app/src/main/java/com/openautolink/app/navigation/`
+
+OAL uses the Android Car App Library and the privileged Google Templates Host as an intermediary. OAL sends structured `Trip`/maneuver data through `NavigationManager`; the Templates Host and GM services render approved cluster UI. This is the correct unprivileged seam.
+
+### 4.2 What it does not provide
+
+- It does not grant arbitrary drawing or a general cluster surface.
+- It does not let OAL extract turn-by-turn state from native Google Maps.
+- It does not let OAL show the full Maps UI on the cluster.
+- It does not grant direct `CAR_DISPLAY_IN_CLUSTER` or `CAR_NAVIGATION_MANAGER`; the Templates Host owns those privileged permissions.
+
+The analyzed GM cluster path carries structured navigation metadata that the vehicle renders locally; it is not a general projected-video path. A regular Play app cannot route arbitrary content to the physical GM cluster display. For a successor, use the existing metadata/Templates Host path and do not plan around a cluster video surface unless OEM access is secured.
+
+### 4.3 Successor implications
+
+- **Native handoff to official Maps:** Maps remains responsible for its own Templates Host/cluster integration while it is the foreground navigation app. OAL cannot mirror Maps' private navigation state into its own shell.
+- **API-composed navigation:** OAL can generate its own `NavigationSnapshot` and reuse the existing cluster adapters.
+- **Remote phone renderer:** the companion must send normalized navigation metadata separately; inferring cluster state from pixels is not viable.
+
+## 5. VHAL and vehicle control constraints
+
+### 5.1 Reusable read path
+
+`VehicleDataForwarderImpl.kt` reads AOSP-standard properties via `CarPropertyManager` reflection and hardcoded stable IDs for stripped GM fields. The manifest requests normal/dangerous read permissions for speed, energy, powertrain, environment, car info, energy ports, mileage, tires, and dynamics.
+
+This can power an AA-independent dashboard: speed/gear/ignition, battery/range/charge state, outside temperature, tire/ABS data where exposed, and vehicle identity.
+
+### 5.2 Hard privilege wall
+
+The GM package and permission audit established the following boundaries:
+
+- vendor properties require `CAR_VENDOR_EXTENSION` (`signature|privileged`);
+- Ultifi/domain services use GM-signature permissions;
+- door/window/seat/climate/mirror/light/horn controls require privileged control permissions;
+- a normal app has essentially no vehicle write authority.
+
+The current successor can **display** car data but should not promise deep vehicle controls. Any architecture whose shell includes HVAC, drive mode, charging schedule writes, ADAS, or body controls requires OEM privileges or an external sanctioned interface.
+
+Do not build product behavior on the observed exported `com.gm.vehicleinfo.HistoryProvider` weakness. A vulnerability is neither a stable API nor an acceptable product dependency.
+
+## 6. Media, audio, calls, and official Spotify
+
+### 6.1 Current AA-derived media path
+
+Today, Spotify metadata/control works because gearhead publishes AA media playback status and OAL translates it:
+
+- AA parsing: `JniMediaStatusHandler` in `app/src/main/cpp/jni_channel_handlers.cpp`
+- Kotlin event bridge: `AasdkSession.kt`
+- AAOS publication: `app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt`
+- discoverability: `OalMediaBrowserService.kt`
+
+Removing AA removes the metadata source; the process-wide MediaSession remains reusable as an **output** for whatever successor backend supplies.
+
+### 6.2 Native Spotify handoff
+
+An unprivileged shell can launch installed Spotify with an intent. It cannot embed Spotify's activity. Media control/metadata options are narrower:
+
+- bind to any public/exported MediaBrowser contract Spotify exposes, if available and permitted;
+- use a user-approved notification-listener/media-controller approach where platform policy permits;
+- use Spotify's public Web API/Web Playback SDK with OAuth and account/subscription/network constraints;
+- hand off to the native Spotify UI and let the AAOS system media center own playback controls.
+
+None is equivalent to placing the official Spotify UI inside OAL's layout. The most robust unprivileged design is full-screen task handoff plus an OAL-owned, API-fed media card when available.
+
+### 6.3 Calls
+
+Presentation, control, and audio transport must remain separate:
+
+- AA currently supplies projected call presentation/control state.
+- The vehicle's native Bluetooth HFP/SCO stack carries call audio.
+- OAL's app cannot implement/select HFP profiles or SCO as a normal app; relevant APIs require `BLUETOOTH_PRIVILEGED`.
+- Native AAOS dialer takeover/suppression is controlled by OEM projection state and dialer settings, not by OAL's AudioTrack layer.
+
+An AA-independent unprivileged successor should defer calls to the native dialer/HFP stack and avoid promising an owned call overlay beyond public notification state.
+
+## 7. Touch and input constraints
+
+The existing touch path is reusable only for a surface OAL owns:
+
+- Compose overlay and `SurfaceView`: `ProjectionScreen.kt`
+- coordinate normalization: `TouchForwarderImpl.kt`, `TouchScaler.kt`
+- AA serialization: `AasdkSession.kt` → `AasdkNative.kt` → `JniSession::sendTouchEvent`
+
+For native Maps/Spotify activities, Android delivers touch directly to those apps. OAL cannot intercept and redirect arbitrary touches while preserving its own task without system window/task privileges.
+
+For a phone-mirroring backend, displaying pixels is only half the problem. Injecting touch into arbitrary phone apps normally requires Accessibility, privileged input injection, or app cooperation. That is a major UX, safety, and distribution constraint—not a small protocol feature.
+
+Steering-wheel input has the same split:
+
+- `SteeringWheelController.kt` can map keys to backend-neutral actions.
+- GM consumes some keys (notably voice) before they reach the app; this is an observed platform boundary, not something OAL can override.
+- controlling another native app's MediaSession reliably requires platform/system mediation; OAL cannot assume every key reaches its foreground Activity.
+
+## 8. Transport inventory and successor value
+
+### 8.1 Reusable transport primitives
+
+- `AasdkTransportPipe.kt`: generic blocking byte-stream adapter, despite its name.
+- `TcpConnector.kt`: reusable TCP client pattern, keepalive tuning, mDNS/gateway fallback.
+- `PhoneDiscovery.kt`: useful mDNS/UDP/TCP identity discovery and multi-peer correlation.
+- companion identity/mDNS/foreground service in `TcpAdvertiser.kt` / `CompanionService.kt`.
+- `NetworkInterfaceScanner.kt`, `HostUsability.kt`, and diagnostics network probes.
+
+These can underpin a custom OAL protocol if renamed and stripped of AA/WPP assumptions.
+
+### 8.2 AA-specific transports
+
+- `AaWirelessBtControl.kt` / `AaWirelessBtServer.kt`: Google's WPP and AA UUID.
+- `WppTcpServer.kt`: WPP role adaptation.
+- `UsbConnectionManager.kt`, `UsbAccessoryMode.kt`, `UsbTransportPipe.kt`: AOA transport designed to make the phone enter Android Auto accessory mode. The stream abstraction is reusable, but the AOA identity/handshake is AA-specific.
+- `CarWifiManager.kt`: generic Wi-Fi joiner, but current WPP setup intentionally avoids running it because gearhead owns association.
+
+### 8.3 Legacy bridge
+
+`bridge/` and `docs/protocol.md` preserve an OAL-owned three-channel protocol and a headless SBC implementation. It is not the active topology, but it demonstrates a useful architectural idea for a successor: OAL-owned control messages with independent video/audio channels. Do not revive the whole SBC design blindly; salvage the protocol separation and mockability.
+
+## 9. Deployment and build constraints
+
+### 9.1 Car app
+
+- Package: `com.openautolink.app`
+- normal AAOS app, `minSdk 32`, `targetSdk 36`
+- distributed as a signed AAB through Google Play
+- no car ADB and no sideload path
+- `app/src/main/AndroidManifest.xml` requires automotive and Templates Host features
+- native ABIs: `arm64-v8a`, `x86_64`
+
+Play installation grants no platform signature, priv-app placement, SELinux domain, hidden API access, secure settings writes, system-window control, or app-task embedding authority.
+
+The app can request normal/dangerous runtime permissions. Signature/privileged declarations either remain unavailable or are ignored/denied for the normal UID.
+
+### 9.2 Companion
+
+The companion is a normal Android app distributed through GitHub release APKs. `release-apk.yml` builds both modules from a release tag; the car's actual in-vehicle path remains the Play AAB flow. A successor companion can continue using GitHub distribution, but Accessibility, MediaProjection, notification-listener, or VPN-style capabilities would add significant setup and policy friction.
+
+### 9.3 Native dependency and CI constraints
+
+- `app/src/main/cpp/CMakeLists.txt` links prebuilt aasdk/OpenSSL/protobuf/abseil artifacts.
+- `.github/workflows/build-native-deps.yml` refreshes those artifacts when the aasdk pointer/build scripts change.
+- `.github/workflows/ci.yml` currently runs car-app JVM unit tests only.
+- `.github/workflows/release-apk.yml` compiles release APKs but is not the car's Play deployment path.
+- `scripts/linux/bundle-release.sh` builds the signed car AAB; the external signing tooling uploads it.
+
+Removing AA from the default backend could eliminate the native aasdk/protobuf/OpenSSL footprint and simplify car builds substantially. Keep it only if AA remains an optional compatibility backend.
+
+### 9.4 Automotive app-policy constraint
+
+The existing internal-track installation proves the package can be delivered, not that arbitrary public automotive functionality will pass every app-quality/category review. A successor that acts as a general launcher, mirrors arbitrary apps, or uses Accessibility/overlays should be treated as a distribution-risk change. Internal testing is a delivery channel, not a privilege or policy bypass.
+
+## 10. Tests, issues, plans, and design-knowledge quality
+
+### 10.1 Tests present
+
+Tracked JVM tests cover useful reusable units:
+
+- audio frame/purpose/ring-buffer/mic logic under `app/src/test/java/com/openautolink/app/audio/`
+- touch/scaling/steering/GNSS under `app/src/test/java/com/openautolink/app/input/`
+- navigation mapping/formatting under `app/src/test/java/com/openautolink/app/navigation/`
+- state/recovery under `app/src/test/java/com/openautolink/app/session/`
+- host usability under `app/src/test/java/com/openautolink/app/transport/`
+- codec/NAL/frame logic under `app/src/test/java/com/openautolink/app/video/`
+
+Gaps relevant to a successor:
+
+- companion JVM coverage is limited to five focused WPP startup, proxy-port, and
+  network-binding policy tests under `companion/src/test/`;
+- no backend contract tests because no backend seam exists yet;
+- no current connected/instrumentation suite in CI;
+- CI does not run the companion tests or explicitly exercise a native build/test
+  target;
+- old mock-bridge and testing docs primarily describe the retired SBC topology.
+
+A migration should add backend contract tests and a fake backend before moving code.
+
+### 10.2 Baseline limitations that remain on current `main`
+
+The 2026-08-18 `main` baseline still has no backend contract, only five focused
+companion JVM policy/contract tests, no connected/instrumentation suite in CI,
+and no CI gate that runs companion tests or explicitly exercises the native
+build. Hardware and distribution variability therefore remain material migration
+risks. None changes the Android certificate, task-embedding, secure-output, or
+platform-permission boundaries described above.
+
+### 10.3 Evidence precedence
+
+For implementation claims, prefer the current tracked source and build configuration over older architecture or milestone prose. Some older public documents describe the retired SBC topology or superseded pure-Kotlin protocol work. Reverse-engineering observations are useful evidence for the optional AA backend, but they do not create Android platform privileges and are summarized here wherever they affect the feasibility decision.
+
+## 11. Candidate architectures, ranked by feasibility
+
+No unprivileged candidate fully meets all three headline goals. Rankings below are for the current Play-only vehicle.
+
+### Rank 1 — Native-app handoff dashboard
+
+**Shape:** OAL owns a home/dashboard Activity with vehicle cards, shortcuts, diagnostics, and optional media/nav summaries. Tapping Maps or Spotify launches the official native AAOS app as a separate task. Back/Home returns to OAL.
+
+**Feasibility:** high without system privileges.
+
+**Meets:** no AA; official native apps are displayed.
+
+**Does not meet:** persistent OAL shell/layout while those apps are foreground; arbitrary embedding or resizing.
+
+Reuse:
+
+- `MainActivity.kt`, Compose UI/components/settings
+- VHAL/GNSS/IMU and diagnostics
+- process MediaSession for OAL-owned content
+- native app intents and explicit task handoff
+- Templates Host cluster path only for OAL-owned navigation; native Maps handles itself otherwise
+
+This is the fastest honest AA-independent product and the best Phase 1 target.
+
+### Rank 2 — API-composed OAL dashboard
+
+**Shape:** OAL renders navigation and media itself using supported public APIs/SDKs, while launching official apps for features not represented in APIs.
+
+**Feasibility:** medium-high technically; medium/unknown commercially due API terms, keys, quotas, account requirements, offline behavior, and automotive SDK availability.
+
+**Meets:** no AA; OAL owns the layout and feature composition.
+
+**Does not meet:** official app UI. It is an OAL client of official services.
+
+Possible providers:
+
+- approved navigation SDK or map rendering API for OAL-owned maps/guidance;
+- Spotify Web API/Web Playback SDK for metadata/control/playback where account eligibility permits;
+- native-app handoff as fallback.
+
+This is the strongest app-only architecture for a genuinely owned shell.
+
+### Rank 3 — Keep AA as a modular compatibility backend
+
+**Shape:** first refactor current AA into `AaBackend`, then place OAL-owned cards/chrome around the single AA surface. Add native handoff/API backends later.
+
+**Feasibility:** high because most code already exists.
+
+**Meets:** official phone-projected Maps/Spotify and an OAL-owned outer shell.
+
+**Does not meet:** AA independence; cannot split/rearrange the internal Maps and Spotify surfaces because gearhead sends one composed video stream.
+
+This is the lowest-risk migration bridge and should remain available until an AA-independent backend reaches feature parity. It is not the end state requested.
+
+### Rank 4 — Custom phone companion remote renderer
+
+**Shape:** replace gearhead/aasdk with an OAL-owned protocol. The companion renders OAL-owned UI or captures an allowed phone display; the car reuses video/audio/touch primitives.
+
+**Feasibility:**
+
+- medium for an OAL-owned remote UI or browser/API dashboard;
+- low for arbitrary official app mirroring;
+- very low for a seamless, automatic, Play-friendly official-app projection replacement.
+
+Blockers for official phone apps:
+
+- MediaProjection consent/lifecycle;
+- secure-window and app capture opt-out;
+- playback-audio capture opt-in/usage restrictions;
+- touch injection requiring Accessibility/privileged APIs or app cooperation;
+- lock-screen/background-start restrictions;
+- no equivalent public channel for Maps turn metadata, call integration, AA safety restrictions, or cluster state;
+- significant phone battery/thermal load and Play policy review.
+
+Use this only if the product explicitly narrows scope to OAL-owned content.
+
+### Rank 5 — OEM/system task-host shell
+
+**Shape:** platform-signed OAL/CarSystemUI component uses system task/container APIs to host Maps and Spotify activities in managed regions, controls system bars, arbitrates audio/focus/cluster, and accesses privileged VHAL/HFP services.
+
+**Feasibility:** low for this project under current deployment; high only with OEM/Google/vehicle-platform partnership.
+
+**Meets:** the complete product vision in principle.
+
+Requires some combination of:
+
+- platform signing and `/system/priv-app` placement;
+- privapp permission allowlists;
+- task/window organizer or OEM TaskView integration;
+- CarSystemUI and `android.car.SYSTEM_BAR_VISIBILITY_OVERRIDE` control;
+- direct cluster/display permissions;
+- privileged Bluetooth/HFP and vehicle-control APIs;
+- SELinux policy and firmware integration.
+
+A root/custom-ROM variant is technically similar but incompatible with the current no-ADB/no-sideload customer model and is not a distributable product plan.
+
+## 12. Goal/privilege truth table
+
+| Capability | Normal Play-installed OAL | OEM/platform/root |
+|---|---:|---:|
+| Own full-screen Compose dashboard | Yes | Yes |
+| Launch official native Maps/Spotify | Yes, separate task | Yes |
+| Embed official native app Activity inside OAL layout | No supported app API | Yes, with system task/window integration |
+| Keep OAL chrome over arbitrary foreground apps | Not reliably/safely | Yes, via SystemUI/window policy |
+| Hide bars for another app | No; CarSystemUI reimposes policy | Yes; secure/global policy |
+| Read standard user-grantable VHAL properties | Partial | Yes |
+| Write HVAC/body/ADAS/vendor VHAL | No | Yes, if OEM grants |
+| Publish own nav metadata via Templates Host | Yes | Yes |
+| Read native Maps' private turn state | No | Possible only through OEM/partner interfaces |
+| Draw arbitrary UI on GM instrument cluster | No | Yes, with cluster/display privilege |
+| Control vehicle HFP/SCO endpoint | No | Yes |
+| Render OAL-owned remote video surface | Yes | Yes |
+| Capture/control arbitrary official phone apps automatically | Severely constrained | Possible with privileged/device-owner integration |
+
+## 13. Migration/component matrix
+
+| Component | Exact current paths | AA coupling | Reuse class | Successor seam / action | Privilege note |
+|---|---|---|---|---|---|
+| Main shell | `app/src/main/java/com/openautolink/app/MainActivity.kt`; `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt` | Medium | Adapt | Rename projection screen to dashboard/surface host; preserve overlays and surface lifetime | Can host only OAL-owned surfaces/tasks |
+| Settings/preferences | `app/src/main/java/com/openautolink/app/ui/settings/`; `app/src/main/java/com/openautolink/app/data/AppPreferences.kt` | Medium | Adapt | Split backend-neutral settings from AA SDR/WPP settings | Normal app |
+| Video decoder | `app/src/main/java/com/openautolink/app/video/` | Medium-high in policy, low in codec primitives | Adapt | Introduce stream policy; keep codec/NAL/stats primitives | Normal app can decode owned streams |
+| Audio playback | `app/src/main/java/com/openautolink/app/audio/` | Medium | Adapt | Accept backend-neutral purpose frames; reconcile stale ring-buffer comments/tests | Normal AudioTrack; no HFP ownership |
+| Microphone | `app/src/main/java/com/openautolink/app/audio/MicCaptureManager.kt` | Medium | Adapt | Backend-neutral mic source with explicit privacy/lifecycle | Runtime RECORD_AUDIO only |
+| Touch | `app/src/main/java/com/openautolink/app/input/TouchForwarderImpl.kt`; `app/src/main/java/com/openautolink/app/input/TouchScaler.kt`; `app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt` | Low until serialization | Reuse/adapt | Emit backend-neutral pointer events | Only for owned surface; not other apps |
+| Steering keys | `app/src/main/java/com/openautolink/app/input/SteeringWheelController.kt`; `app/src/main/java/com/openautolink/app/MainActivity.kt` | Medium | Adapt | Map physical keys to semantic actions, then backend adapters | Some OEM keys never reach app |
+| Vehicle reads | `app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt`; `app/src/main/java/com/openautolink/app/input/IgnitionMonitor.kt` | Low | Reuse | Publish `VehicleContext` independently of backend | Read-only subset; writes privileged |
+| GNSS/IMU | `app/src/main/java/com/openautolink/app/input/GnssForwarderImpl.kt`; `app/src/main/java/com/openautolink/app/input/ImuForwarder.kt` | Low | Reuse | Feed owned nav/remote backend as needed | Runtime location permission |
+| Domain messages | `app/src/main/java/com/openautolink/app/transport/ControlMessage.kt` | High mixed model | Replace/split | Create `NavigationSnapshot`, `MediaSnapshot`, `CallSnapshot`, `VehicleContext`, `InputEvents` outside transport package | No privilege issue |
+| Session orchestration | `app/src/main/java/com/openautolink/app/session/SessionManager.kt` | Very high | Refactor | Shrink into backend-neutral coordinator; move AA watchdog/SDR/WPP into `AaBackend` | Normal app |
+| AA Kotlin bridge | `app/src/main/java/com/openautolink/app/transport/aasdk/` | Hard | Keep only optional AA plugin | Wrap behind `AaBackend`; remove from AA-independent build flavor if desired | No extra privilege, but Google AA dependency |
+| Native AA stack | `app/src/main/cpp/`; `external/opencardev-aasdk` | Hard | Replace for successor; retain plugin | No native dependency for native-handoff/API backend | Build complexity only |
+| AA protobuf | `app/src/main/proto/oal/` | Hard | Archive/plugin | Keep exact wire schemas only in AA backend; design OAL-owned protocol separately | Private protocol maintenance risk |
+| Generic byte stream | `app/src/main/java/com/openautolink/app/transport/aasdk/AasdkTransportPipe.kt`; `app/src/main/cpp/jni_transport.cpp`; `app/src/main/cpp/jni_transport.h` | Low at stream layer | Reuse/rename | `DuplexBytePipe`; custom protocol may stay Kotlin-only | Normal sockets/USB |
+| TCP discovery | `app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt`; `app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt`; `app/src/main/java/com/openautolink/app/transport/OalProtocol.kt` | Medium | Adapt | Keep identity/versioning; remove WPP/gearhead assumptions | Normal network permissions |
+| WPP/BT startup | `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt`; `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt`; `app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt` | Hard | Remove from AA-independent backend | Retain only for `AaBackend` | Cannot switch active BT devices; privileged APIs closed |
+| USB | `app/src/main/java/com/openautolink/app/transport/usb/` | High AOA coupling | Partial | Keep pipe mechanics; replace AOA identity/handshake for any custom accessory protocol | Per-device USB permission prompt remains |
+| Companion service | `companion/src/main/java/com/openautolink/companion/service/CompanionService.kt`; `companion/src/main/java/com/openautolink/companion/autostart/`; `companion/src/main/java/com/openautolink/companion/wifi/` | Medium | Adapt | Generic OAL companion lifecycle and discovery | Background/FGS restrictions remain |
+| AA proxy/launch | `companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt`; `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt` | Hard | Replace | Custom protocol server/renderer; no gearhead intents | Official-app capture/control constraints |
+| Diagnostics/log upload | `app/src/main/java/com/openautolink/app/diagnostics/`; `companion/src/main/java/com/openautolink/companion/diagnostics/` | Low | Reuse | Add backend identity and privacy redaction | Normal app |
+| Navigation normalization | `app/src/main/java/com/openautolink/app/navigation/NavigationDisplayImpl.kt`; `app/src/main/java/com/openautolink/app/navigation/ManeuverMapper.kt`; `app/src/main/java/com/openautolink/app/transport/ControlMessage.kt` | Medium | Adapt | Backend-neutral nav snapshots | Data source is the hard part, not rendering |
+| Cluster host | `app/src/main/java/com/openautolink/app/cluster/`; `app/src/main/AndroidManifest.xml`; `app/src/main/res/xml/automotive_app_desc.xml` | Low once nav normalized | Reuse | Consume any owned nav backend | Templates only; no arbitrary cluster drawing |
+| MediaSession | `app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt`; `app/src/main/java/com/openautolink/app/media/OalMediaBrowserService.kt` | Medium data-source coupling | Reuse | Publish successor media source; native-app control optional | Other apps' sessions may require user/system mediation |
+| Build/distribution | `app/build.gradle.kts`; `companion/build.gradle.kts`; `.github/workflows/`; `scripts/linux/bundle-release.sh` | Medium native coupling | Adapt | Add product flavors/backends; keep Play AAB car delivery | Play does not grant system privileges |
+| Tests | `app/src/test/java/`; `.github/workflows/ci.yml` | Mixed | Extend | Add fake backend contract tests, companion tests, current instrumentation, and optional native compile gate | Real-car acceptance still required |
+
+## 14. Recommended migration sequence
+
+### Phase 0 — lock the feasibility contract
+
+Document and accept one of these product definitions before coding:
+
+- **A:** “official native apps, separate full-screen handoff”; or
+- **B:** “OAL-owned dashboard using public service APIs”; or
+- **C:** pursue an OEM partner for true embedded official apps.
+
+Do not describe A or B as “official apps inside our shell.”
+
+### Phase 1 — create the backend seam without behavior change
+
+1. Extract backend-neutral navigation/media/call/video/audio/input/vehicle models from `ControlMessage.kt`.
+2. Define `OalContentBackend` and a fake backend.
+3. Move current AasdkSession/JNI/WPP/watchdog wiring behind `AaBackend`.
+4. Keep current AA behavior and release path unchanged.
+5. Add contract tests proving the shell survives backend start/stop/reconnect and surface recreation.
+
+This is the highest-leverage work: it preserves today's functioning product while making every successor experiment isolated and reversible.
+
+### Phase 2 — ship the native-handoff dashboard
+
+1. Convert `ProjectionScreen` into a dashboard with an optional backend surface region.
+2. Add explicit intents/availability checks for installed Maps and Spotify.
+3. Add VHAL/charging/diagnostic cards from existing vehicle data.
+4. Let official apps run as their own tasks; provide an obvious return path.
+5. Keep AA as an optional compatibility tile during transition.
+
+This is achievable under current privileges and immediately removes AA as a requirement for users who accept task handoff.
+
+### Phase 3 — add API-composed features selectively
+
+1. Choose navigation/media providers only after licensing/API feasibility is confirmed.
+2. Feed normalized navigation into the existing Templates Host cluster path.
+3. Feed normalized media into the process-wide MediaSession.
+4. Keep native-app launch as fallback for unsupported actions.
+
+### Phase 4 — custom companion only for owned content
+
+If phone-hosted content is still needed, design a new versioned OAL protocol around owned UI/video/audio and semantic input. Do not start by attempting arbitrary official-app mirroring. Reuse discovery, logging, `MediaCodecDecoder`, audio, and touch only after a narrow prototype proves capture, input, and distribution assumptions on the target phone.
+
+### Phase 5 — OEM track, if available
+
+Prepare a separate system integration proposal rather than contaminating the normal-app architecture with hidden API assumptions. Required deliverables should explicitly list platform signing, task embedding, CarSystemUI/system-bar policy, cluster, VHAL writes, HFP, SELinux, and update ownership.
+
+## 15. Decision
+
+For the current Play-installed target deployment, the recommended architecture is:
+
+```text
+OpenAutoLink Shell (normal Play AAOS app)
+  ├─ Dashboard: VHAL cards, charging, diagnostics, shortcuts
+  ├─ Native handoff: official AAOS Maps / Spotify tasks
+  ├─ Optional API cards: normalized nav/media where licensed
+  ├─ Templates Host: OAL-owned navigation metadata only
+  └─ Backend slot:
+       ├─ AaBackend (existing compatibility, transitional)
+       ├─ ApiDashboardBackend
+       └─ RemoteRendererBackend (owned content only, later)
+```
+
+This gives a credible AA-independent path without pretending Android's app sandbox can be bypassed. If the non-negotiable requirement is simultaneous official Maps/Spotify UI embedded inside an OAL-controlled layout, stop app-only implementation work and pursue OEM/system access; that requirement is outside the capability envelope of the current Play-installed package.

--- a/docs/research/wpp-phone-hotspot-feasibility.md
+++ b/docs/research/wpp-phone-hotspot-feasibility.md
@@ -1,0 +1,195 @@
+# WPP phone-hotspot feasibility on Android Auto 17.4
+
+**Build analyzed:** `com.google.android.projection.gearhead` 17.4.663004-release (`versionCode=174663004`)
+
+**Base APK SHA-256:** `28c0810a538001251f4707424216d1bbfc2628d1e522efb95eaac1c951e8e388`
+
+**Method:** targeted decode of the WPP TCP configuration and Wi-Fi network-selection classes. The decisive control flow is summarized below so the conclusion does not depend on a local decompile tree.
+
+**Verdict: INVALIDATED for the projecting phone hosting the hotspot.**
+
+OpenAutoLink can reach the companion over a phone-hosted hotspot, but Android
+Auto 17.4 will not start WPP projection over that topology. The blocker is not
+IP reachability or the OAL proxy. Gearhead requires a station-mode Wi-Fi
+`Network` matching the SSID/BSSID supplied by the head unit before it opens the
+WPP-over-TCP endpoint. A phone's own SoftAP is not a station association and is
+not returned as the requested network.
+
+## Topology under consideration
+
+```text
+projecting phone
+  ├─ hosts SoftAP / hotspot
+  ├─ companion proxy listens on 127.0.0.1:<ephemeral-port>
+  └─ Android Auto / gearhead
+             ↑
+             │ phone-hotspot Wi-Fi
+             ↓
+AAOS head unit wlan0 (client)
+  └─ OAL car app dials companion on the phone
+```
+
+The OAL half of this topology is valid:
+
+1. The head unit can reach the companion over the phone hotspot.
+2. The car can ask the companion for its current local AA proxy port.
+3. Bluetooth WPP can advertise `127.0.0.1:<proxy-port>` to gearhead.
+4. Gearhead would connect to its own loopback; the companion would splice that
+   socket to the car's outbound socket.
+
+That is already how current WPP avoids the GM telematics AP's inbound firewall.
+See:
+
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt`,
+  `Endpoint.PhoneLoopback`
+- `app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt`,
+  per-handshake endpoint resolver
+- `companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt`,
+  `wpp=<port>` identity response
+- `companion/src/main/java/com/openautolink/companion/connection/AaProxy.kt`,
+  loopback-to-car splice
+
+## The Android Auto gate
+
+The AA 17.4 teardown shows that WPP-over-TCP still has a Wi-Fi configuration as a
+hard dependency.
+
+### 1. TCP configuration includes Wi-Fi configuration
+
+The decompiled type `olt` renders itself as:
+
+```text
+WifiProjectionProtocolOnTcpConfiguration(
+    wifiConfiguration=...,
+    ipAddress=...,
+    port=...
+)
+```
+
+In the analyzed build this string and model occur in obfuscated class `olt`.
+
+### 2. Missing Wi-Fi credentials are fatal even with the TCP manager
+
+`osj.m30126N(...)` throws:
+
+```text
+No credentials available when connecting to the WiFi network despite TCP manager.
+```
+
+In the analyzed build this exception occurs in obfuscated class `osj`.
+
+### 3. The network request is not a generic "any path to this IP" request
+
+The modern network manager builds:
+
+```java
+new NetworkRequest.Builder()
+    .addTransportType(TRANSPORT_WIFI)
+    .removeCapability(NET_CAPABILITY_INTERNET)
+    .setNetworkSpecifier(
+        new WifiNetworkSpecifier.Builder()
+            .setSsid(advertisedSsid)
+            .setBssid(advertisedBssid)
+            .setWpa2Passphrase(advertisedPassword)
+            .build()
+    )
+    .build();
+```
+
+In the analyzed build this request is constructed by obfuscated class `opa` (method `m29884f`).
+
+The WPP TCP manager waits for that Wi-Fi `Network`, then creates its socket using
+the resulting network. The endpoint may be `127.0.0.1`, but network acquisition
+still happens first.
+
+### 4. Gearhead explicitly notices that the phone is hosting a hotspot
+
+On Android 14+, the same manager checks `WifiManager.isWifiApEnabled()` and logs:
+
+```text
+Dual STA is not enabled: hotspot
+```
+
+It then continues with the SSID/BSSID `WifiNetworkSpecifier`; it does not switch
+to the SoftAP network or bypass association.
+
+In the analyzed build these checks occur in obfuscated class `opa` (methods `m29876p` and `m29884f`).
+
+### 5. "Already connected" means station association only
+
+The short circuit checks `WifiManager.getConnectionInfo()`, a valid network ID,
+and equality with the advertised SSID before starting projection:
+
+```text
+already connected to desired network: %s, starting
+```
+
+A phone hosting a SoftAP is not associated to that SoftAP through its station
+interface, so this condition does not represent phone-hotspot mode.
+
+In the analyzed build this short circuit occurs in obfuscated class `osj`.
+
+## Why the companion cannot patch over this
+
+The companion can prepare both sockets, but it cannot make gearhead consume them.
+AA 17.4 disabled the public wireless-start broadcast/intent path. The surviving
+OEM path is WPP over Bluetooth, and gearhead owns its Wi-Fi `NetworkRequest`.
+A normal companion app cannot:
+
+- provide a SoftAP as a station-mode `Network`;
+- manufacture a `Network` with `TRANSPORT_WIFI` capabilities;
+- inject a socket into gearhead;
+- bypass gearhead's SSID/BSSID validation; or
+- call its non-exported/private startup internals.
+
+A VPN/TUN does not help because it is not the requested Wi-Fi transport and still
+does not satisfy the `WifiNetworkSpecifier`.
+
+## Constrained case that can appear to work but is not a vehicle solution
+
+If the phone simultaneously remains associated as a client to a third Wi-Fi
+network (for example home Wi-Fi) while hosting its hotspot, OAL could advertise
+that *station* network to satisfy gearhead while the car reaches the companion
+through the hotspot. The loopback endpoint makes the two data paths independent.
+
+This is not a realistic driving mode:
+
+- it requires valid credentials for the other Wi-Fi network;
+- it depends on STA+AP concurrency;
+- WPP loses its required network as soon as the vehicle leaves that Wi-Fi; and
+- it therefore fails precisely when the car is driven.
+
+Do not productize this as Phone Hotspot mode.
+
+## Viable wireless topologies
+
+| Topology | WPP result | Notes |
+|---|---|---|
+| Car/telematics AP; phone joins | Works | Current default. Companion loopback avoids the AP's inbound firewall. |
+| Shared third-party AP; car and phone both clients | Works | Proven architecture; requires AP credentials. |
+| Projecting phone hosts AP; car joins | **Cannot work on stock AA 17.4** | Gearhead cannot acquire its own SoftAP as the required station Wi-Fi network. |
+| Second phone/travel router hosts AP; projecting phone and car join | Works in principle | This is a shared third-party AP, not phone-hotspot mode on the projecting phone. |
+| USB | Works | No WPP/Wi-Fi acquisition involved. |
+
+## What would have to change
+
+At least one external constraint must change:
+
+1. Google adds a WPP mode that accepts an already-usable endpoint without a
+   station Wi-Fi `NetworkRequest`;
+2. gearhead is patched/privileged to accept its SoftAP network or skip Wi-Fi
+   acquisition for loopback endpoints;
+3. the head unit gains an AP that the projecting phone can join; or
+4. a separate device supplies the shared AP.
+
+None of these can be implemented by an ordinary OAL car or companion app today.
+
+## Product consequence
+
+Do not add a WPP `Phone Hotspot` submode or hide the failure behind empty Wi-Fi
+fields. The existing `connectionMode=phone_hotspot` setting belongs to the legacy
+OAL TCP transport; it must not be presented as a valid WPP topology. If the UI is
+reworked, WPP should describe only:
+
+- **Car AP** (normal current mode), and
+- **Shared AP** (advanced, credentials required).


### PR DESCRIPTION
## Summary
- publish the Android Auto 17.4 host/compositor and privilege analysis
- publish the GM/AAOS, Maps, and Spotify integration feasibility findings
- publish the current OAL component reuse and AA-independent successor architecture audit
- publish the WPP projecting-phone-hotspot feasibility result

## Public-safety and grounding cleanup
- replaced local decompile/workspace references with package versions, version codes, hashes, targeted scope, and summarized decisive behavior
- removed private environment identifiers and internal workflow/Kanban references
- retained clean-room, licensing, Play-policy, and OEM privilege boundaries
- corrected current test coverage: five focused companion tests exist, while CI runs only car-app JVM tests
- replaced shorthand source citations with exact repository paths where applicable

## Verification
- Google Maps and Spotify artifact identities match their retained artifact metadata
- Android Auto 17.4 identity matches the retained targeted artifact record
- all cited repository paths exist on current source
- no ignored teardown/recon dependency or absolute private workspace path remains
- independent review requested before merge
- documentation-only change
