### PR TITLE
fix(wireless): replace stale phone connector

### DIFF
--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -88,7 +88,9 @@ class AasdkSession(
     var sdrConfig = AasdkSdrConfig()
 
     // TCP connector — used in "hotspot" transport mode (Car Hotspot / Phone Hotspot)
-    private var _tcpConnector: TcpConnector? = null
+    @Volatile private var _tcpConnector: TcpConnector? = null
+    /** Serializes connector ownership, socket handoff, and synchronous teardown. */
+    private val connectionStartLock = Any()
 
     /**
      * WPP inbound listener. Only non-null in "wpp" transport mode, where the phone
@@ -295,13 +297,16 @@ class AasdkSession(
             OalLog.i(TAG, "Ignition simulation is in its off window — not dialling $ip")
             return
         }
-        // Only refuse when a dial is genuinely in flight or connected. Refusing
-        // whenever a connector merely EXISTS makes a dead one permanent: after a
-        // disconnect the stale connector blocked every retry, so the session could
-        // never recover and the phone picker appeared to do nothing.
+        // Refuse only a same-target dial that is genuinely in flight. An active
+        // connector can also be an endless retry to a phone that has left the car;
+        // when Bluetooth resolves a different phone, that retry must be replaced.
+        // Refusing whenever a connector merely EXISTS makes stale ownership
+        // permanent and is why Liz's reachable companion was ignored all day.
         val existing = _tcpConnector
-        if (existing != null && existing.isActive) {
-            OalLog.d(TAG, "Already dialling/connected — ignoring dial request for $ip")
+        val existingIsActive = existing?.isActive == true
+        if (companionDialState.shouldIgnoreActiveDial(ip, existingIsActive)) {
+            OalLog.i(TAG, "Already dialling $ip — ignoring the same-target request while " +
+                    "that connector is still active")
             return
         }
         // A live native session outranks a fresh handshake asking us to dial.
@@ -325,9 +330,12 @@ class AasdkSession(
             return
         }
         if (existing != null) {
-            OalLog.i(TAG, "Replacing a dead connector to dial $ip")
-            existing.stop()
-            _tcpConnector = null
+            if (existingIsActive) {
+                OalLog.i(TAG, "Replacing active connector target " +
+                        "${existing.manualIp ?: "discovery"} with different phone $ip")
+            } else {
+                OalLog.i(TAG, "Replacing a dead connector to dial $ip")
+            }
         }
         OalLog.i(TAG, "Companion at $ip — dialling its proxy now (companion is the server)")
         _wppServer?.stop()
@@ -336,35 +344,52 @@ class AasdkSession(
     }
 
     private fun startTcp(manualIp: String? = null) {
-        // Record at the common boundary. WPP restart calls startTcp() directly,
-        // bypassing dialCompanion(); without this, the next handshake destroys
-        // the live session because the same-phone guard has no address to match.
-        companionDialState.recordStartTcpTarget(manualIp)
-        if (!manualIp.isNullOrBlank()) {
-            OalLog.i(TAG, "Recorded TCP target $manualIp for the live-session re-dial guard")
-        }
         OalLog.i(TAG, "Starting aasdk session (TCP/hotspot transport)")
-        _tcpConnector?.stop()
-        _tcpConnector = TcpConnector(
-            context,
-            scope,
-            onSocketReady = { tcpSocket ->
-                scope.launch(Dispatchers.IO) {
-                    OalLog.i(TAG, "TCP socket ready — starting aasdk native session")
-                    handleConnection(tcpSocket)
-                }
-            },
-            onConnectFailure = {
-                // Drive the same reconnectAttempt counter the session-stopped
-                // path uses, so picker escalation works even when we never
-                // got to handshake (companion not listening, phone off-net).
-                consecutiveReconnectFailures++
-                _reconnectAttempt.value = consecutiveReconnectFailures
-            },
-        )
-        // An explicit dial target wins over the configured manual IP.
-        _tcpConnector?.manualIp = manualIp ?: manualIpAddress
-        _tcpConnector?.start()
+        synchronized(connectionStartLock) {
+            // Record at the common ownership boundary. WPP restart calls startTcp()
+            // directly, so recording only in dialCompanion() leaves the guard stale.
+            companionDialState.recordStartTcpTarget(manualIp)
+            if (!manualIp.isNullOrBlank()) {
+                OalLog.i(TAG, "Recorded TCP target $manualIp for the live-session re-dial guard")
+            }
+
+            _tcpConnector?.stop()
+            _tcpConnector = null
+            lateinit var connector: TcpConnector
+            connector = TcpConnector(
+                context,
+                scope,
+                onSocketReady = { tcpSocket ->
+                    scope.launch(Dispatchers.IO) {
+                        synchronized(connectionStartLock) {
+                            if (_tcpConnector !== connector) {
+                                OalLog.i(TAG, "Superseded connector delivered a late socket — closing it")
+                                runCatching { tcpSocket.close() }
+                            } else {
+                                OalLog.i(TAG, "TCP socket ready — starting aasdk native session")
+                                handleConnection(tcpSocket)
+                            }
+                        }
+                    }
+                },
+                onConnectFailure = {
+                    synchronized(connectionStartLock) {
+                        if (_tcpConnector === connector) {
+                            // Drive the same reconnectAttempt counter the session-stopped
+                            // path uses, even when TCP never reaches native aasdk.
+                            consecutiveReconnectFailures++
+                            _reconnectAttempt.value = consecutiveReconnectFailures
+                        } else {
+                            OalLog.i(TAG, "Ignoring connect failure from a superseded connector")
+                        }
+                    }
+                },
+            )
+            // An explicit dial target wins over the configured manual IP.
+            connector.manualIp = manualIp ?: manualIpAddress
+            _tcpConnector = connector
+            connector.start()
+        }
     }
 
     private fun startUsb() {
@@ -474,16 +499,18 @@ class AasdkSession(
         explicitStop = true
         OalLog.i(TAG, "Stopping aasdk session")
         cancelPendingReconnect("explicit stop")
-        _tcpConnector?.stop()
-        _tcpConnector = null
-        _wppServer?.stop()
-        _wppServer = null
-        _usbConnectionManager?.stop()
-        _usbConnectionManager = null
-        transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
-            OalLog.i(TAG, "Transport pipe closed — stopping native session")
-            AasdkNative.nativeStopSession()
-            OalLog.i(TAG, "Native session stop completed after transport close")
+        synchronized(connectionStartLock) {
+            _tcpConnector?.stop()
+            _tcpConnector = null
+            _wppServer?.stop()
+            _wppServer = null
+            _usbConnectionManager?.stop()
+            _usbConnectionManager = null
+            transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
+                OalLog.i(TAG, "Transport pipe closed — stopping native session")
+                AasdkNative.nativeStopSession()
+                OalLog.i(TAG, "Native session stop completed after transport close")
+            }
         }
         _connectionState.value = ConnectionState.DISCONNECTED
     }
@@ -507,16 +534,18 @@ class AasdkSession(
             // both reconnects race and one fails with "Native session start failed".
             explicitStop = true
             cancelPendingReconnect("force reconnect")
-            _tcpConnector?.stop()
-            _tcpConnector = null
-            _wppServer?.stop()
-            _wppServer = null
-            _usbConnectionManager?.stop()
-            _usbConnectionManager = null
-            transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
-                OalLog.i(TAG, "Transport pipe closed — stopping native session")
-                AasdkNative.nativeStopSession()
-                OalLog.i(TAG, "Native session stop completed after transport close")
+            synchronized(connectionStartLock) {
+                _tcpConnector?.stop()
+                _tcpConnector = null
+                _wppServer?.stop()
+                _wppServer = null
+                _usbConnectionManager?.stop()
+                _usbConnectionManager = null
+                transportPipe = NativeTransportTeardown.closePipeBeforeNativeStop(transportPipe) {
+                    OalLog.i(TAG, "Transport pipe closed — stopping native session")
+                    AasdkNative.nativeStopSession()
+                    OalLog.i(TAG, "Native session stop completed after transport close")
+                }
             }
             _connectionState.value = ConnectionState.DISCONNECTED
             // Now clear the explicitStop flag so the freshly-started session can

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/CompanionDialState.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/CompanionDialState.kt
@@ -6,7 +6,9 @@ package com.openautolink.app.transport.aasdk
  * The target must be recorded at the shared [AasdkSession.startTcp] boundary,
  * not only in [AasdkSession.dialCompanion]. WPP restart can call startTcp
  * directly; if that path is not recorded, the next Bluetooth handshake looks
- * like a new phone and replaces the live session it just established.
+ * like a new phone and replaces the live session it just established. Conversely,
+ * an active retry may belong to a phone that has left the car, so only a request
+ * for the same recorded target is single-flight; a different phone must replace it.
  */
 internal class CompanionDialState {
     @Volatile
@@ -18,4 +20,7 @@ internal class CompanionDialState {
 
     fun shouldIgnoreRedial(requestedIp: String, hasLiveTransport: Boolean): Boolean =
         hasLiveTransport && requestedIp == startTcpTarget
+
+    fun shouldIgnoreActiveDial(requestedIp: String, connectorIsActive: Boolean): Boolean =
+        connectorIsActive && requestedIp == startTcpTarget
 }

--- a/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
+++ b/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
@@ -196,6 +196,14 @@ class TcpConnector(
         return try {
             val socket = Socket()
             socket.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)
+            // Socket.connect() is blocking and is not cancelled with connectJob.
+            // A different Bluetooth phone can replace this connector while the
+            // old dial is still inside connect(); never publish that late socket.
+            if (!isRunning) {
+                OalLog.i(TAG, "Connector stopped while dialling $host — closing late socket")
+                runCatching { socket.close() }
+                return false
+            }
             socket.tcpNoDelay = true
             // Detect dead phone within ~10s (kernel sends keepalive after idle, then
             // 3 probes 2s apart). Critical for sleep/wake and ungraceful disconnects.

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/CompanionDialStateTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/CompanionDialStateTest.kt
@@ -1,5 +1,6 @@
 package com.openautolink.app.transport.aasdk
 
+import java.io.File
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -29,5 +30,65 @@ class CompanionDialStateTest {
         state.recordStartTcpTarget("10.19.238.82")
 
         assertFalse(state.shouldIgnoreRedial("10.19.238.82", hasLiveTransport = false))
+    }
+
+    @Test
+    fun activeRetryForDifferentPhoneDoesNotBlockNewPhone() {
+        val state = CompanionDialState()
+        state.recordStartTcpTarget("10.19.238.184")
+
+        assertFalse(state.shouldIgnoreActiveDial("10.19.238.82", connectorIsActive = true))
+    }
+
+    @Test
+    fun activeRetryForSamePhoneRemainsSingleFlight() {
+        val state = CompanionDialState()
+        state.recordStartTcpTarget("10.19.238.82")
+
+        assertTrue(state.shouldIgnoreActiveDial("10.19.238.82", connectorIsActive = true))
+    }
+
+    @Test
+    fun dialCompanionUsesTargetAwareActiveConnectorGuard() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val body = source.substringAfter("fun dialCompanion(ip: String)")
+            .substringBefore("private fun startTcp")
+
+        assertTrue(body.contains("companionDialState.shouldIgnoreActiveDial(ip, existingIsActive)"))
+        val startTcpBody = source.substringAfter("private fun startTcp")
+            .substringBefore("private fun startUsb")
+        val lockIndex = startTcpBody.indexOf("synchronized(connectionStartLock)")
+        val ownerCheckIndex = startTcpBody.indexOf("if (_tcpConnector !== connector)")
+        val nativeStartIndex = startTcpBody.indexOf("handleConnection(tcpSocket)")
+        assertTrue(lockIndex >= 0)
+        assertTrue(ownerCheckIndex > lockIndex)
+        assertTrue(nativeStartIndex > ownerCheckIndex)
+        val stopBody = source.substringAfter("fun stop()")
+            .substringBefore("fun forceReconnect")
+        assertTrue(stopBody.contains("synchronized(connectionStartLock)"))
+        val forceReconnectBody = source.substringAfter("fun forceReconnect")
+            .substringBefore("fun sendTouchEvent")
+        assertTrue(forceReconnectBody.contains("synchronized(connectionStartLock)"))
+    }
+
+    @Test
+    fun cancelledConnectorCannotPublishLateSocket() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt",
+        ).readText()
+        val afterConnect = source.substringAfter("socket.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)")
+            .substringBefore("onSocketReady(socket)")
+
+        assertTrue(afterConnect.contains("if (!isRunning)"))
+        assertTrue(afterConnect.contains("socket.close()"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .first { it.isFile }
     }
 }


### PR DESCRIPTION
## Summary
- replace a stale active connector when Bluetooth resolves a different phone
- preserve same-target single-flight and live-session re-dial protection
- serialize connector ownership, socket handoff, and teardown so a cancelled old-phone dial cannot win after replacement
- close sockets that finish connecting after their connector was stopped

## Evidence
The 2026-08-19 car log kept retrying an old companion address while Liz's Bluetooth phone repeatedly resolved at a different reachable address. Save & Reconnect destroyed the stale connector and immediately streamed. This change makes the automatic path perform that target-aware replacement.

## Verification
- `:app:testDebugUnitTest --rerun-tasks`: 326 tests, 0 failures/errors
- `:app:compileReleaseKotlin --rerun-tasks`: successful
- focused target/ownership tests exercised RED before GREEN
- added runtime markers for same-target suppression, different-target replacement, superseded socket closure, and ignored stale failures

## Runtime status
This is a shipped fix attempt pending an in-car two-phone capture. Positive proof requires the next Liz-only cycle to log the different-target replacement (or direct current-target dial), `Connected to companion`, `First frame rendered`, and sustained `vflow` without Save & Reconnect.
