### PR TITLE
feat(protocol): add experimental GAL 6.0 mode (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ its automatic MAC policy.
 
 **Multiple drivers?** On 17.4+ the car projects to whichever phone it is currently connected to over Bluetooth, so switching phones means switching the connection in the **car's own Bluetooth settings** — the APIs an app would need to do that are privileged and closed to us. The phone list on the projection screen still shows every phone it can see, and tapping one retries the connection to it.
 
+> **Multi-phone identity:** Give every phone a unique Bluetooth device name. In each phone's OAL companion, set **Phone identity → Friendly name** to exactly match that phone's Bluetooth name. The car uses this first match to bind the Bluetooth phone to the companion's stable `phone_id`, preventing one reachable companion from being selected for another phone's WPP handshake.
+
 On Android Auto 17.3 and older, both phones can be on the car's WiFi at once and the floating phone icon switches between them directly. Settings → Connection → Known Phones → "Set Default" changes the preferred phone permanently.
 
 > **Tip:** The companion app has a built-in **Setup Guide** (tap the info button next to "Car WiFi") that walks you through these steps.

--- a/app/src/main/cpp/jni_channel_handlers.cpp
+++ b/app/src/main/cpp/jni_channel_handlers.cpp
@@ -153,7 +153,7 @@ void JniAudioSinkHandler::onMediaChannelSetupRequest(
     logProtoRaw("AudioSetup", request);
     aap_protobuf::service::media::shared::message::Config config;
     config.set_status(aap_protobuf::service::media::shared::message::Config::STATUS_READY);
-    config.set_max_unacked(30);
+    config.set_max_unacked(session_.mediaSetupMaxUnacked());
     config.add_configuration_indices(0);
     auto promise = aasdk::channel::SendPromise::defer(strand_);
     promise->then([]() {}, [this](const auto& e) { this->onChannelError(e); });
@@ -167,15 +167,20 @@ void JniAudioSinkHandler::onMediaChannelSetupRequest(
 void JniAudioSinkHandler::onMediaChannelStartIndication(
     const aap_protobuf::service::media::shared::message::Start& indication)
 {
+    activeSessionId_.store(indication.session_id());
     LOGI("Audio start (type=%d) session=%d config_idx=%d", static_cast<int>(type_),
          indication.session_id(), indication.configuration_index());
     logProtoRaw("AudioStart", indication);
+    char channelName[32];
+    snprintf(channelName, sizeof(channelName), "audio[%d]", static_cast<int>(type_));
+    session_.reportGal6StartEnvelope(channelName, indication);
     channel_->receive(shared_from_this());
 }
 
 void JniAudioSinkHandler::onMediaChannelStopIndication(
     const aap_protobuf::service::media::shared::message::Stop& indication)
 {
+    activeSessionId_.store(0);
     LOGI("Audio stop (type=%d)", static_cast<int>(type_));
     logProtoRaw("AudioStop", indication);
     channel_->receive(shared_from_this());
@@ -185,13 +190,16 @@ void JniAudioSinkHandler::onMediaWithTimestampIndication(
     aasdk::messenger::Timestamp::ValueType /*timestamp*/,
     const aasdk::common::DataConstBuffer& buffer)
 {
-    // ACK immediately for flow control
-    aap_protobuf::service::media::source::message::Ack ack;
-    ack.set_session_id(0);
-    ack.set_ack(1);
-    auto promise = aasdk::channel::SendPromise::defer(strand_);
-    promise->then([]() {}, [](const auto&) {});
-    channel_->sendMediaAckIndication(ack, std::move(promise));
+    // GAL 5+/6 audio is ackless. Legacy mode keeps per-frame ACKs and uses
+    // the active Start.session_id rather than the historical hard-coded zero.
+    if (session_.shouldSendAudioAcks()) {
+        aap_protobuf::service::media::source::message::Ack ack;
+        ack.set_session_id(activeSessionId_.load());
+        ack.set_ack(1);
+        auto promise = aasdk::channel::SendPromise::defer(strand_);
+        promise->then([]() {}, [](const auto&) {});
+        channel_->sendMediaAckIndication(ack, std::move(promise));
+    }
 
     // Dispatch to Kotlin via JniSession
     int purpose = purposeFromType();
@@ -205,6 +213,13 @@ void JniAudioSinkHandler::onMediaWithTimestampIndication(
 void JniAudioSinkHandler::onMediaIndication(const aasdk::common::DataConstBuffer& buffer)
 {
     onMediaWithTimestampIndication(0, buffer);
+}
+
+void JniAudioSinkHandler::onMediaOptions(const aasdk::common::DataConstBuffer& buffer)
+{
+    char channelName[32];
+    snprintf(channelName, sizeof(channelName), "audio[%d]", static_cast<int>(type_));
+    session_.reportGal6RawEnvelope(channelName, "GAL6 MediaOptions", buffer);
 }
 
 void JniAudioSinkHandler::onChannelError(const aasdk::error::Error& e)
@@ -777,6 +792,12 @@ void JniNavStatusHandler::onCurrentPosition(
         destDistanceMeters, destDistDisplay, destDistUnit);
 
     channel_->receive(shared_from_this());
+}
+
+void JniNavStatusHandler::onVehicleEnergyForecast(
+    const aasdk::common::DataConstBuffer& buffer)
+{
+    session_.reportGal6RawEnvelope("navigation", "GAL6 VehicleEnergyForecast", buffer);
 }
 
 void JniNavStatusHandler::onChannelError(const aasdk::error::Error& e)

--- a/app/src/main/cpp/jni_channel_handlers.cpp
+++ b/app/src/main/cpp/jni_channel_handlers.cpp
@@ -190,11 +190,12 @@ void JniAudioSinkHandler::onMediaWithTimestampIndication(
     aasdk::messenger::Timestamp::ValueType /*timestamp*/,
     const aasdk::common::DataConstBuffer& buffer)
 {
-    // GAL 5+/6 audio is ackless. Legacy mode keeps per-frame ACKs and uses
-    // the active Start.session_id rather than the historical hard-coded zero.
+    // GAL 5+/6 audio is ackless. Legacy mode keeps its historical per-frame
+    // ACK behavior, including session_id=0, so disabling the toggle is a true
+    // compatibility fallback.
     if (session_.shouldSendAudioAcks()) {
         aap_protobuf::service::media::source::message::Ack ack;
-        ack.set_session_id(activeSessionId_.load());
+        ack.set_session_id(session_.mediaAckSessionId(activeSessionId_.load()));
         ack.set_ack(1);
         auto promise = aasdk::channel::SendPromise::defer(strand_);
         promise->then([]() {}, [](const auto&) {});

--- a/app/src/main/cpp/jni_channel_handlers.h
+++ b/app/src/main/cpp/jni_channel_handlers.h
@@ -63,6 +63,7 @@ private:
     void onMediaWithTimestampIndication(aasdk::messenger::Timestamp::ValueType timestamp,
                                         const aasdk::common::DataConstBuffer& buffer) override;
     void onMediaIndication(const aasdk::common::DataConstBuffer& buffer) override;
+    void onMediaOptions(const aasdk::common::DataConstBuffer& buffer) override;
     void onChannelError(const aasdk::error::Error& e) override;
 
     int purposeFromType() const;
@@ -71,6 +72,7 @@ private:
     std::shared_ptr<aasdk::channel::mediasink::audio::AudioMediaSinkService> channel_;
     JniSession& session_;
     AudioType type_;
+    std::atomic<int> activeSessionId_{0};
 };
 
 // ============================================================================
@@ -146,6 +148,7 @@ private:
     void onDistanceEvent(const aap_protobuf::service::navigationstatus::message::NavigationNextTurnDistanceEvent& distanceEvent) override;
     void onNavigationState(const aap_protobuf::service::navigationstatus::message::NavigationState& navState) override;
     void onCurrentPosition(const aap_protobuf::service::navigationstatus::message::NavigationCurrentPosition& position) override;
+    void onVehicleEnergyForecast(const aasdk::common::DataConstBuffer& buffer) override;
 
     boost::asio::io_service::strand& strand_;
     std::shared_ptr<aasdk::channel::navigationstatus::NavigationStatusService> channel_;

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -251,6 +251,18 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     sdrConfig_.gpsForwarding = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "gpsForwarding", "Z"));
     sdrConfig_.autoNegotiate = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "autoNegotiate", "Z"));
     sdrConfig_.videoCodec = readString("videoCodec");
+    sdrConfig_.experimentalGal6 = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "experimentalGal6", "Z")) != JNI_FALSE;
+    sdrConfig_.requestedGalMajor = env->GetIntField(
+        sdrConfig, env->GetFieldID(sdrClass, "requestedGalMajor", "I"));
+    sdrConfig_.requestedGalMinor = env->GetIntField(
+        sdrConfig, env->GetFieldID(sdrClass, "requestedGalMinor", "I"));
+    sdrConfig_.mediaSetupMaxUnacked = env->GetIntField(
+        sdrConfig, env->GetFieldID(sdrClass, "mediaSetupMaxUnacked", "I"));
+    sdrConfig_.sendAudioAcks = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "sendAudioAcks", "Z")) != JNI_FALSE;
+    sdrConfig_.hevcKeyframeIntervalSeconds = env->GetIntField(
+        sdrConfig, env->GetFieldID(sdrClass, "hevcKeyframeIntervalSeconds", "I"));
     sdrConfig_.realDensity = env->GetIntField(sdrConfig, env->GetFieldID(sdrClass, "realDensity", "I"));
     sdrConfig_.safeAreaTop = env->GetIntField(sdrConfig, env->GetFieldID(sdrClass, "safeAreaTop", "I"));
     sdrConfig_.safeAreaBottom = env->GetIntField(sdrConfig, env->GetFieldID(sdrClass, "safeAreaBottom", "I"));
@@ -278,6 +290,22 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     sdrConfig_.evConnectorTypes = readIntArray("evConnectorTypes");
 
     env->DeleteLocalRef(sdrClass);
+
+    const int requestedMajor = sdrConfig_.requestedGalMajor;
+    const int requestedMinor = sdrConfig_.requestedGalMinor;
+    requestedGalMajor_.store(requestedMajor);
+    requestedGalMinor_.store(requestedMinor);
+    const int expectedGop = expectedHevcGopFrames();
+    LOGI("GAL policy: requested=%d.%d experimental=%d maxUnacked=%d "
+         "audioAcks=%d expectedHevcGopFrames=%d",
+         requestedMajor, requestedMinor, sdrConfig_.experimentalGal6 ? 1 : 0,
+         mediaSetupMaxUnacked(), shouldSendAudioAcks() ? 1 : 0, expectedGop);
+    nativeDiag(1, "gal6", "GAL policy: requested=" + std::to_string(requestedMajor) +
+               "." + std::to_string(requestedMinor) +
+               " experimental=" + (sdrConfig_.experimentalGal6 ? "true" : "false") +
+               " maxUnacked=" + std::to_string(mediaSetupMaxUnacked()) +
+               " audioAcks=" + (shouldSendAudioAcks() ? "true" : "false") +
+               " expectedHevcGopFrames=" + std::to_string(expectedGop));
 
     LOGI("Starting session: video=%dx%d@%dfps dpi=%d realDpi=%d pixelAspect=%d marginW=%d marginH=%d viewDistMm=%d decAddDepth=%d autoNeg=%d codec=%s targetLayoutDp=%d",
          sdrConfig_.videoWidth, sdrConfig_.videoHeight,
@@ -370,8 +398,12 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
                 *strand_, messenger_);
         }
 
-        // 5. Initiate version exchange (request v1.7 — DHU uses 1.7, aasdk defaults to 1.6)
-        LOGI("Sending version request (v1.7)...");
+        // 5. Initiate version exchange. Legacy mode preserves 1.7; the
+        // default-off experimental toggle requests 6.0 to activate Gearhead's
+        // modern media envelopes and short HEVC keyframe policy.
+        const uint16_t requestedMajor = static_cast<uint16_t>(requestedGalMajor_.load());
+        const uint16_t requestedMinor = static_cast<uint16_t>(requestedGalMinor_.load());
+        LOGI("Sending version request (v%d.%d)...", requestedMajor, requestedMinor);
         {
             auto message = std::make_shared<aasdk::messenger::Message>(
                 aasdk::messenger::ChannelId::CONTROL,
@@ -381,11 +413,10 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
                 aasdk::messenger::MessageId(
                     aap_protobuf::service::control::message::ControlMessageType::MESSAGE_VERSION_REQUEST).getData());
             aasdk::common::Data versionBuffer(4, 0);
-            uint16_t major = 1, minor = 7;
-            versionBuffer[0] = (major >> 8) & 0xFF;
-            versionBuffer[1] = major & 0xFF;
-            versionBuffer[2] = (minor >> 8) & 0xFF;
-            versionBuffer[3] = minor & 0xFF;
+            versionBuffer[0] = (requestedMajor >> 8) & 0xFF;
+            versionBuffer[1] = requestedMajor & 0xFF;
+            versionBuffer[2] = (requestedMinor >> 8) & 0xFF;
+            versionBuffer[3] = requestedMinor & 0xFF;
             message->insertPayload(versionBuffer);
             auto promise = aasdk::channel::SendPromise::defer(*strand_);
             promise->then([]() {},
@@ -544,6 +575,39 @@ void JniSession::nativeDiag(int level, const char* tag, const std::string& msg)
     releaseEnv(attached);
 }
 
+void JniSession::reportGal6StartEnvelope(
+    const char* channel,
+    const aap_protobuf::service::media::shared::message::Start& indication)
+{
+    if (!sdrConfig_.experimentalGal6) return;
+    const int unknownCount = indication.unknown_fields().field_count();
+    const auto bytes = indication.ByteSizeLong();
+    const int sessionType = indication.has_session_type() ? indication.session_type() : -1;
+    const size_t mediaConfigBytes = indication.has_media_config()
+        ? indication.media_config().size() : 0;
+    const std::string msg = "GAL6 " + std::string(channel) +
+        " Start envelope: session=" + std::to_string(indication.session_id()) +
+        " config_idx=" + std::to_string(indication.configuration_index()) +
+        " session_type=" + std::to_string(sessionType) +
+        " media_config_bytes=" + std::to_string(mediaConfigBytes) +
+        " bytes=" + std::to_string(bytes) +
+        " unknown_fields=" + std::to_string(unknownCount);
+    LOGI("%s", msg.c_str());
+    nativeDiag(1, "gal6", msg);
+}
+
+void JniSession::reportGal6RawEnvelope(
+    const char* channel,
+    const char* envelope,
+    const aasdk::common::DataConstBuffer& buffer)
+{
+    const std::string msg = std::string(envelope) + " channel=" + channel +
+        " bytes=" + std::to_string(buffer.size) +
+        " raw=" + hexDump(buffer.cdata, buffer.size, 128);
+    LOGI("%s", msg.c_str());
+    nativeDiag(1, "gal6", msg);
+}
+
 void JniSession::notifySensorSubscribed(int sensorType)
 {
     if (!cbMethods_.onSensorSubscribed || !callbackRef_) return;
@@ -563,7 +627,25 @@ void JniSession::notifySensorSubscribed(int sensorType)
 void JniSession::onVersionResponse(uint16_t majorCode, uint16_t minorCode,
                                     aap_protobuf::shared::MessageStatus status)
 {
-    LOGI("Version response: %d.%d status=%d", majorCode, minorCode, static_cast<int>(status));
+    LOGI("Version response: %d.%d status=%d (requested=%d.%d experimental=%d)",
+         majorCode, minorCode, static_cast<int>(status),
+         requestedGalMajor_.load(), requestedGalMinor_.load(),
+         sdrConfig_.experimentalGal6 ? 1 : 0);
+    nativeDiag(1, "gal6", "GAL negotiated: requested=" +
+               std::to_string(requestedGalMajor_.load()) + "." +
+               std::to_string(requestedGalMinor_.load()) + " response=" +
+               std::to_string(majorCode) + "." + std::to_string(minorCode) +
+               " status=" + std::to_string(static_cast<int>(status)));
+
+    if (status != aap_protobuf::shared::STATUS_SUCCESS) {
+        const std::string reason = "GAL version negotiation rejected: requested=" +
+            std::to_string(requestedGalMajor_.load()) + "." +
+            std::to_string(requestedGalMinor_.load()) +
+            " status=" + std::to_string(static_cast<int>(status));
+        nativeDiag(3, "gal6", reason);
+        triggerAbort(reason);
+        return;
+    }
 
     try {
         cryptor_->doHandshake();
@@ -958,7 +1040,7 @@ void JniSession::onMediaChannelSetupRequest(
 
     aap_protobuf::service::media::shared::message::Config config;
     config.set_status(aap_protobuf::service::media::shared::message::Config::STATUS_READY);
-    config.set_max_unacked(30);
+    config.set_max_unacked(mediaSetupMaxUnacked());
     if (sdrConfig_.autoNegotiate) {
         // Auto mode: accept every config we advertised.
         int n = advertisedVideoConfigCount_.load();
@@ -994,9 +1076,11 @@ void JniSession::onMediaChannelSetupRequest(
 void JniSession::onMediaChannelStartIndication(
     const aap_protobuf::service::media::shared::message::Start& indication)
 {
+    activeVideoSessionId_.store(indication.session_id());
     LOGI("Video stream starting: session=%d config_idx=%d",
          indication.session_id(), indication.configuration_index());
     logProtoRaw("VideoStart", indication);
+    reportGal6StartEnvelope("video", indication);
     nativeDiag(1, "video", "phone->us VideoStart session=" +
                std::to_string(indication.session_id()) + " config_idx=" +
                std::to_string(indication.configuration_index()) +
@@ -1017,6 +1101,7 @@ void JniSession::onMediaChannelStartIndication(
 void JniSession::onMediaChannelStopIndication(
     const aap_protobuf::service::media::shared::message::Stop& /*indication*/)
 {
+    activeVideoSessionId_.store(0);
     LOGI("Video stream stopping");
     nativeDiag(2, "video", "phone->us VideoStop (stream stopping)");
     videoChannel_->receive(shared_from_this());
@@ -1028,7 +1113,7 @@ void JniSession::onMediaWithTimestampIndication(
 {
     // Hot path Ã¢â‚¬â€ video frame. Send ACK immediately (flow control).
     aap_protobuf::service::media::source::message::Ack ack;
-    ack.set_session_id(0);
+    ack.set_session_id(activeVideoSessionId_.load());
     ack.set_ack(1);
     auto promise = aasdk::channel::SendPromise::defer(*strand_);
     promise->then([]() {}, [](const auto&) {});
@@ -1114,6 +1199,11 @@ void JniSession::onMediaWithTimestampIndication(
 void JniSession::onMediaIndication(const aasdk::common::DataConstBuffer& buffer)
 {
     onMediaWithTimestampIndication(0, buffer);
+}
+
+void JniSession::onMediaOptions(const aasdk::common::DataConstBuffer& buffer)
+{
+    reportGal6RawEnvelope("video", "GAL6 MediaOptions", buffer);
 }
 
 void JniSession::onVideoFocusRequest(
@@ -1406,6 +1496,15 @@ void JniSession::buildServiceDiscoveryResponse(
           if (sdrConfig_.viewingDistanceMm > 0) vc->set_viewing_distance(sdrConfig_.viewingDistanceMm);
           if (sdrConfig_.decoderAdditionalDepth > 0) vc->set_decoder_additional_depth(sdrConfig_.decoderAdditionalDepth);
           applySafeArea(vc);
+          // GAL 4.3+ stops deriving these ownership flags from the legacy
+          // ServiceDiscoveryResponse.session_configuration bitmask. Preserve
+          // the existing user choices in the modern UiConfig envelope.
+          if (sdrConfig_.experimentalGal6) {
+              auto* ui = vc->mutable_ui_config();
+              if (sdrConfig_.hideClock) ui->add_hidden_ui_elements(1);
+              if (sdrConfig_.hideBattery) ui->add_hidden_ui_elements(2);
+              if (sdrConfig_.hideSignal) ui->add_hidden_ui_elements(3);
+          }
       };
 
       auto computeDensity = [&](int tier) -> int {

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -74,6 +74,16 @@ static std::string hexDump(const uint8_t* data, size_t len, size_t maxBytes = 51
     return ss.str();
 }
 
+static std::string hexCompact(const uint8_t* data, size_t len) {
+    static constexpr char digits[] = "0123456789abcdef";
+    std::string result(len * 2, '0');
+    for (size_t i = 0; i < len; ++i) {
+        result[i * 2] = digits[(data[i] >> 4) & 0x0f];
+        result[i * 2 + 1] = digits[data[i] & 0x0f];
+    }
+    return result;
+}
+
 // Log raw bytes + unknown fields for any protobuf message
 template<typename T>
 static void logProtoRaw(const char* label, const T& msg) {
@@ -594,6 +604,11 @@ void JniSession::reportGal6StartEnvelope(
         " unknown_fields=" + std::to_string(unknownCount);
     LOGI("%s", msg.c_str());
     nativeDiag(1, "gal6", msg);
+
+    std::string raw;
+    indication.SerializeToString(&raw);
+    reportGal6Payload(channel, "Start",
+        reinterpret_cast<const uint8_t*>(raw.data()), raw.size());
 }
 
 void JniSession::reportGal6RawEnvelope(
@@ -601,11 +616,46 @@ void JniSession::reportGal6RawEnvelope(
     const char* envelope,
     const aasdk::common::DataConstBuffer& buffer)
 {
-    const std::string msg = std::string(envelope) + " channel=" + channel +
-        " bytes=" + std::to_string(buffer.size) +
-        " raw=" + hexDump(buffer.cdata, buffer.size, 128);
-    LOGI("%s", msg.c_str());
-    nativeDiag(1, "gal6", msg);
+    reportGal6Payload(channel, envelope, buffer.cdata, buffer.size);
+}
+
+void JniSession::reportGal6Payload(
+    const char* channel,
+    const char* envelope,
+    const uint8_t* data,
+    size_t size)
+{
+    if (!sdrConfig_.experimentalGal6) return;
+
+    // DiagnosticLog truncates messages at 500 characters. Compact-hex chunks
+    // preserve the complete opaque payload in uploaded logs for later decoding.
+    static constexpr size_t GAL6_PAYLOAD_CHUNK_BYTES = 128;
+    const uint64_t id = gal6EnvelopeSequence_.fetch_add(1) + 1;
+    const size_t totalChunks = std::max<size_t>(1,
+        (size + GAL6_PAYLOAD_CHUNK_BYTES - 1) / GAL6_PAYLOAD_CHUNK_BYTES);
+
+    for (size_t chunk = 0; chunk < totalChunks; ++chunk) {
+        const size_t offset = chunk * GAL6_PAYLOAD_CHUNK_BYTES;
+        const size_t chunkBytes = offset < size
+            ? std::min(GAL6_PAYLOAD_CHUNK_BYTES, size - offset) : 0;
+        const std::string hex = chunkBytes > 0
+            ? hexCompact(data + offset, chunkBytes) : std::string();
+        const std::string line = "GAL6 payload id=" + std::to_string(id) +
+            " envelope=" + envelope +
+            " channel=" + channel +
+            " bytes=" + std::to_string(size) +
+            " chunk=" + std::to_string(chunk + 1) +
+            " total_chunks=" + std::to_string(totalChunks) +
+            " offset=" + std::to_string(offset) +
+            " hex=" + hex;
+        if (line.size() <= 500) {
+            LOGI("%s", line.c_str());
+            nativeDiag(1, "gal6", line);
+        } else {
+            nativeDiag(3, "gal6", "GAL6 payload chunk formatting overflow id=" +
+                std::to_string(id));
+        }
+    }
 }
 
 void JniSession::notifySensorSubscribed(int sensorType)
@@ -1113,7 +1163,7 @@ void JniSession::onMediaWithTimestampIndication(
 {
     // Hot path Ã¢â‚¬â€ video frame. Send ACK immediately (flow control).
     aap_protobuf::service::media::source::message::Ack ack;
-    ack.set_session_id(activeVideoSessionId_.load());
+    ack.set_session_id(mediaAckSessionId(activeVideoSessionId_.load()));
     ack.set_ack(1);
     auto promise = aasdk::channel::SendPromise::defer(*strand_);
     promise->then([]() {}, [](const auto&) {});

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -294,6 +294,7 @@ private:
     std::atomic<int> activeVideoSessionId_{0};
     std::atomic<int> requestedGalMajor_{1};
     std::atomic<int> requestedGalMinor_{7};
+    std::atomic<uint64_t> gal6EnvelopeSequence_{0};
 
     // Current video focus state for the main display.
     // 1 = VIDEO_FOCUS_PROJECTED (default — we always project on AAOS).
@@ -319,6 +320,9 @@ private:
 
 public:
     bool shouldSendAudioAcks() const { return sdrConfig_.sendAudioAcks; }
+    int mediaAckSessionId(int activeSessionId) const {
+        return sdrConfig_.experimentalGal6 ? activeSessionId : 0;
+    }
     int mediaSetupMaxUnacked() const { return sdrConfig_.mediaSetupMaxUnacked; }
     int expectedHevcGopFrames() const {
         return sdrConfig_.hevcKeyframeIntervalSeconds * std::max(0, sdrConfig_.videoFps);
@@ -330,6 +334,11 @@ public:
         const char* channel,
         const char* envelope,
         const aasdk::common::DataConstBuffer& buffer);
+    void reportGal6Payload(
+        const char* channel,
+        const char* envelope,
+        const uint8_t* data,
+        size_t size);
 
     /**
      * Centralized channel-error reporting. Called by per-channel handlers.

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <thread>
 #include <atomic>
+#include <algorithm>
 #include <map>
 #include <mutex>
 #include <string>
@@ -192,6 +193,7 @@ public:
         aasdk::messenger::Timestamp::ValueType timestamp,
         const aasdk::common::DataConstBuffer& buffer) override;
     void onMediaIndication(const aasdk::common::DataConstBuffer& buffer) override;
+    void onMediaOptions(const aasdk::common::DataConstBuffer& buffer) override;
     void onVideoFocusRequest(
         const aap_protobuf::service::media::video::message::VideoFocusRequestNotification& request) override;
 
@@ -289,6 +291,10 @@ private:
     /** Set once a ByeBye has been dispatched, so two callers cannot double-send. */
     std::atomic<bool> byeByeSent_{false};
     std::atomic<int> negotiatedCodecType_{0};
+    std::atomic<int> activeVideoSessionId_{0};
+    std::atomic<int> requestedGalMajor_{1};
+    std::atomic<int> requestedGalMinor_{7};
+
     // Current video focus state for the main display.
     // 1 = VIDEO_FOCUS_PROJECTED (default — we always project on AAOS).
     // Tracking this lets onVideoFocusRequest reply with our actual current
@@ -312,6 +318,19 @@ private:
     void schedulePing();
 
 public:
+    bool shouldSendAudioAcks() const { return sdrConfig_.sendAudioAcks; }
+    int mediaSetupMaxUnacked() const { return sdrConfig_.mediaSetupMaxUnacked; }
+    int expectedHevcGopFrames() const {
+        return sdrConfig_.hevcKeyframeIntervalSeconds * std::max(0, sdrConfig_.videoFps);
+    }
+    void reportGal6StartEnvelope(
+        const char* channel,
+        const aap_protobuf::service::media::shared::message::Start& indication);
+    void reportGal6RawEnvelope(
+        const char* channel,
+        const char* envelope,
+        const aasdk::common::DataConstBuffer& buffer);
+
     /**
      * Centralized channel-error reporting. Called by per-channel handlers.
      * Coalesces log spam and escalates to triggerAbort() when many errors
@@ -358,6 +377,12 @@ private:
         bool gpsForwarding = true;
         bool autoNegotiate = true;
         std::string videoCodec = "h265";
+        bool experimentalGal6 = false;
+        int requestedGalMajor = 1;
+        int requestedGalMinor = 7;
+        int mediaSetupMaxUnacked = 30;
+        bool sendAudioAcks = true;
+        int hevcKeyframeIntervalSeconds = 60;
         int realDensity = 0;
         int safeAreaTop = 0;
         int safeAreaBottom = 0;

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -33,6 +33,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val VIDEO_AUTO_NEGOTIATE = booleanPreferencesKey("video_auto_negotiate")
         val VIDEO_CODEC = stringPreferencesKey("video_codec")
         val VIDEO_FPS = intPreferencesKey("video_fps")
+        val EXPERIMENTAL_GAL6 = booleanPreferencesKey("experimental_gal6")
         val DISPLAY_MODE = stringPreferencesKey("display_mode")
         val MIC_SOURCE = stringPreferencesKey("mic_source")
         // Manual override for the head unit's Bluetooth MAC, advertised in
@@ -248,6 +249,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_VIDEO_AUTO_NEGOTIATE = true
         const val DEFAULT_VIDEO_CODEC = "h264"
         const val DEFAULT_VIDEO_FPS = 60
+        const val DEFAULT_EXPERIMENTAL_GAL6 = false
         const val DEFAULT_DISPLAY_MODE = "fullscreen_immersive"
         const val DEFAULT_MIC_SOURCE = "car"
         const val DEFAULT_BT_MAC_OVERRIDE = ""
@@ -389,6 +391,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val videoFps: Flow<Int> = dataStore.data.map { prefs ->
         prefs[VIDEO_FPS] ?: DEFAULT_VIDEO_FPS
+    }
+
+    val experimentalGal6: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[EXPERIMENTAL_GAL6] ?: DEFAULT_EXPERIMENTAL_GAL6
     }
 
     val displayMode: Flow<String> = dataStore.data.map { prefs ->
@@ -720,6 +726,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setVideoFps(fps: Int) {
         dataStore.edit { it[VIDEO_FPS] = fps }
+    }
+
+    suspend fun setExperimentalGal6(enabled: Boolean) {
+        dataStore.edit { it[EXPERIMENTAL_GAL6] = enabled }
     }
 
     suspend fun setDisplayMode(mode: String) {

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.runBlocking
  *   video_auto_negotiate --ez bvalue <bool>    true/false
  *   video_codec         --es svalue <str>      h264, h265
  *   video_fps           --ei value <int>       30, 60
+ *   experimental_gal6   --ez bvalue <bool>     request GAL/PDK 6.0 (experimental)
  *   direct_transport    --es svalue <str>      hotspot, usb
  *   drive_side          --es svalue <str>      left, right
  *   manual_ip_enabled   --ez bvalue <bool>     true/false
@@ -109,6 +110,10 @@ class SettingsReceiver : BroadcastReceiver() {
                 "video_fps" -> {
                     val v = intent.getIntExtra("value", -1)
                     if (v > 0) { prefs.setVideoFps(v); log("video_fps=$v") }
+                }
+                "experimental_gal6" -> {
+                    val v = intent.getBooleanExtra("bvalue", false)
+                    prefs.setExperimentalGal6(v); log("experimental_gal6=$v")
                 }
                 "direct_transport" -> {
                     val v = intent.getStringExtra("svalue") ?: return@runBlocking
@@ -189,6 +194,7 @@ class SettingsReceiver : BroadcastReceiver() {
                     gpsForwarding = prefs.gpsForwarding.first(),
                     manualIpAddress = if (prefs.manualIpEnabled.first())
                         prefs.manualIpAddress.first().takeIf { it.isNotBlank() } else null,
+                    experimentalGal6 = prefs.experimentalGal6.first(),
                 )
                 OalLog.i("SettingsRcv", "RECONNECT: triggered")
             } catch (e: Exception) {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -857,6 +857,7 @@ class SessionManager(
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
+        experimentalGal6: Boolean = false,
     ) {
         // Cache for later reconnects that don't know the resolved IP (e.g.
         // Settings "Save & Reconnect" in Car Hotspot mode).
@@ -1137,7 +1138,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
                 safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding)
+                gpsForwarding, experimentalGal6)
         }
 
         // Listen for system sleep so we can gracefully tear down before the
@@ -1161,6 +1162,7 @@ class SessionManager(
         manualIpAddress: String? = null,
         safeAreaTop: Int = 0, safeAreaBottom: Int = 0, safeAreaLeft: Int = 0, safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
+        experimentalGal6: Boolean = false,
     ) {
         aasdkSession?.stop()
         _transportMode.value = directTransport
@@ -1405,6 +1407,7 @@ class SessionManager(
             gpsForwarding = gpsForwarding,
             autoNegotiate = videoAutoNegotiate,
             videoCodec = codec,
+            experimentalGal6 = experimentalGal6,
             // realDensity removed — interferes with pixel_aspect_ratio_e4 on some AA versions
             safeAreaTop = effSafeTop,
             safeAreaBottom = effSafeBottom,
@@ -1728,6 +1731,7 @@ class SessionManager(
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
+        experimentalGal6: Boolean = false,
     ) {
         // "Save & Reconnect" from Settings doesn't know the resolved Car
         // Hotspot IP — fall back to the last value we successfully used so
@@ -1746,7 +1750,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery,
                 volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                 effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding,
+                gpsForwarding, experimentalGal6,
             )
             return
         }
@@ -1828,7 +1832,7 @@ class SessionManager(
                     videoFps, driveSide, hideClock, hideSignal, hideBattery,
                     volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                     effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                    gpsForwarding,
+                    gpsForwarding, experimentalGal6,
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
@@ -1855,6 +1859,7 @@ class SessionManager(
         manualIpAddress: String?,
         safeAreaTop: Int, safeAreaBottom: Int, safeAreaLeft: Int, safeAreaRight: Int,
         gpsForwarding: Boolean,
+        experimentalGal6: Boolean,
     ) {
         observeJob = null
         decoderWatchJob = null
@@ -1916,7 +1921,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
                 safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding)
+                gpsForwarding, experimentalGal6)
         }
 
         // 9. Re-establish cluster binding — GM Templates Host may have killed

--- a/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
+++ b/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
@@ -168,14 +168,22 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * mid-session; publishing on every discovery keeps it current rather than
      * pinning a value that was right a minute ago.
      */
-    private fun publishPhoneAddress(host: String, reportedProxyPort: Int? = null) {
+    private fun publishPhoneAddress(
+        host: String,
+        reportedProxyPort: Int? = null,
+        phoneId: String? = null,
+        friendlyName: String? = null,
+    ) {
         val bt = com.openautolink.app.transport.bluetooth.AaWirelessBtControl
-        bt.lastKnownPhoneIp = host
-        // During an attempt-owned WPP bootstrap, pass through the proxy port the
-        // identity response actually reported. Port 5280 completes the current
-        // exchange; an older companion's dynamic port triggers one compatibility
-        // re-advertise after the current handshake exits.
-        bt.readvertiseForNewCompanionAddress(host, reportedProxyPort)
+        // Do not publish this host into the global dial cache before ownership is
+        // proven. Nearby phones share discovery, but only the Bluetooth-owned
+        // attempt may accept/cache this identity.
+        bt.readvertiseForNewCompanionAddress(
+            host = host,
+            reportedProxyPort = reportedProxyPort,
+            reportedPhoneId = phoneId,
+            reportedFriendlyName = friendlyName,
+        )
     }
 
     private val _isDiscovering = MutableStateFlow(false)
@@ -555,7 +563,12 @@ class PhoneDiscovery private constructor(private val context: Context) {
                         if (ident != null) {
                             // Remember where the companion lives so the Bluetooth
                             // advertiser can ask it for its AA proxy port.
-                            publishPhoneAddress(ip, ident.wppProxyPort)
+                            publishPhoneAddress(
+                                host = ip,
+                                reportedProxyPort = ident.wppProxyPort,
+                                phoneId = ident.phoneId,
+                                friendlyName = ident.friendlyName,
+                            )
                             addOrUpdate(
                                 phoneId = ident.phoneId,
                                 friendlyName = ident.friendlyName,
@@ -865,7 +878,13 @@ class PhoneDiscovery private constructor(private val context: Context) {
     ) {
         // Every discovery source funnels through here, so this is the one place
         // that always has the freshest address for the Bluetooth advertiser.
-        host?.takeIf { it.isNotBlank() }?.let { publishPhoneAddress(it) }
+        host?.takeIf { it.isNotBlank() }?.let {
+            publishPhoneAddress(
+                host = it,
+                phoneId = phoneId,
+                friendlyName = friendlyName,
+            )
+        }
 
         synchronized(lock) {
             val canonicalKey = keyFor(phoneId, mdnsServiceName, host)

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
@@ -71,6 +71,9 @@ class AasdkSdrConfig(
     /** Video codec preference for manual mode: "h264" or "h265". */
     @JvmField val videoCodec: String = "h265",
 
+    /** Request experimental GAL/PDK 6.0 compatibility instead of legacy 1.7. */
+    @JvmField val experimentalGal6: Boolean = false,
+
     /** Physical pixel density of the AAOS display (from DisplayMetrics.densityDpi). */
     @JvmField val realDensity: Int = 0,
 
@@ -121,4 +124,13 @@ class AasdkSdrConfig(
      */
     @JvmField val panelWidth: Int = 0,
     @JvmField val panelHeight: Int = 0,
-)
+) {
+    private val galPolicy = GalProtocolPolicy.forExperimentalGal6(experimentalGal6)
+
+    /** Materialized policy fields consumed directly by JNI; do not re-derive natively. */
+    @JvmField val requestedGalMajor: Int = galPolicy.requestedVersion.major
+    @JvmField val requestedGalMinor: Int = galPolicy.requestedVersion.minor
+    @JvmField val mediaSetupMaxUnacked: Int = galPolicy.maxUnacked
+    @JvmField val sendAudioAcks: Boolean = galPolicy.sendAudioAcks
+    @JvmField val hevcKeyframeIntervalSeconds: Int = galPolicy.hevcKeyframeIntervalSeconds
+}

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -216,11 +216,12 @@ class AasdkSession(
         // "connected". Discovery even found the phone; nothing acted on it,
         // because in WPP mode only the handshake triggers a dial.
         val known = com.openautolink.app.transport.bluetooth.AaWirelessBtControl
-            .lastKnownPhoneIp
+            .withIdentityValidatedCompanion { address ->
+                OalLog.i(TAG, "WPP restart with a known companion at $address — dialling " +
+                        "rather than waiting for a handshake that is not coming")
+                startTcp(manualIp = address)
+            }
         if (known != null) {
-            OalLog.i(TAG, "WPP restart with a known companion at $known — dialling " +
-                    "rather than waiting for a handshake that is not coming")
-            startTcp(manualIp = known)
             // Dialling the companion is only half the connection. Android Auto's
             // previous localhost socket belonged to the bridge that just ended;
             // reconnecting the car socket does not by itself make AA open a new
@@ -560,8 +561,10 @@ class AasdkSession(
                     // falls through to the gateway heuristic and dials the house
                     // router.
                     val known = com.openautolink.app.transport.bluetooth
-                        .AaWirelessBtControl.lastKnownPhoneIp
-                    startTcp(manualIp = known)
+                        .AaWirelessBtControl.withIdentityValidatedCompanion { address ->
+                            startTcp(manualIp = address)
+                        }
+                    if (known == null) startTcp(manualIp = null)
                 }
             }
         } finally {
@@ -742,6 +745,7 @@ class AasdkSession(
                     OalLog.i(TAG, "Restarting transport connector")
                     when (transportMode) {
                         "usb" -> startUsb()
+                        "wpp" -> startWpp()
                         else -> {
                             // Keep the companion's address on a retry.
                             //
@@ -751,8 +755,10 @@ class AasdkSession(
                             //     Connecting to 192.168.0.1:5277 (gateway)  x10
                             // The companion is never at the gateway in WPP mode.
                             val known = com.openautolink.app.transport.bluetooth
-                                .AaWirelessBtControl.lastKnownPhoneIp
-                            startTcp(manualIp = known)
+                                .AaWirelessBtControl.withIdentityValidatedCompanion { address ->
+                                    startTcp(manualIp = address)
+                                }
+                            if (known == null) startTcp(manualIp = null)
                         }
                     }
                 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
@@ -1,0 +1,53 @@
+package com.openautolink.app.transport.aasdk
+
+/** Raw GAL protocol version requested by the head unit before TLS. */
+data class GalProtocolVersion(val major: Int, val minor: Int)
+
+/**
+ * Behavior selected by the experimental GAL 6 compatibility toggle.
+ *
+ * GAL 6.0 is not just a version label: Gearhead switches audio to ackless,
+ * enriches AV start envelopes, and selects the HEVC encoder's short (2-second)
+ * keyframe interval. The setup window remains OAL's proven value of 30.
+ */
+data class GalProtocolConfig(
+    val requestedVersion: GalProtocolVersion,
+    val maxUnacked: Int,
+    val sendAudioAcks: Boolean,
+    val hevcKeyframeIntervalSeconds: Int,
+)
+
+object GalProtocolPolicy {
+    private const val LEGACY_KEYFRAME_INTERVAL_SECONDS = 60
+    private const val GAL6_KEYFRAME_INTERVAL_SECONDS = 2
+
+    fun forExperimentalGal6(enabled: Boolean): GalProtocolConfig =
+        if (enabled) {
+            GalProtocolConfig(
+                requestedVersion = GalProtocolVersion(6, 0),
+                // The audited GAL gates require only a positive setup value;
+                // ackless audio does not consume this as per-buffer credit.
+                maxUnacked = 30,
+                sendAudioAcks = false,
+                hevcKeyframeIntervalSeconds = GAL6_KEYFRAME_INTERVAL_SECONDS,
+            )
+        } else {
+            GalProtocolConfig(
+                requestedVersion = GalProtocolVersion(1, 7),
+                maxUnacked = 30,
+                sendAudioAcks = true,
+                hevcKeyframeIntervalSeconds = LEGACY_KEYFRAME_INTERVAL_SECONDS,
+            )
+        }
+
+    /**
+     * Expected OMX HEVC GOP frame count.
+     *
+     * AOSP converts I-frame seconds to frames using configured fps. This is a
+     * diagnostic prediction, not a guarantee for every vendor encoder.
+     */
+    fun expectedHevcGopFrames(experimentalGal6: Boolean, advertisedFps: Int): Int {
+        return forExperimentalGal6(experimentalGal6).hevcKeyframeIntervalSeconds *
+            advertisedFps.coerceAtLeast(0)
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -346,15 +346,24 @@ object AaWirelessBtControl {
             while (System.currentTimeMillis() < deadline) {
                 // A newer Bluetooth dial-back owns a different attempt. Let this
                 // scanner die without consuming or dialling on its behalf.
-                if (bootstrapAttempt.get() !== attempt || sessionIsStreaming?.invoke() == true) {
+                if (bootstrapAttempt.get() !== attempt ||
+                    !phoneClaimStillOwned(attempt.phoneBtAddress, attempt.claimGeneration) ||
+                    sessionIsStreaming?.invoke() == true
+                ) {
                     return@launch
                 }
                 scanAttempt++
-                var found: Pair<String, Int>? = null
+                var found: ResolvedCompanion? = null
                 for (ip in candidates.take(MAX_PRESCAN_PROBES)) {
-                    val proxyPort = askCompanion(ip, connectTimeoutMs = 800)
-                    if (proxyPort != null) {
-                        found = ip to proxyPort
+                    val probe = askCompanion(ip, connectTimeoutMs = 800)
+                    if (probe != null && probeMatchesBluetoothOwner(
+                            attempt.phoneBtAddress,
+                            attempt.phoneBtName,
+                            ip,
+                            probe,
+                            attempt.expectedPhoneId,
+                        )) {
+                        found = ResolvedCompanion(ip, probe)
                         break
                     }
                 }
@@ -362,13 +371,26 @@ object AaWirelessBtControl {
                     val remainingMs = (deadline - System.currentTimeMillis())
                         .coerceIn(1L, 5_000L)
                         .toInt()
-                    found = findCompanionOnAnySubnet(manualIp, remainingMs)
+                    found = findCompanionOnAnySubnet(
+                        manualIp = manualIp,
+                        phoneBtAddress = attempt.phoneBtAddress,
+                        phoneBtName = attempt.phoneBtName,
+                        overallTimeoutMs = remainingMs,
+                    )
                 }
                 if (found != null) {
-                    val (ip, proxyPort) = found
-                    OalLog.i(TAG, "Bootstrap discovery found companion at $ip " +
-                            "on attempt $scanAttempt (proxy port $proxyPort)")
-                    readvertiseForNewCompanionAddress(ip, proxyPort, attempt)
+                    val ip = found.host
+                    val probe = found.probe
+                    OalLog.i(TAG, "Bootstrap discovery identity-matched companion at $ip " +
+                            "id=${probe.phoneId} on attempt $scanAttempt " +
+                            "(proxy port ${probe.proxyPort})")
+                    readvertiseForNewCompanionAddress(
+                        host = ip,
+                        reportedProxyPort = probe.proxyPort,
+                        expectedAttempt = attempt,
+                        reportedPhoneId = probe.phoneId,
+                        reportedFriendlyName = probe.friendlyName,
+                    )
                     return@launch
                 }
                 kotlinx.coroutines.delay(750)
@@ -383,11 +405,15 @@ object AaWirelessBtControl {
         val (pending, admissionToken) = synchronized(handshakeStateLock) {
             if (activeHandshakeCount.get() > 0 || handshakeAdmissionBlocked) return
             val candidate = pendingLegacyReadvertise.get() ?: return
-            if (bootstrapAttempt.get() !== candidate.attempt) {
+            val consumed = synchronized(phoneClaimLock) {
+                activePhoneBt.equals(candidate.attempt.phoneBtAddress, ignoreCase = true) &&
+                    phoneClaimGeneration == candidate.attempt.claimGeneration &&
+                    bootstrapAttempt.compareAndSet(candidate.attempt, null)
+            }
+            if (!consumed) {
                 pendingLegacyReadvertise.compareAndSet(candidate, null)
                 return
             }
-            if (!bootstrapAttempt.compareAndSet(candidate.attempt, null)) return
             pendingLegacyReadvertise.compareAndSet(candidate, null)
             val token = handshakeAdmissionSequence.incrementAndGet()
             handshakeAdmissionBlocked = true
@@ -401,18 +427,51 @@ object AaWirelessBtControl {
         readvertise(admissionToken)
     }
 
-    fun readvertiseForNewCompanionAddress(host: String, reportedProxyPort: Int? = null) {
-        readvertiseForNewCompanionAddress(host, reportedProxyPort, null)
+    fun readvertiseForNewCompanionAddress(
+        host: String,
+        reportedProxyPort: Int? = null,
+        reportedPhoneId: String? = null,
+        reportedFriendlyName: String? = null,
+    ) {
+        readvertiseForNewCompanionAddress(
+            host = host,
+            reportedProxyPort = reportedProxyPort,
+            expectedAttempt = null,
+            reportedPhoneId = reportedPhoneId,
+            reportedFriendlyName = reportedFriendlyName,
+        )
     }
 
     private fun readvertiseForNewCompanionAddress(
         host: String,
         reportedProxyPort: Int? = null,
         expectedAttempt: BootstrapAttempt? = null,
+        reportedPhoneId: String? = null,
+        reportedFriendlyName: String? = null,
     ) {
-        val proxyPort = reportedProxyPort ?: askCompanion(host, connectTimeoutMs = 800) ?: return
+        val liveProbe = askCompanion(host, connectTimeoutMs = 800)
+        val probe = liveProbe ?: reportedProxyPort?.let { port ->
+            CompanionProbe(reportedPhoneId, reportedFriendlyName, port)
+        } ?: return
         val attempt = expectedAttempt ?: bootstrapAttempt.get()
         if (expectedAttempt != null && bootstrapAttempt.get() !== expectedAttempt) return
+        if (attempt != null &&
+            !phoneClaimStillOwned(attempt.phoneBtAddress, attempt.claimGeneration)
+        ) {
+            OalLog.i(TAG, "Ignoring late companion for superseded claim ${attempt.phoneBtAddress}")
+            return
+        }
+        if (attempt != null && !probeMatchesBluetoothOwner(
+                attempt.phoneBtAddress,
+                attempt.phoneBtName,
+                host,
+                probe,
+                attempt.expectedPhoneId,
+            )) {
+            OalLog.i(TAG, "Ignoring late companion at $host — identity belongs to another phone")
+            return
+        }
+        val proxyPort = probe.proxyPort
         when (WppBootstrapPolicy.onCompanionReachable(
             bootstrapLoopbackPending = attempt != null,
             usesReservedProxyPort = proxyPort == OalProtocol.WPP_PROXY_PORT,
@@ -420,16 +479,29 @@ object AaWirelessBtControl {
             sessionStreaming = sessionIsStreaming?.invoke() == true,
         )) {
             LateCompanionAction.DIAL_COMPANION -> {
-                // Atomic consumption makes concurrent TCP-scan and cached-address
-                // results one event. Only the Bluetooth phone that opened this
-                // attempt owns the right to complete it.
-                if (attempt == null || !bootstrapAttempt.compareAndSet(attempt, null)) return
-                lastKnownPhoneIp = host
-                lastAddressByPhone[attempt.phoneBtAddress] = host
-                activePhoneCompanionIp = host
-                OalLog.i(TAG, "Companion became reachable at $host after AP association — " +
-                        "dialling it into reserved loopback port $proxyPort; no second WPP exchange")
-                onCompanionSelected?.invoke(host)
+                // Consume and dial under the same claim lock. A newer Bluetooth
+                // claimant cannot overtake this completion between the generation
+                // check and the connector replacement.
+                if (attempt == null) return
+                val dialled = synchronized(phoneClaimLock) {
+                    if (!activePhoneBt.equals(attempt.phoneBtAddress, ignoreCase = true) ||
+                        phoneClaimGeneration != attempt.claimGeneration ||
+                        !bootstrapAttempt.compareAndSet(attempt, null)
+                    ) {
+                        false
+                    } else {
+                        lastKnownPhoneIp = host
+                        lastAddressByPhone[attempt.phoneBtAddress] = host
+                        activePhoneCompanionIp = host
+                        OalLog.i(TAG, "Companion became reachable at $host after AP association — " +
+                                "dialling it into reserved loopback port $proxyPort; no second WPP exchange")
+                        onCompanionSelected?.invoke(host)
+                        true
+                    }
+                }
+                if (!dialled) {
+                    OalLog.i(TAG, "Ignoring late dial from superseded phone claim ${attempt.phoneBtAddress}")
+                }
             }
             LateCompanionAction.QUEUE_READVERTISE -> {
                 OalLog.i(TAG, "Older companion at $host uses dynamic proxy port $proxyPort; " +
@@ -456,13 +528,18 @@ object AaWirelessBtControl {
                 flushPendingReadvertise()
             }
             LateCompanionAction.IGNORE -> {
-                if (sessionIsStreaming?.invoke() == true) bootstrapAttempt.set(null)
+                if (sessionIsStreaming?.invoke() == true && attempt != null) {
+                    bootstrapAttempt.compareAndSet(attempt, null)
+                }
             }
         }
     }
 
     private data class BootstrapAttempt(
         val phoneBtAddress: String,
+        val phoneBtName: String?,
+        val expectedPhoneId: String?,
+        val claimGeneration: Long,
         val generation: Long,
     )
 
@@ -534,6 +611,14 @@ object AaWirelessBtControl {
 
     /** The address each phone's companion last answered on, keyed by BT MAC. */
     private val lastAddressByPhone = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** Stable companion phone_id learned after a Bluetooth-name identity match. */
+    private val phoneIdByBtAddress = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    private data class ResolvedCompanion(
+        val host: String,
+        val probe: CompanionProbe,
+    )
 
     /**
      * The phone currently holding the projection session, by BT address.
@@ -615,9 +700,62 @@ object AaWirelessBtControl {
     @Volatile
     var activePhoneBt: String? = null
 
+    private val phoneClaimLock = Any()
+    private var phoneClaimGeneration = 0L
+
     /** When [activePhoneBt] took the session, for ageing out a stale claim. */
     @Volatile
     private var activePhoneClaimedAt: Long = 0L
+
+    private fun claimPhoneForHandshake(
+        phoneBtAddress: String,
+        holderIsStreaming: Boolean,
+    ): Long? = synchronized(phoneClaimLock) {
+        val claimed = activePhoneBt
+        val claimAgeMs = System.currentTimeMillis() - activePhoneClaimedAt
+        if (claimed != null &&
+            !claimed.equals(phoneBtAddress, ignoreCase = true) &&
+            claimAgeMs < CLAIM_TIMEOUT_MS &&
+            holderIsStreaming
+        ) {
+            OalLog.i(TAG, "Not switching to $phoneBtAddress — $claimed is " +
+                    "streaming (claimed ${claimAgeMs / 1000}s ago). Switch phones " +
+                    "in the car's Bluetooth settings; disconnecting $claimed " +
+                    "releases the session immediately.")
+            return null
+        }
+        if (claimed != null && !claimed.equals(phoneBtAddress, ignoreCase = true)) {
+            OalLog.i(TAG, "Handing the session from $claimed to $phoneBtAddress, " +
+                    "which is dialling now (previous claim ${claimAgeMs / 1000}s old, " +
+                    "streaming=$holderIsStreaming)")
+        }
+        activePhoneBt = phoneBtAddress
+        activePhoneClaimedAt = System.currentTimeMillis()
+        phoneClaimGeneration++
+        phoneClaimGeneration
+    }
+
+    private fun phoneClaimStillOwned(phoneBtAddress: String, generation: Long): Boolean =
+        synchronized(phoneClaimLock) {
+            activePhoneBt.equals(phoneBtAddress, ignoreCase = true) &&
+                phoneClaimGeneration == generation
+        }
+
+    /**
+     * Returns only the companion address proven to belong to the Bluetooth phone
+     * currently holding the WPP claim.
+     *
+     * Discovery's global address history is intentionally excluded: it can contain
+     * every nearby phone and was the source of cross-phone speculative dials.
+     */
+    fun withIdentityValidatedCompanion(action: (String) -> Unit): String? =
+        synchronized(phoneClaimLock) {
+            val btAddress = activePhoneBt ?: return null
+            if (phoneIdByBtAddress[btAddress].isNullOrBlank()) return null
+            val address = lastAddressByPhone[btAddress] ?: return null
+            action(address)
+            address
+        }
 
     /**
      * Reset attempt ownership on ignition off while retaining address hints.
@@ -727,11 +865,14 @@ object AaWirelessBtControl {
         }
     }
 
-    fun releaseActivePhone() {
+    fun releaseActivePhone() = synchronized(phoneClaimLock) {
         activePhoneBt?.let { OalLog.i(TAG, "Released the session claim held by $it") }
         activePhoneBt = null
         activePhoneClaimedAt = 0L
         activePhoneCompanionIp = null
+        bootstrapAttempt.set(null)
+        pendingLegacyReadvertise.set(null)
+        phoneClaimGeneration++
     }
 
     /**
@@ -1007,8 +1148,10 @@ object AaWirelessBtControl {
      */
     private fun findCompanionOnAnySubnet(
         manualIp: String?,
+        phoneBtAddress: String,
+        phoneBtName: String?,
         overallTimeoutMs: Int = 20_000,
-    ): Pair<String, Int>? {
+    ): ResolvedCompanion? {
         val localIps = buildList {
             manualIp?.takeIf { it.isNotBlank() }?.let { add(it) }
             addAll(allLocalIpv4())
@@ -1021,7 +1164,13 @@ object AaWirelessBtControl {
             if (prefix.isEmpty()) continue
             val remainingMs = (deadline - System.currentTimeMillis()).coerceAtLeast(1L).toInt()
             OalLog.i(TAG, "Scanning $prefix.0/24 for the companion")
-            scanSubnet(prefix, ip, remainingMs)?.let { return it }
+            scanSubnet(
+                prefix = prefix,
+                ourIp = ip,
+                phoneBtAddress = phoneBtAddress,
+                phoneBtName = phoneBtName,
+                overallTimeoutMs = remainingMs,
+            )?.let { return it }
             if (System.currentTimeMillis() >= deadline) break
         }
         OalLog.w(TAG, "No companion on any local subnet (${localIps.joinToString()})")
@@ -1061,8 +1210,10 @@ object AaWirelessBtControl {
     private fun scanSubnet(
         prefix: String,
         ourIp: String,
+        phoneBtAddress: String,
+        phoneBtName: String?,
         overallTimeoutMs: Int = 20_000,
-    ): Pair<String, Int>? {
+    ): ResolvedCompanion? {
         val pool = java.util.concurrent.Executors.newFixedThreadPool(128)
         return try {
             val tasks = (1..254)
@@ -1070,7 +1221,11 @@ object AaWirelessBtControl {
                 .filter { it != ourIp }
                 .map { ip ->
                     java.util.concurrent.Callable {
-                        askCompanion(ip, connectTimeoutMs = 1200)?.let { ip to it }
+                        val probe = askCompanion(ip, connectTimeoutMs = 1200)
+                        if (probe != null && probeMatchesBluetoothOwner(
+                                phoneBtAddress, phoneBtName, ip, probe)) {
+                            ResolvedCompanion(ip, probe)
+                        } else null
                     }
                 }
             // Budget must cover the whole /24 at the chosen timeout, or the scan
@@ -1092,7 +1247,8 @@ object AaWirelessBtControl {
                 .asSequence()
                 .mapNotNull { runCatching { it.get() }.getOrNull() }
                 .firstOrNull()
-                ?.also { OalLog.i(TAG, "Companion found at ${it.first} with proxy port ${it.second}") }
+                ?.also { OalLog.i(TAG, "Identity-matched companion found at ${it.host} " +
+                        "id=${it.probe.phoneId} with proxy port ${it.probe.proxyPort}") }
         } catch (e: Exception) {
             OalLog.w(TAG, "Scan of $prefix.0/24 failed: ${e.message}")
             null
@@ -1102,33 +1258,50 @@ object AaWirelessBtControl {
     }
 
     /**
-     * Asks the companion at [phoneIp] for its Android Auto proxy port.
+     * Asks the companion at [phoneIp] for its complete identity and live proxy.
      *
-     * Returns null if nothing answers, the reply is not ours, or it reports no
-     * proxy (wpp=0). A zero must not be treated as a port: advertising a dead
-     * port sends Android Auto to a closed socket and fails silently on both ends.
-     *
-     * The default timeout is generous because the telematics bridge is slow — a
-     * probe that would succeed at 1200ms returned nothing at 250ms.
+     * Identity is mandatory: accepting only `wpp=<port>` allowed whichever phone
+     * answered first to impersonate the Bluetooth owner of the current attempt.
      */
-    private fun askCompanion(phoneIp: String, connectTimeoutMs: Int = 1200): Int? = runCatching {
+    private fun askCompanion(
+        phoneIp: String,
+        connectTimeoutMs: Int = 1200,
+    ): CompanionProbe? = runCatching {
         java.net.Socket().use { sock ->
             sock.connect(java.net.InetSocketAddress(phoneIp, IDENTITY_PORT), connectTimeoutMs)
             sock.soTimeout = connectTimeoutMs
             sock.getOutputStream().apply { write("OAL?\n".toByteArray()); flush() }
             val reply = sock.getInputStream().bufferedReader().readLine().orEmpty()
-            if (!reply.startsWith("OAL!")) return@runCatching null
-            reply.removePrefix("OAL!").split('\t')
-                .firstOrNull { it.startsWith("wpp=") }
-                ?.removePrefix("wpp=")?.trim()?.toIntOrNull()
-                ?.takeIf { it in 1..65535 }
+            CompanionIdentityPolicy.parseProbe(reply)
         }
     }.getOrNull()
 
-    private fun companionProxyPort(phoneIp: String): Int? =
-        askCompanion(phoneIp)?.also {
-            OalLog.i(TAG, "Companion at $phoneIp reports AA proxy on port $it")
+    private fun probeMatchesBluetoothOwner(
+        phoneBtAddress: String,
+        phoneBtName: String?,
+        phoneIp: String,
+        probe: CompanionProbe,
+        expectedPhoneIdOverride: String? = null,
+    ): Boolean {
+        val expectedPhoneId = expectedPhoneIdOverride ?: phoneIdByBtAddress[phoneBtAddress]
+        val matches = CompanionIdentityPolicy.matches(
+            expectedPhoneId = expectedPhoneId,
+            bluetoothDeviceName = phoneBtName,
+            probe = probe,
+        )
+        if (!matches) {
+            OalLog.i(
+                TAG,
+                "Rejected companion at $phoneIp id=${probe.phoneId ?: "unknown"} " +
+                    "name=${probe.friendlyName ?: "unknown"} — Bluetooth owner is " +
+                    "$phoneBtAddress name=${phoneBtName ?: "unknown"} " +
+                    "expectedId=${expectedPhoneId ?: "unlearned"}",
+            )
+            return false
         }
+        probe.phoneId?.let { phoneIdByBtAddress[phoneBtAddress] = it }
+        return true
+    }
 
     /**
      * Frequencies (MHz) advertised as supported by the head unit's access point.
@@ -1263,7 +1436,7 @@ object AaWirelessBtControl {
         // the car's access point is never asked to accept an inbound connection —
         // which it refuses. Falling back to the car's own address preserves the
         // shared-network case (proven working on a tablet) and costs nothing.
-        bt.setEndpointResolver { phoneBtAddress ->
+        bt.setEndpointResolver { phoneBtAddress, phoneBtName ->
             // Only serve the phone the head unit is actually paired-and-connected
             // to for projection. Two phones can dial the SDP record concurrently,
             // and the endpoint is per-phone: 127.0.0.1:<port> only means anything
@@ -1280,36 +1453,11 @@ object AaWirelessBtControl {
             //
             // A phone that dials the SDP record IS present and IS trying to
             // connect, so an old claim should lose to a live handshake.
-            val claimed = activePhoneBt
-            val claimAgeMs = System.currentTimeMillis() - activePhoneClaimedAt
-            // A claim only outranks a live handshake while projection is actually
-            // running. Otherwise the phone dialling now has the better evidence of
-            // being present: the claim describes a session that may have ended,
-            // while the handshake is happening in front of us.
-            //
-            // This matters for the only way a phone can be switched — the car's
-            // own Bluetooth settings, since the APIs to do it ourselves are
-            // privileged. Refusing the new phone for up to two minutes made a
-            // deliberate user action look broken.
             val holderIsStreaming = sessionIsStreaming?.invoke() == true
-            if (claimed != null &&
-                !claimed.equals(phoneBtAddress, ignoreCase = true) &&
-                claimAgeMs < CLAIM_TIMEOUT_MS &&
-                holderIsStreaming
-            ) {
-                OalLog.i(TAG, "Not switching to $phoneBtAddress — $claimed is " +
-                        "streaming (claimed ${claimAgeMs / 1000}s ago). Switch phones " +
-                        "in the car's Bluetooth settings; disconnecting $claimed " +
-                        "releases the session immediately.")
-                return@setEndpointResolver null
-            }
-            if (claimed != null && !claimed.equals(phoneBtAddress, ignoreCase = true)) {
-                OalLog.i(TAG, "Handing the session from $claimed to $phoneBtAddress, " +
-                        "which is dialling now (previous claim ${claimAgeMs / 1000}s old, " +
-                        "streaming=$holderIsStreaming)")
-            }
-            activePhoneBt = phoneBtAddress
-            activePhoneClaimedAt = System.currentTimeMillis()
+            val claimGeneration = claimPhoneForHandshake(
+                phoneBtAddress = phoneBtAddress,
+                holderIsStreaming = holderIsStreaming,
+            ) ?: return@setEndpointResolver null
 
             // Resolve the companion's address, preferring one discovery already
             // found. The sweep is the fallback, not the primary: it runs on the
@@ -1405,10 +1553,16 @@ object AaWirelessBtControl {
             // One or two probes is a cheap bet on the address being unchanged.
             // More than that is a tax on everyone whose address did change.
             for (ip in candidates.take(MAX_PRESCAN_PROBES)) {
-                val p = askCompanion(ip, connectTimeoutMs = 2500)
-                if (p != null) {
-                    OalLog.i(TAG, "Companion at $ip reports AA proxy on port $p")
-                    proxyPort = p
+                val probe = askCompanion(ip, connectTimeoutMs = 2500)
+                if (probe != null && probeMatchesBluetoothOwner(
+                        phoneBtAddress, phoneBtName, ip, probe)) {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Ignoring identity result from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
+                    OalLog.i(TAG, "Identity-matched companion at $ip " +
+                            "id=${probe.phoneId} reports AA proxy on port ${probe.proxyPort}")
+                    proxyPort = probe.proxyPort
                     companionIp = ip
                     lastKnownPhoneIp = ip
                     lastAddressByPhone[phoneBtAddress] = ip
@@ -1425,17 +1579,30 @@ object AaWirelessBtControl {
                 }
                 // The scan returns the port too — asking again would cost another
                 // slow round trip over the telematics bridge.
-                findCompanionOnAnySubnet(manualIp)?.let { (ip, port) ->
+                findCompanionOnAnySubnet(
+                    manualIp = manualIp,
+                    phoneBtAddress = phoneBtAddress,
+                    phoneBtName = phoneBtName,
+                )?.let { resolved ->
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Ignoring scan result from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
+                    val ip = resolved.host
+                    val probe = resolved.probe
                     lastKnownPhoneIp = ip
-                    // Record it against this phone too, or the next handshake
-                    // from it starts from the shared list again.
+                    // Cache only after identity has matched the Bluetooth owner.
                     lastAddressByPhone[phoneBtAddress] = ip
-                    proxyPort = port
+                    proxyPort = probe.proxyPort
                     companionIp = ip
                 }
             }
             when {
                 proxyPort != null -> {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Not dialing endpoint from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     // Open the car->companion socket BEFORE the handshake tells
                     // Android Auto where to connect. AA reaches the proxy within
                     // ~2s of the Bluetooth handshake; the car used to still be
@@ -1448,30 +1615,64 @@ object AaWirelessBtControl {
                     // listened forever while the phone waited for a car socket.
                     // Remember which companion belongs to the Bluetooth-connected
                     // phone so the UI can mark it in the discovery list.
-                    activePhoneCompanionIp = companionIp
-                    bootstrapAttempt.set(null)
-                    OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy " +
-                            "127.0.0.1:$proxyPort via companion at $companionIp " +
-                            "phone=$phoneBtAddress — this is the working path")
                     val dialTarget = companionIp
-                    if (dialTarget.isNullOrBlank()) {
-                        OalLog.e(TAG, "Have proxy port $proxyPort but no companion address — " +
-                                "cannot dial; the session will not connect")
-                    } else {
-                        onCompanionSelected?.invoke(dialTarget)
+                    val accepted = synchronized(phoneClaimLock) {
+                        if (!activePhoneBt.equals(phoneBtAddress, ignoreCase = true) ||
+                            phoneClaimGeneration != claimGeneration
+                        ) {
+                            false
+                        } else {
+                            activePhoneCompanionIp = dialTarget
+                            bootstrapAttempt.set(null)
+                            OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy " +
+                                    "127.0.0.1:$proxyPort via companion at $dialTarget " +
+                                    "phone=$phoneBtAddress — this is the working path")
+                            if (dialTarget.isNullOrBlank()) {
+                                OalLog.e(TAG, "Have proxy port $proxyPort but no companion address — " +
+                                        "cannot dial; the session will not connect")
+                            } else {
+                                onCompanionSelected?.invoke(dialTarget)
+                            }
+                            true
+                        }
+                    }
+                    if (!accepted) {
+                        OalLog.i(TAG, "Not dialing endpoint from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
                     }
                     AaWirelessBtServer.Endpoint.PhoneLoopback(proxyPort)
                 }
                 else -> {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Not starting bootstrap for superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     // The phone is not on the car AP yet, so the companion cannot
                     // answer. Use the port both new apps reserve in advance. WPP
                     // moves the phone onto the AP, Android Auto can attach to its
                     // local proxy immediately, and discovery then supplies the
                     // car-side socket to that same waiting bridge.
-                    val attempt = BootstrapAttempt(phoneBtAddress,
-                        bootstrapAttemptSequence.incrementAndGet(),
+                    val attempt = BootstrapAttempt(
+                        phoneBtAddress = phoneBtAddress,
+                        phoneBtName = phoneBtName,
+                        expectedPhoneId = phoneIdByBtAddress[phoneBtAddress],
+                        claimGeneration = claimGeneration,
+                        generation = bootstrapAttemptSequence.incrementAndGet(),
                     )
-                    bootstrapAttempt.set(attempt)
+                    val published = synchronized(phoneClaimLock) {
+                        if (!activePhoneBt.equals(phoneBtAddress, ignoreCase = true) ||
+                            phoneClaimGeneration != claimGeneration
+                        ) {
+                            false
+                        } else {
+                            bootstrapAttempt.set(attempt)
+                            true
+                        }
+                    }
+                    if (!published) {
+                        OalLog.i(TAG, "Not publishing bootstrap for superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     OalLog.i(TAG, "CONNECT SUMMARY: endpoint=bootstrap-loopback " +
                             "127.0.0.1:${OalProtocol.WPP_PROXY_PORT} phone=$phoneBtAddress " +
                             "knownAddrs=${allKnown.joinToString().ifEmpty { "none" }} " +

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -339,8 +339,11 @@ class AaWirelessBtServer(
 
             if (client != null) {
                 outcomeObserver.phoneDialbackAt(SystemClock.elapsedRealtime())
-                val remote = runCatching { client.remoteDevice?.address ?: "?" }.getOrDefault("?")
-                OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote")
+                val remoteDevice = runCatching { client.remoteDevice }.getOrNull()
+                val remote = runCatching { remoteDevice?.address ?: "?" }.getOrDefault("?")
+                val remoteName = runCatching { remoteDevice?.name }.getOrNull()
+                OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote" +
+                        (remoteName?.let { " name=$it" } ?: " name=unknown"))
                 // Flag it here rather than inside handleHandshake: the window that
                 // matters starts the instant the phone dials, and the coroutine
                 // may not be scheduled for several milliseconds.
@@ -351,7 +354,7 @@ class AaWirelessBtServer(
                     continue
                 }
                 val handshakeJob = scope.launch(CoroutineName("AaWirelessBt-Handshake")) {
-                    handleHandshake(client, remote, handshakeLease)
+                    handleHandshake(client, remote, remoteName, handshakeLease)
                 }
                 handshakeJob.invokeOnCompletion {
                     // This also runs when the coroutine is cancelled before its
@@ -458,8 +461,11 @@ class AaWirelessBtServer(
          *   The port is meaningful only on the phone that owns it — 127.0.0.1
          *   resolves on whichever device connects — so a mixed-up port sends a
          *   phone's Android Auto to a closed socket on its own loopback.
+         * @param phoneBtName the remote Bluetooth device name from the same socket.
+         *   Companion identity must agree with this owner (or a previously learned
+         *   phone_id binding) before an endpoint is accepted.
          */
-        fun currentEndpoint(phoneBtAddress: String): Endpoint?
+        fun currentEndpoint(phoneBtAddress: String, phoneBtName: String?): Endpoint?
     }
 
     @Volatile
@@ -480,6 +486,7 @@ class AaWirelessBtServer(
     private suspend fun handleHandshake(
         socket: BluetoothSocket,
         phoneBtAddress: String,
+        phoneBtName: String?,
         handshakeLease: AaWirelessBtControl.HandshakeLease,
     ) {
         val stored = credentials
@@ -496,7 +503,7 @@ class AaWirelessBtServer(
         // Prefer the companion's loopback proxy when one is available: it is the
         // only endpoint the car's access point cannot block, because the phone
         // connects to itself.
-        val endpoint = endpointResolver?.currentEndpoint(phoneBtAddress)
+        val endpoint = endpointResolver?.currentEndpoint(phoneBtAddress, phoneBtName)
         val creds = when (endpoint) {
             is Endpoint.PhoneLoopback -> {
                 OalLog.i(TAG, "Advertising the companion's loopback proxy " +

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
@@ -1,0 +1,51 @@
+package com.openautolink.app.transport.bluetooth
+
+import java.util.Locale
+
+/** Identity returned by the companion's dedicated OAL probe endpoint. */
+internal data class CompanionProbe(
+    val phoneId: String?,
+    val friendlyName: String?,
+    val proxyPort: Int,
+)
+
+/** Pure parsing and ownership policy for Bluetooth-phone → companion matching. */
+internal object CompanionIdentityPolicy {
+    private const val PREFIX = "OAL!"
+
+    fun parseProbe(reply: String): CompanionProbe? {
+        if (!reply.startsWith(PREFIX)) return null
+        val parts = reply.removePrefix(PREFIX).split('\t')
+        val port = parts.firstOrNull { it.startsWith("wpp=") }
+            ?.removePrefix("wpp=")
+            ?.trim()
+            ?.toIntOrNull()
+            ?.takeIf { it in 1..65535 }
+            ?: return null
+        return CompanionProbe(
+            phoneId = parts.getOrNull(0)?.trim()?.takeIf { it.isNotEmpty() },
+            friendlyName = parts.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() },
+            proxyPort = port,
+        )
+    }
+
+    fun matches(
+        expectedPhoneId: String?,
+        bluetoothDeviceName: String?,
+        probe: CompanionProbe,
+    ): Boolean {
+        val expectedId = expectedPhoneId?.trim()?.takeIf { it.isNotEmpty() }
+        if (expectedId != null) {
+            return expectedId == probe.phoneId
+        }
+        val btName = normalizeName(bluetoothDeviceName) ?: return false
+        val companionName = normalizeName(probe.friendlyName) ?: return false
+        return btName == companionName
+    }
+
+    private fun normalizeName(value: String?): String? = value
+        ?.trim()
+        ?.replace(Regex("\\s+"), " ")
+        ?.lowercase(Locale.ROOT)
+        ?.takeIf { it.isNotEmpty() }
+}

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -590,6 +590,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             val aaDecAddDepth = preferences.aaDecoderAdditionalDepth.first()
             val aaAutoM = preferences.aaAutoMargins.first()
             val videoFps = preferences.videoFps.first()
+            val experimentalGal6 = preferences.experimentalGal6.first()
             val driveSide = preferences.driveSide.first()
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
@@ -799,6 +800,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
+                experimentalGal6 = experimentalGal6,
             )
     }
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -1188,6 +1188,51 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Spacer(modifier = Modifier.height(4.dp))
 
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .clickable { viewModel.updateExperimentalGal6(!uiState.experimentalGal6) }
+                .padding(vertical = 10.dp)
+                .testTag("experimentalGal6Toggle"),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Switch(
+                checked = uiState.experimentalGal6,
+                onCheckedChange = viewModel::updateExperimentalGal6,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column {
+                Text(
+                    text = "Experimental GAL 6.0",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = if (uiState.experimentalGal6) {
+                        "Enabled — Save & Reconnect to request the modern media protocol"
+                    } else {
+                        "Off (recommended until tested in your vehicle)"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Text(
+            text = "Requests Gearhead GAL/PDK 6.0. This enables modern media envelopes, " +
+                    "ackless audio, and the short HEVC keyframe policy that may remove " +
+                    "H.265 startup green. It is compatibility-tested only at build level " +
+                    "and may affect audio, navigation, or video until road-tested.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(bottom = 20.dp),
+        )
+
+        HorizontalDivider(modifier = Modifier.fillMaxWidth(0.7f))
+
+        Spacer(modifier = Modifier.height(20.dp))
+
         Text(
             text = "When enabled, the phone picks the best codec and resolution it supports. " +
                     "Disable to manually choose a specific codec and resolution.",
@@ -1230,8 +1275,9 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
         Text(
             text = "Video codec the phone uses to encode the AA stream. " +
                     "H.264 is the safe default — instant clean startup, capped at 1080p. " +
-                    "H.265 supports up to 4K but may show a brief green/distorted picture " +
-                    "for the first 30–60 seconds while the phone's encoder warms up.",
+                    "H.265 supports up to 4K but legacy GAL can take roughly two minutes " +
+                    "to deliver a full content IDR at 60 FPS. The experimental GAL 6.0 " +
+                    "toggle requests Gearhead's short HEVC keyframe policy.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 12.dp)

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -30,6 +30,7 @@ data class SettingsUiState(
     val videoAutoNegotiate: Boolean = AppPreferences.DEFAULT_VIDEO_AUTO_NEGOTIATE,
     val videoCodec: String = AppPreferences.DEFAULT_VIDEO_CODEC,
     val videoFps: Int = AppPreferences.DEFAULT_VIDEO_FPS,
+    val experimentalGal6: Boolean = AppPreferences.DEFAULT_EXPERIMENTAL_GAL6,
     val displayMode: String = AppPreferences.DEFAULT_DISPLAY_MODE,
     val micSource: String = AppPreferences.DEFAULT_MIC_SOURCE,
     val btMacOverride: String = AppPreferences.DEFAULT_BT_MAC_OVERRIDE,
@@ -204,6 +205,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         SettingsUiState()
     )
 
+    val experimentalGal6: StateFlow<Boolean> = preferences.experimentalGal6.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        AppPreferences.DEFAULT_EXPERIMENTAL_GAL6,
+    )
+
     private val _hotspotSsidOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_SSID)
     private val _hotspotPasswordOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_PASSWORD)
     private val _wppBssidOverride = MutableStateFlow("")
@@ -247,6 +254,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _wppLocalIpOverride,
         _wppApInterfaceOverride,
         _wppChannelMhzOverride,
+        experimentalGal6,
     ) { arr ->
         val state = arr[0] as SettingsUiState
         state.copy(
@@ -255,6 +263,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             wppLocalIp = arr[5] as String,
             wppApInterface = arr[6] as String,
             wppChannelMhz = arr[7] as String,
+            experimentalGal6 = arr[8] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -384,6 +393,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateVideoFps(fps: Int) {
         viewModelScope.launch { preferences.setVideoFps(fps) }
+    }
+
+    fun updateExperimentalGal6(enabled: Boolean) {
+        viewModelScope.launch { preferences.setExperimentalGal6(enabled) }
     }
 
     fun updateDisplayMode(mode: String) {
@@ -616,6 +629,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val aaDecAddDepth = preferences.aaDecoderAdditionalDepth.first()
             val aaAutoM = preferences.aaAutoMargins.first()
             val videoFps = preferences.videoFps.first()
+            val experimentalGal6 = preferences.experimentalGal6.first()
             val driveSide = preferences.driveSide.first()
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
@@ -662,6 +676,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
+                experimentalGal6 = experimentalGal6,
             )
         }
     }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
@@ -1,0 +1,75 @@
+package com.openautolink.app.transport.aasdk
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Gal6ModernMessageContractTest {
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun `aasdk explicitly accepts GAL6 media options on video and audio`() {
+        val ids = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/sink/MediaMessageId.proto")
+        val videoApi = projectFile("external/opencardev-aasdk/include/aasdk/Channel/MediaSink/Video/IVideoMediaSinkServiceEventHandler.hpp")
+        val audioApi = projectFile("external/opencardev-aasdk/include/aasdk/Channel/MediaSink/Audio/IAudioMediaSinkServiceEventHandler.hpp")
+        val video = projectFile("external/opencardev-aasdk/src/Channel/MediaSink/Video/VideoMediaSinkService.cpp")
+        val audio = projectFile("external/opencardev-aasdk/src/Channel/MediaSink/Audio/AudioMediaSinkService.cpp")
+        val appHeader = projectFile("app/src/main/cpp/jni_session.h")
+        val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
+        val app = projectFile("app/src/main/cpp/jni_session.cpp")
+        val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
+
+        assertTrue(ids.contains("MEDIA_MESSAGE_MEDIA_OPTIONS = 32788"))
+        assertTrue(videoApi.contains("onMediaOptions"))
+        assertTrue(audioApi.contains("onMediaOptions"))
+        assertTrue(video.contains("MEDIA_MESSAGE_MEDIA_OPTIONS"))
+        assertTrue(audio.contains("MEDIA_MESSAGE_MEDIA_OPTIONS"))
+        assertTrue(appHeader.contains("onMediaOptions"))
+        assertTrue(handlerHeader.contains("onMediaOptions"))
+        assertTrue(app.contains("GAL6 MediaOptions"))
+        assertTrue(handlers.contains("GAL6 MediaOptions"))
+    }
+
+    @Test
+    fun `GAL6 preserves HU-provided status UI ownership in modern UiConfig`() {
+        val uiConfig = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/UiConfig.proto")
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+
+        assertTrue(uiConfig.contains("repeated int32 hidden_ui_elements = 5"))
+        assertTrue(native.contains("add_hidden_ui_elements(1)"))
+        assertTrue(native.contains("add_hidden_ui_elements(2)"))
+        assertTrue(native.contains("add_hidden_ui_elements(3)"))
+    }
+
+    @Test
+    fun `GAL6 enriched start envelope fields are parsed and reported`() {
+        val startProto = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/Start.proto")
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+
+        assertTrue(startProto.contains("optional int32 session_type = 3"))
+        assertTrue(startProto.contains("optional bytes media_config = 4"))
+        assertTrue(native.contains("session_type="))
+        assertTrue(native.contains("media_config_bytes="))
+    }
+
+    @Test
+    fun `aasdk explicitly accepts GAL5_1 vehicle energy forecast`() {
+        val ids = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/navigationstatus/NavigationStatusMessageId.proto")
+        val api = projectFile("external/opencardev-aasdk/include/aasdk/Channel/NavigationStatus/INavigationStatusServiceEventHandler.hpp")
+        val service = projectFile("external/opencardev-aasdk/src/Channel/NavigationStatus/NavigationStatusService.cpp")
+        val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
+        val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
+
+        assertTrue(ids.contains("INSTRUMENT_CLUSTER_VEHICLE_ENERGY_FORECAST = 32776"))
+        assertTrue(api.contains("onVehicleEnergyForecast"))
+        assertTrue(service.contains("INSTRUMENT_CLUSTER_VEHICLE_ENERGY_FORECAST"))
+        assertTrue(handlerHeader.contains("onVehicleEnergyForecast"))
+        assertTrue(handlers.contains("GAL6 VehicleEnergyForecast"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
@@ -37,6 +37,22 @@ class Gal6ModernMessageContractTest {
     }
 
     @Test
+    fun `opaque GAL6 payloads are fully reconstructable below the diagnostic line cap`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val header = projectFile("app/src/main/cpp/jni_session.h")
+
+        assertTrue(native.contains("GAL6_PAYLOAD_CHUNK_BYTES = 128"))
+        assertTrue(header.contains("gal6EnvelopeSequence_"))
+        assertTrue(native.contains("chunk="))
+        assertTrue(native.contains("total_chunks="))
+        assertTrue(native.contains("offset="))
+        assertTrue(native.contains("indication.SerializeToString(&raw)"))
+        assertTrue(native.contains("reportGal6Payload(channel, \"Start\""))
+        assertTrue(native.contains("reportGal6Payload(channel, envelope, buffer.cdata, buffer.size)"))
+        assertTrue(native.contains("line.size() <= 500"))
+    }
+
+    @Test
     fun `GAL6 preserves HU-provided status UI ownership in modern UiConfig`() {
         val uiConfig = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/UiConfig.proto")
         val native = projectFile("app/src/main/cpp/jni_session.cpp")

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
@@ -1,0 +1,35 @@
+package com.openautolink.app.transport.aasdk
+
+import com.openautolink.app.data.AppPreferences
+import com.openautolink.app.ui.settings.SettingsUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Gal6PreferenceContractTest {
+
+    @Test
+    fun `SDR config materializes tested GAL policy for JNI`() {
+        val legacy = AasdkSdrConfig(experimentalGal6 = false)
+        assertEquals(1, legacy.requestedGalMajor)
+        assertEquals(7, legacy.requestedGalMinor)
+        assertEquals(30, legacy.mediaSetupMaxUnacked)
+        assertTrue(legacy.sendAudioAcks)
+        assertEquals(60, legacy.hevcKeyframeIntervalSeconds)
+
+        val modern = AasdkSdrConfig(experimentalGal6 = true)
+        assertEquals(6, modern.requestedGalMajor)
+        assertEquals(0, modern.requestedGalMinor)
+        assertEquals(30, modern.mediaSetupMaxUnacked)
+        assertFalse(modern.sendAudioAcks)
+        assertEquals(2, modern.hevcKeyframeIntervalSeconds)
+    }
+
+    @Test
+    fun `experimental GAL 6 mode is off by default through every user-facing layer`() {
+        assertFalse(AppPreferences.DEFAULT_EXPERIMENTAL_GAL6)
+        assertFalse(SettingsUiState().experimentalGal6)
+        assertFalse(AasdkSdrConfig().experimentalGal6)
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
@@ -1,0 +1,82 @@
+package com.openautolink.app.transport.aasdk
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Gal6WiringContractTest {
+
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun `experimental toggle is writable visible and carried into every session path`() {
+        val preferences = projectFile("app/src/main/java/com/openautolink/app/data/AppPreferences.kt")
+        val settingsVm = projectFile("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
+        val settingsUi = projectFile("app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt")
+        val projectionVm = projectFile("app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt")
+        val sessionManager = projectFile("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+
+        assertTrue(preferences.contains("val experimentalGal6: Flow<Boolean>"))
+        assertTrue(preferences.contains("suspend fun setExperimentalGal6"))
+        assertTrue(settingsVm.contains("fun updateExperimentalGal6"))
+        assertTrue(settingsVm.contains("val experimentalGal6: StateFlow<Boolean>"))
+        assertTrue(settingsVm.contains("experimentalGal6 = arr[8] as Boolean"))
+        assertTrue(settingsUi.contains("testTag(\"experimentalGal6Toggle\")"))
+        assertTrue(settingsUi.contains("Experimental GAL 6.0"))
+        assertTrue(projectionVm.contains("preferences.experimentalGal6.first()"))
+        assertTrue(projectionVm.contains("experimentalGal6 = experimentalGal6"))
+        assertTrue(sessionManager.contains("experimentalGal6: Boolean = false"))
+        assertTrue(sessionManager.contains("experimentalGal6 = experimentalGal6"))
+    }
+
+    @Test
+    fun `native session applies GAL6 version media window ack and session policy`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val nativeHeader = projectFile("app/src/main/cpp/jni_session.h")
+        val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
+        val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
+
+        assertTrue(native.contains("experimentalGal6"))
+        assertTrue(native.contains("requestedGalMajor_"))
+        assertTrue(native.contains("requestedGalMinor_"))
+        assertTrue(native.contains("GAL policy: requested="))
+        assertTrue(native.contains("activeVideoSessionId_"))
+        assertTrue(native.contains("ack.set_session_id(activeVideoSessionId_.load())"))
+        assertTrue(native.contains("mediaSetupMaxUnacked()"))
+        assertTrue(native.contains("expectedHevcGopFrames"))
+        assertTrue(nativeHeader.contains("shouldSendAudioAcks"))
+        assertTrue(handlers.contains("activeSessionId_"))
+        assertTrue(handlers.contains("session_.shouldSendAudioAcks()"))
+        assertTrue(handlerHeader.contains("activeSessionId_"))
+    }
+
+    @Test
+    fun `rejected GAL version aborts before TLS handshake`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val response = native.substringAfter("void JniSession::onVersionResponse")
+            .substringBefore("void JniSession::onAuthComplete")
+
+        val rejection = response.indexOf("status != aap_protobuf::shared::STATUS_SUCCESS")
+        val abort = response.indexOf("GAL version negotiation rejected")
+        val handshake = response.indexOf("cryptor_->doHandshake()")
+        assertTrue(rejection >= 0)
+        assertTrue(abort > rejection)
+        assertTrue(handshake > abort)
+    }
+
+    @Test
+    fun `GAL6 enriched envelopes remain observable without rejecting unknown fields`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
+
+        assertTrue(native.contains("reportGal6StartEnvelope(\"video\", indication)"))
+        assertTrue(handlers.contains("session_.reportGal6StartEnvelope(channelName, indication)"))
+        assertTrue(native.contains("unknown_fields="))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
@@ -47,12 +47,14 @@ class Gal6WiringContractTest {
         assertTrue(native.contains("requestedGalMinor_"))
         assertTrue(native.contains("GAL policy: requested="))
         assertTrue(native.contains("activeVideoSessionId_"))
-        assertTrue(native.contains("ack.set_session_id(activeVideoSessionId_.load())"))
+        assertTrue(native.contains("ack.set_session_id(mediaAckSessionId(activeVideoSessionId_.load()))"))
         assertTrue(native.contains("mediaSetupMaxUnacked()"))
         assertTrue(native.contains("expectedHevcGopFrames"))
         assertTrue(nativeHeader.contains("shouldSendAudioAcks"))
+        assertTrue(nativeHeader.contains("return sdrConfig_.experimentalGal6 ? activeSessionId : 0"))
         assertTrue(handlers.contains("activeSessionId_"))
         assertTrue(handlers.contains("session_.shouldSendAudioAcks()"))
+        assertTrue(handlers.contains("session_.mediaAckSessionId(activeSessionId_.load())"))
         assertTrue(handlerHeader.contains("activeSessionId_"))
     }
 

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
@@ -1,0 +1,37 @@
+package com.openautolink.app.transport.aasdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GalProtocolPolicyTest {
+
+    @Test
+    fun `legacy mode requests GAL 1_7 and keeps media acknowledgements`() {
+        val config = GalProtocolPolicy.forExperimentalGal6(enabled = false)
+
+        assertEquals(GalProtocolVersion(1, 7), config.requestedVersion)
+        assertEquals(30, config.maxUnacked)
+        assertTrue(config.sendAudioAcks)
+        assertEquals(60, config.hevcKeyframeIntervalSeconds)
+    }
+
+    @Test
+    fun `experimental mode requests GAL 6_0 and makes audio ackless without changing setup window`() {
+        val config = GalProtocolPolicy.forExperimentalGal6(enabled = true)
+
+        assertEquals(GalProtocolVersion(6, 0), config.requestedVersion)
+        assertEquals(30, config.maxUnacked)
+        assertFalse(config.sendAudioAcks)
+        assertEquals(2, config.hevcKeyframeIntervalSeconds)
+    }
+
+    @Test
+    fun `expected HEVC GOP uses negotiated encoder policy and advertised fps`() {
+        assertEquals(3_600, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = false, advertisedFps = 60))
+        assertEquals(1_800, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = false, advertisedFps = 30))
+        assertEquals(120, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = true, advertisedFps = 60))
+        assertEquals(60, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = true, advertisedFps = 30))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
@@ -1,0 +1,125 @@
+package com.openautolink.app.transport.bluetooth
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionIdentityPolicyTest {
+
+    @Test
+    fun `probe parser preserves phone identity and proxy port`() {
+        val probe = CompanionIdentityPolicy.parseProbe(
+            "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=5280",
+        )
+
+        requireNotNull(probe)
+        assertEquals("19bbbce4-1234", probe.phoneId)
+        assertEquals("Liz OnePlus 13", probe.friendlyName)
+        assertEquals(5280, probe.proxyPort)
+    }
+
+    @Test
+    fun `probe parser rejects missing live proxy`() {
+        assertNull(
+            CompanionIdentityPolicy.parseProbe(
+                "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=0",
+            ),
+        )
+    }
+
+    @Test
+    fun `bluetooth device name selects only its matching companion`() {
+        val liz = CompanionProbe("liz-id", "Liz OnePlus 13", 5280)
+        val lance = CompanionProbe("lance-id", "Lance OnePlus 13", 5280)
+
+        assertTrue(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "Liz OnePlus 13",
+                probe = liz,
+            ),
+        )
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "Liz OnePlus 13",
+                probe = lance,
+            ),
+        )
+    }
+
+    @Test
+    fun `learned phone id outranks a renamed device`() {
+        val probe = CompanionProbe("liz-id", "New Device Name", 5280)
+
+        assertTrue(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = "liz-id",
+                bluetoothDeviceName = "Old Device Name",
+                probe = probe,
+            ),
+        )
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = "lance-id",
+                bluetoothDeviceName = "New Device Name",
+                probe = probe,
+            ),
+        )
+    }
+
+    @Test
+    fun `unidentified companion is never accepted as the bluetooth owner`() {
+        val probe = CompanionProbe("some-id", null, 5280)
+
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = null,
+                probe = probe,
+            ),
+        )
+    }
+
+    @Test
+    fun `bluetooth endpoint resolution carries and enforces remote device identity`() {
+        val server = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt",
+        ).readText()
+        val control = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        val session = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        assertTrue(server.contains("remoteDevice?.name"))
+        assertTrue(server.contains("currentEndpoint(phoneBtAddress, phoneBtName)"))
+        assertTrue(control.contains("CompanionIdentityPolicy.matches("))
+        assertTrue(control.contains("private val phoneClaimLock = Any()"))
+        assertTrue(control.contains("private var phoneClaimGeneration = 0L"))
+        assertTrue(control.contains("claimGeneration = claimPhoneForHandshake("))
+        assertTrue(control.contains("phoneClaimStillOwned(phoneBtAddress, claimGeneration)"))
+        assertTrue(control.contains("val claimGeneration: Long"))
+        assertTrue(session.contains("withIdentityValidatedCompanion"))
+        assertFalse(session.contains("identityValidatedCompanionIp()"))
+        assertFalse(session.contains("AaWirelessBtControl.lastKnownPhoneIp"))
+        assertFalse(session.contains(".lastKnownPhoneIp"))
+        assertTrue(session.windowed("\"wpp\" -> startWpp()".length)
+            .count { it == "\"wpp\" -> startWpp()" } >= 3)
+        val matchIndex = control.indexOf("CompanionIdentityPolicy.matches(")
+        val cacheIndex = control.indexOf("lastAddressByPhone[phoneBtAddress] = ip", matchIndex)
+        assertTrue(matchIndex >= 0)
+        assertTrue(cacheIndex > matchIndex)
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .first { it.isFile }
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
@@ -83,7 +83,9 @@ class WppBootstrapPolicyTest {
             "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
         ).readText()
 
-        assertTrue(source.contains("val attempt = BootstrapAttempt(phoneBtAddress"))
+        assertTrue(source.contains("val attempt = BootstrapAttempt("))
+        assertTrue(source.contains("phoneBtAddress = phoneBtAddress"))
+        assertTrue(source.contains("phoneBtName = phoneBtName"))
         assertTrue(
             source.contains(
                 "AaWirelessBtServer.Endpoint.PhoneLoopback(OalProtocol.WPP_PROXY_PORT)",
@@ -101,9 +103,11 @@ class WppBootstrapPolicyTest {
 
         assertTrue(scanner.contains("bootstrapAttempt.get() !== attempt"))
         assertTrue(scanner.contains("val remainingMs = (deadline - System.currentTimeMillis())"))
-        assertTrue(scanner.contains("findCompanionOnAnySubnet(manualIp, remainingMs)"))
+        assertTrue(scanner.contains("findCompanionOnAnySubnet("))
+        assertTrue(scanner.contains("phoneBtAddress = attempt.phoneBtAddress"))
+        assertTrue(scanner.contains("phoneBtName = attempt.phoneBtName"))
         assertTrue(scanner.contains("WppBootstrapPolicy.DISCOVERY_DEADLINE_MS"))
-        assertTrue(scanner.contains("readvertiseForNewCompanionAddress(ip, proxyPort, attempt)"))
+        assertTrue(scanner.contains("reportedPhoneId = probe.phoneId"))
     }
 
     @Test
@@ -170,8 +174,9 @@ class WppBootstrapPolicyTest {
             "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
         ).readText()
 
-        assertTrue(source.contains("publishPhoneAddress(ip, ident.wppProxyPort)"))
-        assertTrue(source.contains("readvertiseForNewCompanionAddress(host, reportedProxyPort)"))
+        assertTrue(source.contains("reportedProxyPort = ident.wppProxyPort"))
+        assertTrue(source.contains("phoneId = ident.phoneId"))
+        assertTrue(source.contains("reportedPhoneId = phoneId"))
     }
 
     private fun projectFile(path: String): File {

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -399,7 +399,15 @@ fun MainScreen(
                 text = "ID: $phoneIdShort  (auto-generated, used by the car app to remember this phone)",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(vertical = 4.dp),
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Text(
+                text = "Multiple phones: give every phone a unique Bluetooth device name, " +
+                    "then set this Friendly name to exactly match that Bluetooth name. " +
+                    "The car uses the match only to learn this phone's stable ID.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
             )
 
             Spacer(Modifier.height(20.dp))

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -1,0 +1,67 @@
+# Experimental GAL/PDK 6.0 compatibility mode
+
+OpenAutoLink normally requests Android Auto GAL 1.7. The **Experimental GAL 6.0**
+toggle in **Settings → Video** changes only the next AA session; use **Save &
+Reconnect** after changing it.
+
+The toggle is **off by default**.
+
+## What enabling it changes
+
+- Requests raw GAL/PDK version **6.0** instead of 1.7 during the pre-TLS version
+  exchange; a rejected version response aborts before TLS instead of continuing
+  under an invalid assumption.
+- Preserves OAL's proven 30-frame AV setup window; GAL 5+ ackless audio no
+  longer uses this value as per-buffer ACK credit.
+- Treats phone-to-head-unit audio as ackless; legacy sessions continue sending
+  per-frame audio ACKs.
+- Uses the active `Start.session_id` for legacy audio ACKs and all video ACKs.
+- Parses and logs GAL 5/6 `Start` extensions (`session_type` and raw
+  `media_config`).
+- Explicitly accepts and logs standalone audio/video `MediaOptions` (`0x8014`).
+- Explicitly accepts and logs navigation `VehicleEnergyForecast` (`0x8008`).
+- Sends modern `UiConfig.hidden_ui_elements` values for the existing hide-clock,
+  hide-battery, and hide-signal preferences; the legacy session bitmask remains
+  populated too.
+
+## Expected H.265 effect
+
+Gearhead's legacy wireless HEVC policy uses a 60-second I-frame interval. Android's
+OMX codec path converts that to a frame count using the configured frame rate, so
+60 FPS produces an approximately 3600-frame GOP. OAL measured normal real HEVC
+IDRs at 3575–3641-frame intervals.
+
+Gearhead's GAL 6 path selects its 2-second HEVC interval. Predictions:
+
+| Advertised FPS | Legacy GAL | GAL 6.0 |
+|---:|---:|---:|
+| 60 | ~3600 frames | ~120 frames |
+| 30 | ~1800 frames | ~60 frames |
+
+These are framework-derived predictions, not vehicle verification.
+
+## Runtime evidence
+
+Uploaded diagnostic logs use the `gal6` tag. A useful GAL 6 test must contain:
+
+- `GAL policy: requested=6.0 experimental=true`
+- `GAL negotiated: requested=6.0 response=... status=...`
+- `GAL6 video Start envelope: ... session_type=... media_config_bytes=...`
+- any `GAL6 MediaOptions ...` and `GAL6 VehicleEnergyForecast ...` lines
+- `H265-IDR` and `H265-pflow` lines
+- continuous `vflow` after the session reaches streaming
+
+The positive success signal is not merely a 6.x version response. It is a stable
+end-to-end session with video, audio, touch, navigation, and substantially shorter
+**frame-count** spacing between real H.265 IDRs.
+
+## Risk and fallback
+
+GAL 5.0+ changes audio flow control and AV start envelopes; GAL 5.1+ adds
+asynchronous MediaOptions and VehicleEnergyForecast; GAL 6.0 changes video media
+options and HEVC behavior. The mode is therefore experimental even though OAL
+accepts these known envelopes.
+
+If projection, audio, touch, or navigation regresses, turn the toggle off and use
+**Save & Reconnect** to return to GAL 1.7. Do not use video-focus bouncing as a
+keyframe workaround: it caused a verified encoder-throttle regression.

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -15,11 +15,15 @@ The toggle is **off by default**.
   longer uses this value as per-buffer ACK credit.
 - Treats phone-to-head-unit audio as ackless; legacy sessions continue sending
   per-frame audio ACKs.
-- Uses the active `Start.session_id` for legacy audio ACKs and all video ACKs.
+- Preserves the legacy `session_id=0` ACK behavior when disabled; GAL 6 uses the
+  active `Start.session_id` for video ACKs. GAL 6 audio is ackless.
 - Parses and logs GAL 5/6 `Start` extensions (`session_type` and raw
   `media_config`).
 - Explicitly accepts and logs standalone audio/video `MediaOptions` (`0x8014`).
 - Explicitly accepts and logs navigation `VehicleEnergyForecast` (`0x8008`).
+- Writes complete Start, MediaOptions, and VehicleEnergyForecast protobuf bytes
+  as numbered compact-hex chunks. Each line stays below DiagnosticLog's
+  500-character cap, so uploaded logs can reconstruct opaque payloads exactly.
 - Sends modern `UiConfig.hidden_ui_elements` values for the existing hide-clock,
   hide-battery, and hide-signal preferences; the legacy session bitmask remains
   populated too.
@@ -48,6 +52,8 @@ Uploaded diagnostic logs use the `gal6` tag. A useful GAL 6 test must contain:
 - `GAL negotiated: requested=6.0 response=... status=...`
 - `GAL6 video Start envelope: ... session_type=... media_config_bytes=...`
 - any `GAL6 MediaOptions ...` and `GAL6 VehicleEnergyForecast ...` lines
+- matching `GAL6 payload id=... chunk=... total_chunks=... hex=...` lines for
+  every opaque Start, MediaOptions, and VehicleEnergyForecast envelope
 - `H265-IDR` and `H265-pflow` lines
 - continuous `vflow` after the session reaches streaming
 


### PR DESCRIPTION
## Summary
- add a persisted **Experimental GAL 6.0** toggle under Settings → Video, off by default
- preserve the current GAL 1.7 path byte-for-byte when disabled
- request raw 6.0 when enabled and log requested/returned versions
- enable cumulative GAL 5.0/5.1/6.0 compatibility: ackless audio, richer AV Start envelopes, MediaOptions, VehicleEnergyForecast, modern UI ownership, and active media session IDs
- retain OAL's proven `max_unacked=30`; suppress audio ACKs only in GAL 6 mode and retain video ACKs
- abort failed version negotiation before TLS
- retain/log opaque MediaOptions rather than inventing unsupported semantics

Depends on draft mossyhub/aasdk#2 (`491aad9`).

## Verification
- TDD RED→GREEN for policy, settings/JNI wiring, modern messages, and rejected-version ordering
- focused GAL tests: **13 passed**, 0 failed/errors/skipped
- full car-app unit suite: **339 passed**, 0 failed/errors/skipped
- `:app:externalNativeBuildDebug` passed for arm64-v8a and x86_64 with `--rerun-tasks`
- `:app:assembleDebug` passed
- APK containment: toggle and native GAL markers are present in both ABI libraries and absent from the prior debug APK
- debug APK SHA-256: `7755347b9efbd0eea847e6aeda858fe0fd7aeb99827e75a066d35c4ff9c9b602`

## Runtime acceptance required
This is an **attempt**, not a verified H.265 fix. Do not merge/release until real USB and wireless sessions confirm:
- requested 6.0 receives successful 6.x response (expected 6.1)
- video, audio, touch, focus, navigation, and reconnect remain healthy
- H.265 real-IDR spacing changes from about 3600 frames toward about 120 frames at 60 FPS
- disabling the toggle restores the known GAL 1.7 behavior

Closes no issue; issue #18 remains open until an in-vehicle capture proves the outcome.
