### PR TITLE
fix(wireless): bind companion endpoints to Bluetooth phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ its automatic MAC policy.
 
 **Multiple drivers?** On 17.4+ the car projects to whichever phone it is currently connected to over Bluetooth, so switching phones means switching the connection in the **car's own Bluetooth settings** — the APIs an app would need to do that are privileged and closed to us. The phone list on the projection screen still shows every phone it can see, and tapping one retries the connection to it.
 
+> **Multi-phone identity:** Give every phone a unique Bluetooth device name. In each phone's OAL companion, set **Phone identity → Friendly name** to exactly match that phone's Bluetooth name. The car uses this first match to bind the Bluetooth phone to the companion's stable `phone_id`, preventing one reachable companion from being selected for another phone's WPP handshake.
+
 On Android Auto 17.3 and older, both phones can be on the car's WiFi at once and the floating phone icon switches between them directly. Settings → Connection → Known Phones → "Set Default" changes the preferred phone permanently.
 
 > **Tip:** The companion app has a built-in **Setup Guide** (tap the info button next to "Car WiFi") that walks you through these steps.

--- a/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
+++ b/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
@@ -168,14 +168,22 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * mid-session; publishing on every discovery keeps it current rather than
      * pinning a value that was right a minute ago.
      */
-    private fun publishPhoneAddress(host: String, reportedProxyPort: Int? = null) {
+    private fun publishPhoneAddress(
+        host: String,
+        reportedProxyPort: Int? = null,
+        phoneId: String? = null,
+        friendlyName: String? = null,
+    ) {
         val bt = com.openautolink.app.transport.bluetooth.AaWirelessBtControl
-        bt.lastKnownPhoneIp = host
-        // During an attempt-owned WPP bootstrap, pass through the proxy port the
-        // identity response actually reported. Port 5280 completes the current
-        // exchange; an older companion's dynamic port triggers one compatibility
-        // re-advertise after the current handshake exits.
-        bt.readvertiseForNewCompanionAddress(host, reportedProxyPort)
+        // Do not publish this host into the global dial cache before ownership is
+        // proven. Nearby phones share discovery, but only the Bluetooth-owned
+        // attempt may accept/cache this identity.
+        bt.readvertiseForNewCompanionAddress(
+            host = host,
+            reportedProxyPort = reportedProxyPort,
+            reportedPhoneId = phoneId,
+            reportedFriendlyName = friendlyName,
+        )
     }
 
     private val _isDiscovering = MutableStateFlow(false)
@@ -555,7 +563,12 @@ class PhoneDiscovery private constructor(private val context: Context) {
                         if (ident != null) {
                             // Remember where the companion lives so the Bluetooth
                             // advertiser can ask it for its AA proxy port.
-                            publishPhoneAddress(ip, ident.wppProxyPort)
+                            publishPhoneAddress(
+                                host = ip,
+                                reportedProxyPort = ident.wppProxyPort,
+                                phoneId = ident.phoneId,
+                                friendlyName = ident.friendlyName,
+                            )
                             addOrUpdate(
                                 phoneId = ident.phoneId,
                                 friendlyName = ident.friendlyName,
@@ -865,7 +878,13 @@ class PhoneDiscovery private constructor(private val context: Context) {
     ) {
         // Every discovery source funnels through here, so this is the one place
         // that always has the freshest address for the Bluetooth advertiser.
-        host?.takeIf { it.isNotBlank() }?.let { publishPhoneAddress(it) }
+        host?.takeIf { it.isNotBlank() }?.let {
+            publishPhoneAddress(
+                host = it,
+                phoneId = phoneId,
+                friendlyName = friendlyName,
+            )
+        }
 
         synchronized(lock) {
             val canonicalKey = keyFor(phoneId, mdnsServiceName, host)

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -216,11 +216,12 @@ class AasdkSession(
         // "connected". Discovery even found the phone; nothing acted on it,
         // because in WPP mode only the handshake triggers a dial.
         val known = com.openautolink.app.transport.bluetooth.AaWirelessBtControl
-            .lastKnownPhoneIp
+            .withIdentityValidatedCompanion { address ->
+                OalLog.i(TAG, "WPP restart with a known companion at $address — dialling " +
+                        "rather than waiting for a handshake that is not coming")
+                startTcp(manualIp = address)
+            }
         if (known != null) {
-            OalLog.i(TAG, "WPP restart with a known companion at $known — dialling " +
-                    "rather than waiting for a handshake that is not coming")
-            startTcp(manualIp = known)
             // Dialling the companion is only half the connection. Android Auto's
             // previous localhost socket belonged to the bridge that just ended;
             // reconnecting the car socket does not by itself make AA open a new
@@ -560,8 +561,10 @@ class AasdkSession(
                     // falls through to the gateway heuristic and dials the house
                     // router.
                     val known = com.openautolink.app.transport.bluetooth
-                        .AaWirelessBtControl.lastKnownPhoneIp
-                    startTcp(manualIp = known)
+                        .AaWirelessBtControl.withIdentityValidatedCompanion { address ->
+                            startTcp(manualIp = address)
+                        }
+                    if (known == null) startTcp(manualIp = null)
                 }
             }
         } finally {
@@ -742,6 +745,7 @@ class AasdkSession(
                     OalLog.i(TAG, "Restarting transport connector")
                     when (transportMode) {
                         "usb" -> startUsb()
+                        "wpp" -> startWpp()
                         else -> {
                             // Keep the companion's address on a retry.
                             //
@@ -751,8 +755,10 @@ class AasdkSession(
                             //     Connecting to 192.168.0.1:5277 (gateway)  x10
                             // The companion is never at the gateway in WPP mode.
                             val known = com.openautolink.app.transport.bluetooth
-                                .AaWirelessBtControl.lastKnownPhoneIp
-                            startTcp(manualIp = known)
+                                .AaWirelessBtControl.withIdentityValidatedCompanion { address ->
+                                    startTcp(manualIp = address)
+                                }
+                            if (known == null) startTcp(manualIp = null)
                         }
                     }
                 }

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -346,15 +346,24 @@ object AaWirelessBtControl {
             while (System.currentTimeMillis() < deadline) {
                 // A newer Bluetooth dial-back owns a different attempt. Let this
                 // scanner die without consuming or dialling on its behalf.
-                if (bootstrapAttempt.get() !== attempt || sessionIsStreaming?.invoke() == true) {
+                if (bootstrapAttempt.get() !== attempt ||
+                    !phoneClaimStillOwned(attempt.phoneBtAddress, attempt.claimGeneration) ||
+                    sessionIsStreaming?.invoke() == true
+                ) {
                     return@launch
                 }
                 scanAttempt++
-                var found: Pair<String, Int>? = null
+                var found: ResolvedCompanion? = null
                 for (ip in candidates.take(MAX_PRESCAN_PROBES)) {
-                    val proxyPort = askCompanion(ip, connectTimeoutMs = 800)
-                    if (proxyPort != null) {
-                        found = ip to proxyPort
+                    val probe = askCompanion(ip, connectTimeoutMs = 800)
+                    if (probe != null && probeMatchesBluetoothOwner(
+                            attempt.phoneBtAddress,
+                            attempt.phoneBtName,
+                            ip,
+                            probe,
+                            attempt.expectedPhoneId,
+                        )) {
+                        found = ResolvedCompanion(ip, probe)
                         break
                     }
                 }
@@ -362,13 +371,26 @@ object AaWirelessBtControl {
                     val remainingMs = (deadline - System.currentTimeMillis())
                         .coerceIn(1L, 5_000L)
                         .toInt()
-                    found = findCompanionOnAnySubnet(manualIp, remainingMs)
+                    found = findCompanionOnAnySubnet(
+                        manualIp = manualIp,
+                        phoneBtAddress = attempt.phoneBtAddress,
+                        phoneBtName = attempt.phoneBtName,
+                        overallTimeoutMs = remainingMs,
+                    )
                 }
                 if (found != null) {
-                    val (ip, proxyPort) = found
-                    OalLog.i(TAG, "Bootstrap discovery found companion at $ip " +
-                            "on attempt $scanAttempt (proxy port $proxyPort)")
-                    readvertiseForNewCompanionAddress(ip, proxyPort, attempt)
+                    val ip = found.host
+                    val probe = found.probe
+                    OalLog.i(TAG, "Bootstrap discovery identity-matched companion at $ip " +
+                            "id=${probe.phoneId} on attempt $scanAttempt " +
+                            "(proxy port ${probe.proxyPort})")
+                    readvertiseForNewCompanionAddress(
+                        host = ip,
+                        reportedProxyPort = probe.proxyPort,
+                        expectedAttempt = attempt,
+                        reportedPhoneId = probe.phoneId,
+                        reportedFriendlyName = probe.friendlyName,
+                    )
                     return@launch
                 }
                 kotlinx.coroutines.delay(750)
@@ -383,11 +405,15 @@ object AaWirelessBtControl {
         val (pending, admissionToken) = synchronized(handshakeStateLock) {
             if (activeHandshakeCount.get() > 0 || handshakeAdmissionBlocked) return
             val candidate = pendingLegacyReadvertise.get() ?: return
-            if (bootstrapAttempt.get() !== candidate.attempt) {
+            val consumed = synchronized(phoneClaimLock) {
+                activePhoneBt.equals(candidate.attempt.phoneBtAddress, ignoreCase = true) &&
+                    phoneClaimGeneration == candidate.attempt.claimGeneration &&
+                    bootstrapAttempt.compareAndSet(candidate.attempt, null)
+            }
+            if (!consumed) {
                 pendingLegacyReadvertise.compareAndSet(candidate, null)
                 return
             }
-            if (!bootstrapAttempt.compareAndSet(candidate.attempt, null)) return
             pendingLegacyReadvertise.compareAndSet(candidate, null)
             val token = handshakeAdmissionSequence.incrementAndGet()
             handshakeAdmissionBlocked = true
@@ -401,18 +427,51 @@ object AaWirelessBtControl {
         readvertise(admissionToken)
     }
 
-    fun readvertiseForNewCompanionAddress(host: String, reportedProxyPort: Int? = null) {
-        readvertiseForNewCompanionAddress(host, reportedProxyPort, null)
+    fun readvertiseForNewCompanionAddress(
+        host: String,
+        reportedProxyPort: Int? = null,
+        reportedPhoneId: String? = null,
+        reportedFriendlyName: String? = null,
+    ) {
+        readvertiseForNewCompanionAddress(
+            host = host,
+            reportedProxyPort = reportedProxyPort,
+            expectedAttempt = null,
+            reportedPhoneId = reportedPhoneId,
+            reportedFriendlyName = reportedFriendlyName,
+        )
     }
 
     private fun readvertiseForNewCompanionAddress(
         host: String,
         reportedProxyPort: Int? = null,
         expectedAttempt: BootstrapAttempt? = null,
+        reportedPhoneId: String? = null,
+        reportedFriendlyName: String? = null,
     ) {
-        val proxyPort = reportedProxyPort ?: askCompanion(host, connectTimeoutMs = 800) ?: return
+        val liveProbe = askCompanion(host, connectTimeoutMs = 800)
+        val probe = liveProbe ?: reportedProxyPort?.let { port ->
+            CompanionProbe(reportedPhoneId, reportedFriendlyName, port)
+        } ?: return
         val attempt = expectedAttempt ?: bootstrapAttempt.get()
         if (expectedAttempt != null && bootstrapAttempt.get() !== expectedAttempt) return
+        if (attempt != null &&
+            !phoneClaimStillOwned(attempt.phoneBtAddress, attempt.claimGeneration)
+        ) {
+            OalLog.i(TAG, "Ignoring late companion for superseded claim ${attempt.phoneBtAddress}")
+            return
+        }
+        if (attempt != null && !probeMatchesBluetoothOwner(
+                attempt.phoneBtAddress,
+                attempt.phoneBtName,
+                host,
+                probe,
+                attempt.expectedPhoneId,
+            )) {
+            OalLog.i(TAG, "Ignoring late companion at $host — identity belongs to another phone")
+            return
+        }
+        val proxyPort = probe.proxyPort
         when (WppBootstrapPolicy.onCompanionReachable(
             bootstrapLoopbackPending = attempt != null,
             usesReservedProxyPort = proxyPort == OalProtocol.WPP_PROXY_PORT,
@@ -420,16 +479,29 @@ object AaWirelessBtControl {
             sessionStreaming = sessionIsStreaming?.invoke() == true,
         )) {
             LateCompanionAction.DIAL_COMPANION -> {
-                // Atomic consumption makes concurrent TCP-scan and cached-address
-                // results one event. Only the Bluetooth phone that opened this
-                // attempt owns the right to complete it.
-                if (attempt == null || !bootstrapAttempt.compareAndSet(attempt, null)) return
-                lastKnownPhoneIp = host
-                lastAddressByPhone[attempt.phoneBtAddress] = host
-                activePhoneCompanionIp = host
-                OalLog.i(TAG, "Companion became reachable at $host after AP association — " +
-                        "dialling it into reserved loopback port $proxyPort; no second WPP exchange")
-                onCompanionSelected?.invoke(host)
+                // Consume and dial under the same claim lock. A newer Bluetooth
+                // claimant cannot overtake this completion between the generation
+                // check and the connector replacement.
+                if (attempt == null) return
+                val dialled = synchronized(phoneClaimLock) {
+                    if (!activePhoneBt.equals(attempt.phoneBtAddress, ignoreCase = true) ||
+                        phoneClaimGeneration != attempt.claimGeneration ||
+                        !bootstrapAttempt.compareAndSet(attempt, null)
+                    ) {
+                        false
+                    } else {
+                        lastKnownPhoneIp = host
+                        lastAddressByPhone[attempt.phoneBtAddress] = host
+                        activePhoneCompanionIp = host
+                        OalLog.i(TAG, "Companion became reachable at $host after AP association — " +
+                                "dialling it into reserved loopback port $proxyPort; no second WPP exchange")
+                        onCompanionSelected?.invoke(host)
+                        true
+                    }
+                }
+                if (!dialled) {
+                    OalLog.i(TAG, "Ignoring late dial from superseded phone claim ${attempt.phoneBtAddress}")
+                }
             }
             LateCompanionAction.QUEUE_READVERTISE -> {
                 OalLog.i(TAG, "Older companion at $host uses dynamic proxy port $proxyPort; " +
@@ -456,13 +528,18 @@ object AaWirelessBtControl {
                 flushPendingReadvertise()
             }
             LateCompanionAction.IGNORE -> {
-                if (sessionIsStreaming?.invoke() == true) bootstrapAttempt.set(null)
+                if (sessionIsStreaming?.invoke() == true && attempt != null) {
+                    bootstrapAttempt.compareAndSet(attempt, null)
+                }
             }
         }
     }
 
     private data class BootstrapAttempt(
         val phoneBtAddress: String,
+        val phoneBtName: String?,
+        val expectedPhoneId: String?,
+        val claimGeneration: Long,
         val generation: Long,
     )
 
@@ -534,6 +611,14 @@ object AaWirelessBtControl {
 
     /** The address each phone's companion last answered on, keyed by BT MAC. */
     private val lastAddressByPhone = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** Stable companion phone_id learned after a Bluetooth-name identity match. */
+    private val phoneIdByBtAddress = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    private data class ResolvedCompanion(
+        val host: String,
+        val probe: CompanionProbe,
+    )
 
     /**
      * The phone currently holding the projection session, by BT address.
@@ -615,9 +700,62 @@ object AaWirelessBtControl {
     @Volatile
     var activePhoneBt: String? = null
 
+    private val phoneClaimLock = Any()
+    private var phoneClaimGeneration = 0L
+
     /** When [activePhoneBt] took the session, for ageing out a stale claim. */
     @Volatile
     private var activePhoneClaimedAt: Long = 0L
+
+    private fun claimPhoneForHandshake(
+        phoneBtAddress: String,
+        holderIsStreaming: Boolean,
+    ): Long? = synchronized(phoneClaimLock) {
+        val claimed = activePhoneBt
+        val claimAgeMs = System.currentTimeMillis() - activePhoneClaimedAt
+        if (claimed != null &&
+            !claimed.equals(phoneBtAddress, ignoreCase = true) &&
+            claimAgeMs < CLAIM_TIMEOUT_MS &&
+            holderIsStreaming
+        ) {
+            OalLog.i(TAG, "Not switching to $phoneBtAddress — $claimed is " +
+                    "streaming (claimed ${claimAgeMs / 1000}s ago). Switch phones " +
+                    "in the car's Bluetooth settings; disconnecting $claimed " +
+                    "releases the session immediately.")
+            return null
+        }
+        if (claimed != null && !claimed.equals(phoneBtAddress, ignoreCase = true)) {
+            OalLog.i(TAG, "Handing the session from $claimed to $phoneBtAddress, " +
+                    "which is dialling now (previous claim ${claimAgeMs / 1000}s old, " +
+                    "streaming=$holderIsStreaming)")
+        }
+        activePhoneBt = phoneBtAddress
+        activePhoneClaimedAt = System.currentTimeMillis()
+        phoneClaimGeneration++
+        phoneClaimGeneration
+    }
+
+    private fun phoneClaimStillOwned(phoneBtAddress: String, generation: Long): Boolean =
+        synchronized(phoneClaimLock) {
+            activePhoneBt.equals(phoneBtAddress, ignoreCase = true) &&
+                phoneClaimGeneration == generation
+        }
+
+    /**
+     * Returns only the companion address proven to belong to the Bluetooth phone
+     * currently holding the WPP claim.
+     *
+     * Discovery's global address history is intentionally excluded: it can contain
+     * every nearby phone and was the source of cross-phone speculative dials.
+     */
+    fun withIdentityValidatedCompanion(action: (String) -> Unit): String? =
+        synchronized(phoneClaimLock) {
+            val btAddress = activePhoneBt ?: return null
+            if (phoneIdByBtAddress[btAddress].isNullOrBlank()) return null
+            val address = lastAddressByPhone[btAddress] ?: return null
+            action(address)
+            address
+        }
 
     /**
      * Reset attempt ownership on ignition off while retaining address hints.
@@ -727,11 +865,14 @@ object AaWirelessBtControl {
         }
     }
 
-    fun releaseActivePhone() {
+    fun releaseActivePhone() = synchronized(phoneClaimLock) {
         activePhoneBt?.let { OalLog.i(TAG, "Released the session claim held by $it") }
         activePhoneBt = null
         activePhoneClaimedAt = 0L
         activePhoneCompanionIp = null
+        bootstrapAttempt.set(null)
+        pendingLegacyReadvertise.set(null)
+        phoneClaimGeneration++
     }
 
     /**
@@ -1007,8 +1148,10 @@ object AaWirelessBtControl {
      */
     private fun findCompanionOnAnySubnet(
         manualIp: String?,
+        phoneBtAddress: String,
+        phoneBtName: String?,
         overallTimeoutMs: Int = 20_000,
-    ): Pair<String, Int>? {
+    ): ResolvedCompanion? {
         val localIps = buildList {
             manualIp?.takeIf { it.isNotBlank() }?.let { add(it) }
             addAll(allLocalIpv4())
@@ -1021,7 +1164,13 @@ object AaWirelessBtControl {
             if (prefix.isEmpty()) continue
             val remainingMs = (deadline - System.currentTimeMillis()).coerceAtLeast(1L).toInt()
             OalLog.i(TAG, "Scanning $prefix.0/24 for the companion")
-            scanSubnet(prefix, ip, remainingMs)?.let { return it }
+            scanSubnet(
+                prefix = prefix,
+                ourIp = ip,
+                phoneBtAddress = phoneBtAddress,
+                phoneBtName = phoneBtName,
+                overallTimeoutMs = remainingMs,
+            )?.let { return it }
             if (System.currentTimeMillis() >= deadline) break
         }
         OalLog.w(TAG, "No companion on any local subnet (${localIps.joinToString()})")
@@ -1061,8 +1210,10 @@ object AaWirelessBtControl {
     private fun scanSubnet(
         prefix: String,
         ourIp: String,
+        phoneBtAddress: String,
+        phoneBtName: String?,
         overallTimeoutMs: Int = 20_000,
-    ): Pair<String, Int>? {
+    ): ResolvedCompanion? {
         val pool = java.util.concurrent.Executors.newFixedThreadPool(128)
         return try {
             val tasks = (1..254)
@@ -1070,7 +1221,11 @@ object AaWirelessBtControl {
                 .filter { it != ourIp }
                 .map { ip ->
                     java.util.concurrent.Callable {
-                        askCompanion(ip, connectTimeoutMs = 1200)?.let { ip to it }
+                        val probe = askCompanion(ip, connectTimeoutMs = 1200)
+                        if (probe != null && probeMatchesBluetoothOwner(
+                                phoneBtAddress, phoneBtName, ip, probe)) {
+                            ResolvedCompanion(ip, probe)
+                        } else null
                     }
                 }
             // Budget must cover the whole /24 at the chosen timeout, or the scan
@@ -1092,7 +1247,8 @@ object AaWirelessBtControl {
                 .asSequence()
                 .mapNotNull { runCatching { it.get() }.getOrNull() }
                 .firstOrNull()
-                ?.also { OalLog.i(TAG, "Companion found at ${it.first} with proxy port ${it.second}") }
+                ?.also { OalLog.i(TAG, "Identity-matched companion found at ${it.host} " +
+                        "id=${it.probe.phoneId} with proxy port ${it.probe.proxyPort}") }
         } catch (e: Exception) {
             OalLog.w(TAG, "Scan of $prefix.0/24 failed: ${e.message}")
             null
@@ -1102,33 +1258,50 @@ object AaWirelessBtControl {
     }
 
     /**
-     * Asks the companion at [phoneIp] for its Android Auto proxy port.
+     * Asks the companion at [phoneIp] for its complete identity and live proxy.
      *
-     * Returns null if nothing answers, the reply is not ours, or it reports no
-     * proxy (wpp=0). A zero must not be treated as a port: advertising a dead
-     * port sends Android Auto to a closed socket and fails silently on both ends.
-     *
-     * The default timeout is generous because the telematics bridge is slow — a
-     * probe that would succeed at 1200ms returned nothing at 250ms.
+     * Identity is mandatory: accepting only `wpp=<port>` allowed whichever phone
+     * answered first to impersonate the Bluetooth owner of the current attempt.
      */
-    private fun askCompanion(phoneIp: String, connectTimeoutMs: Int = 1200): Int? = runCatching {
+    private fun askCompanion(
+        phoneIp: String,
+        connectTimeoutMs: Int = 1200,
+    ): CompanionProbe? = runCatching {
         java.net.Socket().use { sock ->
             sock.connect(java.net.InetSocketAddress(phoneIp, IDENTITY_PORT), connectTimeoutMs)
             sock.soTimeout = connectTimeoutMs
             sock.getOutputStream().apply { write("OAL?\n".toByteArray()); flush() }
             val reply = sock.getInputStream().bufferedReader().readLine().orEmpty()
-            if (!reply.startsWith("OAL!")) return@runCatching null
-            reply.removePrefix("OAL!").split('\t')
-                .firstOrNull { it.startsWith("wpp=") }
-                ?.removePrefix("wpp=")?.trim()?.toIntOrNull()
-                ?.takeIf { it in 1..65535 }
+            CompanionIdentityPolicy.parseProbe(reply)
         }
     }.getOrNull()
 
-    private fun companionProxyPort(phoneIp: String): Int? =
-        askCompanion(phoneIp)?.also {
-            OalLog.i(TAG, "Companion at $phoneIp reports AA proxy on port $it")
+    private fun probeMatchesBluetoothOwner(
+        phoneBtAddress: String,
+        phoneBtName: String?,
+        phoneIp: String,
+        probe: CompanionProbe,
+        expectedPhoneIdOverride: String? = null,
+    ): Boolean {
+        val expectedPhoneId = expectedPhoneIdOverride ?: phoneIdByBtAddress[phoneBtAddress]
+        val matches = CompanionIdentityPolicy.matches(
+            expectedPhoneId = expectedPhoneId,
+            bluetoothDeviceName = phoneBtName,
+            probe = probe,
+        )
+        if (!matches) {
+            OalLog.i(
+                TAG,
+                "Rejected companion at $phoneIp id=${probe.phoneId ?: "unknown"} " +
+                    "name=${probe.friendlyName ?: "unknown"} — Bluetooth owner is " +
+                    "$phoneBtAddress name=${phoneBtName ?: "unknown"} " +
+                    "expectedId=${expectedPhoneId ?: "unlearned"}",
+            )
+            return false
         }
+        probe.phoneId?.let { phoneIdByBtAddress[phoneBtAddress] = it }
+        return true
+    }
 
     /**
      * Frequencies (MHz) advertised as supported by the head unit's access point.
@@ -1263,7 +1436,7 @@ object AaWirelessBtControl {
         // the car's access point is never asked to accept an inbound connection —
         // which it refuses. Falling back to the car's own address preserves the
         // shared-network case (proven working on a tablet) and costs nothing.
-        bt.setEndpointResolver { phoneBtAddress ->
+        bt.setEndpointResolver { phoneBtAddress, phoneBtName ->
             // Only serve the phone the head unit is actually paired-and-connected
             // to for projection. Two phones can dial the SDP record concurrently,
             // and the endpoint is per-phone: 127.0.0.1:<port> only means anything
@@ -1280,36 +1453,11 @@ object AaWirelessBtControl {
             //
             // A phone that dials the SDP record IS present and IS trying to
             // connect, so an old claim should lose to a live handshake.
-            val claimed = activePhoneBt
-            val claimAgeMs = System.currentTimeMillis() - activePhoneClaimedAt
-            // A claim only outranks a live handshake while projection is actually
-            // running. Otherwise the phone dialling now has the better evidence of
-            // being present: the claim describes a session that may have ended,
-            // while the handshake is happening in front of us.
-            //
-            // This matters for the only way a phone can be switched — the car's
-            // own Bluetooth settings, since the APIs to do it ourselves are
-            // privileged. Refusing the new phone for up to two minutes made a
-            // deliberate user action look broken.
             val holderIsStreaming = sessionIsStreaming?.invoke() == true
-            if (claimed != null &&
-                !claimed.equals(phoneBtAddress, ignoreCase = true) &&
-                claimAgeMs < CLAIM_TIMEOUT_MS &&
-                holderIsStreaming
-            ) {
-                OalLog.i(TAG, "Not switching to $phoneBtAddress — $claimed is " +
-                        "streaming (claimed ${claimAgeMs / 1000}s ago). Switch phones " +
-                        "in the car's Bluetooth settings; disconnecting $claimed " +
-                        "releases the session immediately.")
-                return@setEndpointResolver null
-            }
-            if (claimed != null && !claimed.equals(phoneBtAddress, ignoreCase = true)) {
-                OalLog.i(TAG, "Handing the session from $claimed to $phoneBtAddress, " +
-                        "which is dialling now (previous claim ${claimAgeMs / 1000}s old, " +
-                        "streaming=$holderIsStreaming)")
-            }
-            activePhoneBt = phoneBtAddress
-            activePhoneClaimedAt = System.currentTimeMillis()
+            val claimGeneration = claimPhoneForHandshake(
+                phoneBtAddress = phoneBtAddress,
+                holderIsStreaming = holderIsStreaming,
+            ) ?: return@setEndpointResolver null
 
             // Resolve the companion's address, preferring one discovery already
             // found. The sweep is the fallback, not the primary: it runs on the
@@ -1405,10 +1553,16 @@ object AaWirelessBtControl {
             // One or two probes is a cheap bet on the address being unchanged.
             // More than that is a tax on everyone whose address did change.
             for (ip in candidates.take(MAX_PRESCAN_PROBES)) {
-                val p = askCompanion(ip, connectTimeoutMs = 2500)
-                if (p != null) {
-                    OalLog.i(TAG, "Companion at $ip reports AA proxy on port $p")
-                    proxyPort = p
+                val probe = askCompanion(ip, connectTimeoutMs = 2500)
+                if (probe != null && probeMatchesBluetoothOwner(
+                        phoneBtAddress, phoneBtName, ip, probe)) {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Ignoring identity result from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
+                    OalLog.i(TAG, "Identity-matched companion at $ip " +
+                            "id=${probe.phoneId} reports AA proxy on port ${probe.proxyPort}")
+                    proxyPort = probe.proxyPort
                     companionIp = ip
                     lastKnownPhoneIp = ip
                     lastAddressByPhone[phoneBtAddress] = ip
@@ -1425,17 +1579,30 @@ object AaWirelessBtControl {
                 }
                 // The scan returns the port too — asking again would cost another
                 // slow round trip over the telematics bridge.
-                findCompanionOnAnySubnet(manualIp)?.let { (ip, port) ->
+                findCompanionOnAnySubnet(
+                    manualIp = manualIp,
+                    phoneBtAddress = phoneBtAddress,
+                    phoneBtName = phoneBtName,
+                )?.let { resolved ->
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Ignoring scan result from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
+                    val ip = resolved.host
+                    val probe = resolved.probe
                     lastKnownPhoneIp = ip
-                    // Record it against this phone too, or the next handshake
-                    // from it starts from the shared list again.
+                    // Cache only after identity has matched the Bluetooth owner.
                     lastAddressByPhone[phoneBtAddress] = ip
-                    proxyPort = port
+                    proxyPort = probe.proxyPort
                     companionIp = ip
                 }
             }
             when {
                 proxyPort != null -> {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Not dialing endpoint from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     // Open the car->companion socket BEFORE the handshake tells
                     // Android Auto where to connect. AA reaches the proxy within
                     // ~2s of the Bluetooth handshake; the car used to still be
@@ -1448,30 +1615,64 @@ object AaWirelessBtControl {
                     // listened forever while the phone waited for a car socket.
                     // Remember which companion belongs to the Bluetooth-connected
                     // phone so the UI can mark it in the discovery list.
-                    activePhoneCompanionIp = companionIp
-                    bootstrapAttempt.set(null)
-                    OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy " +
-                            "127.0.0.1:$proxyPort via companion at $companionIp " +
-                            "phone=$phoneBtAddress — this is the working path")
                     val dialTarget = companionIp
-                    if (dialTarget.isNullOrBlank()) {
-                        OalLog.e(TAG, "Have proxy port $proxyPort but no companion address — " +
-                                "cannot dial; the session will not connect")
-                    } else {
-                        onCompanionSelected?.invoke(dialTarget)
+                    val accepted = synchronized(phoneClaimLock) {
+                        if (!activePhoneBt.equals(phoneBtAddress, ignoreCase = true) ||
+                            phoneClaimGeneration != claimGeneration
+                        ) {
+                            false
+                        } else {
+                            activePhoneCompanionIp = dialTarget
+                            bootstrapAttempt.set(null)
+                            OalLog.i(TAG, "CONNECT SUMMARY: endpoint=loopback proxy " +
+                                    "127.0.0.1:$proxyPort via companion at $dialTarget " +
+                                    "phone=$phoneBtAddress — this is the working path")
+                            if (dialTarget.isNullOrBlank()) {
+                                OalLog.e(TAG, "Have proxy port $proxyPort but no companion address — " +
+                                        "cannot dial; the session will not connect")
+                            } else {
+                                onCompanionSelected?.invoke(dialTarget)
+                            }
+                            true
+                        }
+                    }
+                    if (!accepted) {
+                        OalLog.i(TAG, "Not dialing endpoint from superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
                     }
                     AaWirelessBtServer.Endpoint.PhoneLoopback(proxyPort)
                 }
                 else -> {
+                    if (!phoneClaimStillOwned(phoneBtAddress, claimGeneration)) {
+                        OalLog.i(TAG, "Not starting bootstrap for superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     // The phone is not on the car AP yet, so the companion cannot
                     // answer. Use the port both new apps reserve in advance. WPP
                     // moves the phone onto the AP, Android Auto can attach to its
                     // local proxy immediately, and discovery then supplies the
                     // car-side socket to that same waiting bridge.
-                    val attempt = BootstrapAttempt(phoneBtAddress,
-                        bootstrapAttemptSequence.incrementAndGet(),
+                    val attempt = BootstrapAttempt(
+                        phoneBtAddress = phoneBtAddress,
+                        phoneBtName = phoneBtName,
+                        expectedPhoneId = phoneIdByBtAddress[phoneBtAddress],
+                        claimGeneration = claimGeneration,
+                        generation = bootstrapAttemptSequence.incrementAndGet(),
                     )
-                    bootstrapAttempt.set(attempt)
+                    val published = synchronized(phoneClaimLock) {
+                        if (!activePhoneBt.equals(phoneBtAddress, ignoreCase = true) ||
+                            phoneClaimGeneration != claimGeneration
+                        ) {
+                            false
+                        } else {
+                            bootstrapAttempt.set(attempt)
+                            true
+                        }
+                    }
+                    if (!published) {
+                        OalLog.i(TAG, "Not publishing bootstrap for superseded phone claim $phoneBtAddress")
+                        return@setEndpointResolver null
+                    }
                     OalLog.i(TAG, "CONNECT SUMMARY: endpoint=bootstrap-loopback " +
                             "127.0.0.1:${OalProtocol.WPP_PROXY_PORT} phone=$phoneBtAddress " +
                             "knownAddrs=${allKnown.joinToString().ifEmpty { "none" }} " +

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt
@@ -339,8 +339,11 @@ class AaWirelessBtServer(
 
             if (client != null) {
                 outcomeObserver.phoneDialbackAt(SystemClock.elapsedRealtime())
-                val remote = runCatching { client.remoteDevice?.address ?: "?" }.getOrDefault("?")
-                OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote")
+                val remoteDevice = runCatching { client.remoteDevice }.getOrNull()
+                val remote = runCatching { remoteDevice?.address ?: "?" }.getOrDefault("?")
+                val remoteName = runCatching { remoteDevice?.name }.getOrNull()
+                OalLog.i(TAG, "Phone dialled back on the AA Wireless UUID from $remote" +
+                        (remoteName?.let { " name=$it" } ?: " name=unknown"))
                 // Flag it here rather than inside handleHandshake: the window that
                 // matters starts the instant the phone dials, and the coroutine
                 // may not be scheduled for several milliseconds.
@@ -351,7 +354,7 @@ class AaWirelessBtServer(
                     continue
                 }
                 val handshakeJob = scope.launch(CoroutineName("AaWirelessBt-Handshake")) {
-                    handleHandshake(client, remote, handshakeLease)
+                    handleHandshake(client, remote, remoteName, handshakeLease)
                 }
                 handshakeJob.invokeOnCompletion {
                     // This also runs when the coroutine is cancelled before its
@@ -458,8 +461,11 @@ class AaWirelessBtServer(
          *   The port is meaningful only on the phone that owns it — 127.0.0.1
          *   resolves on whichever device connects — so a mixed-up port sends a
          *   phone's Android Auto to a closed socket on its own loopback.
+         * @param phoneBtName the remote Bluetooth device name from the same socket.
+         *   Companion identity must agree with this owner (or a previously learned
+         *   phone_id binding) before an endpoint is accepted.
          */
-        fun currentEndpoint(phoneBtAddress: String): Endpoint?
+        fun currentEndpoint(phoneBtAddress: String, phoneBtName: String?): Endpoint?
     }
 
     @Volatile
@@ -480,6 +486,7 @@ class AaWirelessBtServer(
     private suspend fun handleHandshake(
         socket: BluetoothSocket,
         phoneBtAddress: String,
+        phoneBtName: String?,
         handshakeLease: AaWirelessBtControl.HandshakeLease,
     ) {
         val stored = credentials
@@ -496,7 +503,7 @@ class AaWirelessBtServer(
         // Prefer the companion's loopback proxy when one is available: it is the
         // only endpoint the car's access point cannot block, because the phone
         // connects to itself.
-        val endpoint = endpointResolver?.currentEndpoint(phoneBtAddress)
+        val endpoint = endpointResolver?.currentEndpoint(phoneBtAddress, phoneBtName)
         val creds = when (endpoint) {
             is Endpoint.PhoneLoopback -> {
                 OalLog.i(TAG, "Advertising the companion's loopback proxy " +

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
@@ -1,0 +1,51 @@
+package com.openautolink.app.transport.bluetooth
+
+import java.util.Locale
+
+/** Identity returned by the companion's dedicated OAL probe endpoint. */
+internal data class CompanionProbe(
+    val phoneId: String?,
+    val friendlyName: String?,
+    val proxyPort: Int,
+)
+
+/** Pure parsing and ownership policy for Bluetooth-phone → companion matching. */
+internal object CompanionIdentityPolicy {
+    private const val PREFIX = "OAL!"
+
+    fun parseProbe(reply: String): CompanionProbe? {
+        if (!reply.startsWith(PREFIX)) return null
+        val parts = reply.removePrefix(PREFIX).split('\t')
+        val port = parts.firstOrNull { it.startsWith("wpp=") }
+            ?.removePrefix("wpp=")
+            ?.trim()
+            ?.toIntOrNull()
+            ?.takeIf { it in 1..65535 }
+            ?: return null
+        return CompanionProbe(
+            phoneId = parts.getOrNull(0)?.trim()?.takeIf { it.isNotEmpty() },
+            friendlyName = parts.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() },
+            proxyPort = port,
+        )
+    }
+
+    fun matches(
+        expectedPhoneId: String?,
+        bluetoothDeviceName: String?,
+        probe: CompanionProbe,
+    ): Boolean {
+        val expectedId = expectedPhoneId?.trim()?.takeIf { it.isNotEmpty() }
+        if (expectedId != null) {
+            return expectedId == probe.phoneId
+        }
+        val btName = normalizeName(bluetoothDeviceName) ?: return false
+        val companionName = normalizeName(probe.friendlyName) ?: return false
+        return btName == companionName
+    }
+
+    private fun normalizeName(value: String?): String? = value
+        ?.trim()
+        ?.replace(Regex("\\s+"), " ")
+        ?.lowercase(Locale.ROOT)
+        ?.takeIf { it.isNotEmpty() }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
@@ -1,0 +1,125 @@
+package com.openautolink.app.transport.bluetooth
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionIdentityPolicyTest {
+
+    @Test
+    fun `probe parser preserves phone identity and proxy port`() {
+        val probe = CompanionIdentityPolicy.parseProbe(
+            "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=5280",
+        )
+
+        requireNotNull(probe)
+        assertEquals("19bbbce4-1234", probe.phoneId)
+        assertEquals("Liz OnePlus 13", probe.friendlyName)
+        assertEquals(5280, probe.proxyPort)
+    }
+
+    @Test
+    fun `probe parser rejects missing live proxy`() {
+        assertNull(
+            CompanionIdentityPolicy.parseProbe(
+                "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=0",
+            ),
+        )
+    }
+
+    @Test
+    fun `bluetooth device name selects only its matching companion`() {
+        val liz = CompanionProbe("liz-id", "Liz OnePlus 13", 5280)
+        val lance = CompanionProbe("lance-id", "Lance OnePlus 13", 5280)
+
+        assertTrue(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "Liz OnePlus 13",
+                probe = liz,
+            ),
+        )
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "Liz OnePlus 13",
+                probe = lance,
+            ),
+        )
+    }
+
+    @Test
+    fun `learned phone id outranks a renamed device`() {
+        val probe = CompanionProbe("liz-id", "New Device Name", 5280)
+
+        assertTrue(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = "liz-id",
+                bluetoothDeviceName = "Old Device Name",
+                probe = probe,
+            ),
+        )
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = "lance-id",
+                bluetoothDeviceName = "New Device Name",
+                probe = probe,
+            ),
+        )
+    }
+
+    @Test
+    fun `unidentified companion is never accepted as the bluetooth owner`() {
+        val probe = CompanionProbe("some-id", null, 5280)
+
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = null,
+                probe = probe,
+            ),
+        )
+    }
+
+    @Test
+    fun `bluetooth endpoint resolution carries and enforces remote device identity`() {
+        val server = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtServer.kt",
+        ).readText()
+        val control = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+
+        val session = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        assertTrue(server.contains("remoteDevice?.name"))
+        assertTrue(server.contains("currentEndpoint(phoneBtAddress, phoneBtName)"))
+        assertTrue(control.contains("CompanionIdentityPolicy.matches("))
+        assertTrue(control.contains("private val phoneClaimLock = Any()"))
+        assertTrue(control.contains("private var phoneClaimGeneration = 0L"))
+        assertTrue(control.contains("claimGeneration = claimPhoneForHandshake("))
+        assertTrue(control.contains("phoneClaimStillOwned(phoneBtAddress, claimGeneration)"))
+        assertTrue(control.contains("val claimGeneration: Long"))
+        assertTrue(session.contains("withIdentityValidatedCompanion"))
+        assertFalse(session.contains("identityValidatedCompanionIp()"))
+        assertFalse(session.contains("AaWirelessBtControl.lastKnownPhoneIp"))
+        assertFalse(session.contains(".lastKnownPhoneIp"))
+        assertTrue(session.windowed("\"wpp\" -> startWpp()".length)
+            .count { it == "\"wpp\" -> startWpp()" } >= 3)
+        val matchIndex = control.indexOf("CompanionIdentityPolicy.matches(")
+        val cacheIndex = control.indexOf("lastAddressByPhone[phoneBtAddress] = ip", matchIndex)
+        assertTrue(matchIndex >= 0)
+        assertTrue(cacheIndex > matchIndex)
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .first { it.isFile }
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
@@ -83,7 +83,9 @@ class WppBootstrapPolicyTest {
             "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
         ).readText()
 
-        assertTrue(source.contains("val attempt = BootstrapAttempt(phoneBtAddress"))
+        assertTrue(source.contains("val attempt = BootstrapAttempt("))
+        assertTrue(source.contains("phoneBtAddress = phoneBtAddress"))
+        assertTrue(source.contains("phoneBtName = phoneBtName"))
         assertTrue(
             source.contains(
                 "AaWirelessBtServer.Endpoint.PhoneLoopback(OalProtocol.WPP_PROXY_PORT)",
@@ -101,9 +103,11 @@ class WppBootstrapPolicyTest {
 
         assertTrue(scanner.contains("bootstrapAttempt.get() !== attempt"))
         assertTrue(scanner.contains("val remainingMs = (deadline - System.currentTimeMillis())"))
-        assertTrue(scanner.contains("findCompanionOnAnySubnet(manualIp, remainingMs)"))
+        assertTrue(scanner.contains("findCompanionOnAnySubnet("))
+        assertTrue(scanner.contains("phoneBtAddress = attempt.phoneBtAddress"))
+        assertTrue(scanner.contains("phoneBtName = attempt.phoneBtName"))
         assertTrue(scanner.contains("WppBootstrapPolicy.DISCOVERY_DEADLINE_MS"))
-        assertTrue(scanner.contains("readvertiseForNewCompanionAddress(ip, proxyPort, attempt)"))
+        assertTrue(scanner.contains("reportedPhoneId = probe.phoneId"))
     }
 
     @Test
@@ -170,8 +174,9 @@ class WppBootstrapPolicyTest {
             "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
         ).readText()
 
-        assertTrue(source.contains("publishPhoneAddress(ip, ident.wppProxyPort)"))
-        assertTrue(source.contains("readvertiseForNewCompanionAddress(host, reportedProxyPort)"))
+        assertTrue(source.contains("reportedProxyPort = ident.wppProxyPort"))
+        assertTrue(source.contains("phoneId = ident.phoneId"))
+        assertTrue(source.contains("reportedPhoneId = phoneId"))
     }
 
     private fun projectFile(path: String): File {

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -399,7 +399,15 @@ fun MainScreen(
                 text = "ID: $phoneIdShort  (auto-generated, used by the car app to remember this phone)",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(vertical = 4.dp),
+                modifier = Modifier.padding(top = 4.dp),
+            )
+            Text(
+                text = "Multiple phones: give every phone a unique Bluetooth device name, " +
+                    "then set this Friendly name to exactly match that Bluetooth name. " +
+                    "The car uses the match only to learn this phone's stable ID.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
             )
 
             Spacer(Modifier.height(20.dp))


### PR DESCRIPTION
## Summary
- correlate each WPP Bluetooth owner with companion probe identity before accepting an endpoint
- reject reachable companions whose identity belongs to a different phone
- learn BT-MAC → stable companion `phone_id` after the configured Bluetooth/friendly-name match
- apply identity gating to cached probes, subnet scans, and late bootstrap discovery before caching or dialing
- generation-fence concurrent phone claims so a slower superseded probe cannot dial after a newer phone takes ownership
- prevent WPP cold-start/retry from using the unowned global discovery cache; only an identity-validated address bound to the active Bluetooth phone may be re-dialed
- document the required unique Bluetooth names for multi-phone setups in the companion UI and README

## Incident evidence
On car 0.1.447 at 20:31, Liz's Bluetooth MAC first selected Lance's reachable companion address. The car connected TCP to Lance while Liz's proxy waited without a car socket. The probe response already contained `phone_id` and friendly name, but the car discarded both and accepted only `wpp=5280`.

## Verification
- strict RED before production implementation: missing `CompanionIdentityPolicy` and missing endpoint integration
- focused identity/bootstrap tests: 18 passed
- full car tests: 332 passed, 0 failures/errors
- full companion tests: 57 passed, 0 failures/errors
- car + companion release Kotlin compilation: successful
- lint: car 89/89 and companion 15/15 diagnostics identical to `origin/main`; zero new findings
- added-line security scan: clean

## Runtime status
This is a release attempt pending an in-car two-phone capture. Positive proof is a Liz Bluetooth dial-back followed by `Rejected companion ... name=Lance...`, then `Identity-matched companion ... name=Liz...`, the correct TCP target, native session start, first rendered frame, and sustained `vflow` without Save & Reconnect.

## Integration base
This PR targets `feat/experimental-gal6` so the identity fix layers onto and preserves the already-deployed 0.1.448 GAL 6/native diagnostics. Lance explicitly approved merging the combined work into `main`.
