### PR TITLE
fix(ev): replay energy model after reconnect

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -195,6 +195,7 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
         LOGW("Session already streaming, ignoring start()");
         return;
     }
+    energyModelDiagMask_ = 0;
 
     // Create global refs
     callbackRef_ = env->NewGlobalRef(callback);
@@ -583,6 +584,17 @@ void JniSession::nativeDiag(int level, const char* tag, const std::string& msg)
         env->DeleteLocalRef(jmsg);
     }
     releaseEnv(attached);
+}
+
+void JniSession::logEnergyModelDiagOnce(
+    uint32_t outcomeBit, int level, const std::string& msg)
+{
+    // Called only from the io_service strand. stop() joins that thread before
+    // deleting callbackRef_, so checking/using the JNI callback is safe here.
+    if (!cbMethods_.onNativeLog || !callbackRef_) return;
+    const uint32_t previous = energyModelDiagMask_.fetch_or(
+        outcomeBit, std::memory_order_relaxed);
+    if ((previous & outcomeBit) == 0) nativeDiag(level, "vem", msg);
 }
 
 void JniSession::reportGal6StartEnvelope(
@@ -2098,7 +2110,7 @@ void JniSession::sendEnergyModelSensor(int batteryLevelWh, int batteryCapacityWh
     float reservePctOverride, int maxChargeWOverride, int maxDischargeWOverride)
 {
     if (!streaming_ || !sensorChannel_) return;
-    // Guard: skip if values are invalid (matches bridge-mode logic)
+    // Guard: skip if values are invalid (matches bridge-mode logic).
     if (batteryCapacityWh <= 0 || batteryLevelWh <= 0 || rangeM <= 0) return;
 
     ioService_->post([this, batteryLevelWh, batteryCapacityWh, rangeM, chargeRateW,
@@ -2152,6 +2164,12 @@ void JniSession::sendEnergyModelSensor(int batteryLevelWh, int batteryCapacityWh
         auto promise = aasdk::channel::SendPromise::defer(*strand_);
         promise->then([]() {}, [](const auto&) {});
         sensorChannel_->sendSensorEventIndication(batch, std::move(promise));
+        logEnergyModelDiagOnce(1u << 0, 1,
+            "sendEnergyModel queued: level=" +
+            std::to_string(batteryLevelWh) + " cap=" +
+            std::to_string(batteryCapacityWh) + " range=" +
+            std::to_string(rangeM) + " charge=" +
+            std::to_string(chargeRateW));
     });
 }
 

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -235,6 +235,7 @@ private:
     // log that gets uploaded). level: 0=d 1=i 2=w 3=e. Safe to call from the io
     // thread; no-op if the callback isn't wired yet.
     void nativeDiag(int level, const char* tag, const std::string& msg);
+    void logEnergyModelDiagOnce(uint32_t outcomeBit, int level, const std::string& msg);
 
     JavaVM* jvm_;
     jobject callbackRef_ = nullptr;
@@ -295,6 +296,7 @@ private:
     std::atomic<int> requestedGalMajor_{1};
     std::atomic<int> requestedGalMinor_{7};
     std::atomic<uint64_t> gal6EnvelopeSequence_{0};
+    std::atomic<uint32_t> energyModelDiagMask_{0};
 
     // Current video focus state for the main display.
     // 1 = VIDEO_FOCUS_PROJECTED (default — we always project on AAOS).

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -84,6 +84,7 @@ class SessionManager(
         private const val SENSOR_TYPE_GEAR = 8
         private const val SENSOR_TYPE_NIGHT_MODE = 10
         private const val SENSOR_TYPE_DRIVING_STATUS = 13
+        private const val SENSOR_TYPE_VEHICLE_ENERGY_MODEL = 23
 
         // Activity-sourced UI-mode snapshot that can be published before
         // SessionManager exists (ViewModel lazy creation path).
@@ -768,6 +769,72 @@ class SessionManager(
         }
     }
 
+    @Synchronized
+    private fun ensureVehicleDataForwarder(): VehicleDataForwarder? {
+        _vehicleDataForwarder?.let { return it }
+        val ctx = context ?: return null
+        return VehicleDataForwarderImpl(
+            ctx,
+            sendMessage = ::forwardVehicleData,
+            onIgnitionOn = { /* aasdk mode doesn't need ignition-based reconnect */ },
+        ).also { _vehicleDataForwarder = it }
+    }
+
+    private fun forwardVehicleData(vd: ControlMessage.VehicleData) {
+        val session = aasdkSession ?: return
+        vd.speedKmh?.let { session.sendSpeed((it / 3.6f * 1000).toInt()) }
+        // Edge-trigger low-cadence properties so each transition fires once.
+        vd.gearRaw?.let {
+            if (lastSentGearRaw != it) { lastSentGearRaw = it; session.sendGear(it) }
+        }
+        vd.parkingBrake?.let {
+            if (lastSentParkingBrake != it) { lastSentParkingBrake = it; session.sendParkingBrake(it) }
+        }
+        vd.nightMode?.let {
+            if (lastSentNightMode != it) { lastSentNightMode = it; session.sendNightMode(it) }
+        }
+        vd.driving?.let {
+            val driving = if (alwaysInPark) false else it
+            if (lastSentDriving != driving) {
+                lastSentDriving = driving
+                session.sendDrivingStatus(driving)
+            }
+        }
+        if (vd.fuelLevelPct != null || vd.rangeKm != null) {
+            session.sendFuel(
+                vd.fuelLevelPct ?: 0,
+                ((vd.rangeKm ?: 0f) * 1000).toInt(),
+                vd.lowFuel ?: false,
+            )
+        }
+        vd.rpmE3?.let { session.sendRpm(it) }
+        if (vd.evBatteryLevelWh != null || vd.evBatteryCapacityWh != null) {
+            val batteryWh = vd.evBatteryLevelWh?.toInt() ?: 0
+            val capacityWh = vd.evBatteryCapacityWh?.toInt() ?: 0
+            val rangeM = ((vd.rangeKm ?: 0f) * 1000).toInt()
+            val chargeW = vd.evChargeRateW?.toInt() ?: 0
+            val now = SystemClock.elapsedRealtime()
+            evLearnedEstimator?.onVehicleTick(vd, now)
+            refreshEvProfileLookup(vd)
+            val movedBattery = kotlin.math.abs(batteryWh - lastVemBatteryWh) >= 100
+            val movedRange = kotlin.math.abs(rangeM - lastVemRangeM) >= 500
+            val movedCharge = kotlin.math.abs(chargeW - lastVemChargeW) >= 100
+            val firstEmit = lastVemLogMs == 0L
+            val staleEnough = (now - lastVemLogMs) >= VEM_LOG_MIN_GAP_MS
+            if (firstEmit || movedBattery || movedRange || movedCharge || staleEnough) {
+                DiagnosticLog.i(
+                    "vem",
+                    "sendEnergyModel: level=${batteryWh}Wh cap=${capacityWh}Wh range=${rangeM}m charge=${chargeW}W${evTuningSummary(batteryWh, rangeM)}",
+                )
+                lastVemLogMs = now
+                lastVemBatteryWh = batteryWh
+                lastVemRangeM = rangeM
+                lastVemChargeW = chargeW
+            }
+            sendEnergyModelWithTuning(session, batteryWh, capacityWh, rangeM, chargeW)
+        }
+    }
+
     /**
      * The phone subscribed to a sensor type. Push current vehicle state now.
      *
@@ -780,6 +847,10 @@ class SessionManager(
      * recorded as sent, which would otherwise suppress this re-push. Issue #61.
      */
     private fun onPhoneSubscribedSensor(sensorType: Int) {
+        if (sensorType == SENSOR_TYPE_VEHICLE_ENERGY_MODEL) {
+            sendCurrentEnergyModel("sensor-subscribe")
+            return
+        }
         val session = aasdkSession ?: return
         val vd = _vehicleDataForwarder?.latestVehicleData?.value
         resetLatchedVehicleSensorState("sensor_subscribe_$sensorType")
@@ -943,81 +1014,13 @@ class SessionManager(
 
         // Create vehicle data forwarder -- sends via AasdkSession
         _vehicleDataForwarder?.stop()
+        _vehicleDataForwarder = null
         // Reset edge-trigger memory so the first tick of the new session
         // unconditionally publishes nightMode / parking / driving / gear to
         // the phone — the phone has no prior state from us.
         resetLatchedVehicleSensorState("start_session")
         observeAlwaysInPark()
-        _vehicleDataForwarder = context?.let { ctx ->
-            VehicleDataForwarderImpl(
-                ctx,
-                sendMessage = { vd ->
-                    val session = aasdkSession ?: return@VehicleDataForwarderImpl
-                    vd.speedKmh?.let { session.sendSpeed((it / 3.6f * 1000).toInt()) }
-                    // Edge-trigger the low-cadence properties so each
-                    // transition fires the phone exactly once. Spamming
-                    // nightMode 10×/s while it's steady-state may have
-                    // contributed to issue #6 (day/night theme transition →
-                    // black video). Same defense for the others — cheap and
-                    // strictly correct.
-                    vd.gearRaw?.let {
-                        if (lastSentGearRaw != it) { lastSentGearRaw = it; session.sendGear(it) }
-                    }
-                    vd.parkingBrake?.let {
-                        if (lastSentParkingBrake != it) { lastSentParkingBrake = it; session.sendParkingBrake(it) }
-                    }
-                    vd.nightMode?.let {
-                        if (lastSentNightMode != it) { lastSentNightMode = it; session.sendNightMode(it) }
-                    }
-                    vd.driving?.let {
-                        val drv = if (alwaysInPark) false else it
-                        if (lastSentDriving != drv) { lastSentDriving = drv; session.sendDrivingStatus(drv) }
-                    }
-                    if (vd.fuelLevelPct != null || vd.rangeKm != null) {
-                        session.sendFuel(
-                            vd.fuelLevelPct ?: 0,
-                            ((vd.rangeKm ?: 0f) * 1000).toInt(),
-                            vd.lowFuel ?: false
-                        )
-                    }
-                    vd.rpmE3?.let { session.sendRpm(it) }
-                    if (vd.evBatteryLevelWh != null || vd.evBatteryCapacityWh != null) {
-                        val batteryWh = vd.evBatteryLevelWh?.toInt() ?: 0
-                        val capacityWh = vd.evBatteryCapacityWh?.toInt() ?: 0
-                        val rangeM = ((vd.rangeKm ?: 0f) * 1000).toInt()
-                        val chargeW = vd.evChargeRateW?.toInt() ?: 0
-                        val now = SystemClock.elapsedRealtime()
-                        // Feed the learned-rate estimator before VEM send so
-                        // the override (if learned mode is selected) reflects
-                        // the latest tick.
-                        evLearnedEstimator?.onVehicleTick(vd, now)
-                        // Refresh the EPA / curated profile match. Cheap —
-                        // early-outs when carMake/Model/Year haven't changed.
-                        refreshEvProfileLookup(vd)
-                        // Suppress identical / near-identical emits — log only
-                        // when a value moved meaningfully or [VEM_LOG_MIN_GAP_MS]
-                        // elapsed. First emit always logs.
-                        val movedBattery = kotlin.math.abs(batteryWh - lastVemBatteryWh) >= 100
-                        val movedRange = kotlin.math.abs(rangeM - lastVemRangeM) >= 500
-                        val movedCharge = kotlin.math.abs(chargeW - lastVemChargeW) >= 100
-                        val firstEmit = lastVemLogMs == 0L
-                        val staleEnough = (now - lastVemLogMs) >= VEM_LOG_MIN_GAP_MS
-                        if (firstEmit || movedBattery || movedRange || movedCharge || staleEnough) {
-                            DiagnosticLog.i(
-                                "vem",
-                                "sendEnergyModel: level=${batteryWh}Wh cap=${capacityWh}Wh range=${rangeM}m charge=${chargeW}W${evTuningSummary(batteryWh, rangeM)}",
-                            )
-                            lastVemLogMs = now
-                            lastVemBatteryWh = batteryWh
-                            lastVemRangeM = rangeM
-                            lastVemChargeW = chargeW
-                        }
-                        sendEnergyModelWithTuning(session, batteryWh, capacityWh, rangeM, chargeW)
-                    }
-                },
-                onIgnitionOn = { /* aasdk mode doesn't need ignition-based reconnect */ }
-            )
-        }
+        ensureVehicleDataForwarder()
 
         // Create IMU forwarder -- sends via AasdkSession
         _imuForwarder?.stop()
@@ -1440,25 +1443,18 @@ class SessionManager(
         session.onNativeSessionStarting = {
             ensureVideoDecoder()
             ensureAudioPlayer()
+            // Re-adopt before restarting any producer: its first refreshed
+            // snapshot must target this replacement session, never a null/stale one.
+            if (aasdkSession !== session) {
+                OalLog.i(TAG, "Re-adopting the session after a transport restart — " +
+                        "without this, touch input and sensor data are silently dropped")
+                aasdkSession = session
+            }
             // Re-subscribe to this session's flows. A transport restart makes a
             // new native session; without this the collectors stay bound to the
             // previous one and its frames go nowhere — silent audio with every
             // upstream signal reporting healthy.
             bindSessionCollectors(session)
-            // Re-adopt the session on every native start.
-            //
-            // stop() nulls aasdkSession, and the recovery path reaches the
-            // transport through dialCompanion() -> startTcp() without re-running
-            // this setup — so after an ignition cycle the field stayed null while
-            // a perfectly good native session ran. Video was fine (frames go
-            // straight from the native callback to the decoder) but every touch
-            // was dropped by `aasdkSession ?: return` in sendControlMessage.
-            // Measured: five native session starts, two full setups.
-            if (aasdkSession !== session) {
-                OalLog.i(TAG, "Re-adopting the session after a transport restart — " +
-                        "without this, touch input is silently dropped")
-                aasdkSession = session
-            }
         }
         com.openautolink.app.transport.bluetooth.AaWirelessBtControl.sessionIsStreaming = {
             sessionState.value == SessionState.STREAMING
@@ -2795,21 +2791,31 @@ class SessionManager(
             " res=${evReservePct}% chg=${evMaxChargeKw}kW]"
     }
 
-    fun forceSendEnergyModel(): Boolean {
-        val session = aasdkSession ?: return false
-        val vd = _vehicleDataForwarder?.latestVehicleData?.value ?: return false
-        if (vd.evBatteryLevelWh == null && vd.evBatteryCapacityWh == null) return false
+    private fun rejectCurrentEnergyModel(reason: String, detail: String): Boolean {
+        DiagnosticLog.w("vem", "sendCurrentEnergyModel[$reason] rejected: $detail")
+        return false
+    }
+
+    private fun sendCurrentEnergyModel(reason: String): Boolean {
+        val session = aasdkSession ?: return rejectCurrentEnergyModel(reason, "no-session")
+        val vd = _vehicleDataForwarder?.latestVehicleData?.value
+            ?: return rejectCurrentEnergyModel(reason, "no-forwarder")
         val batteryWh = vd.evBatteryLevelWh?.toInt() ?: 0
         val capacityWh = vd.evBatteryCapacityWh?.toInt() ?: 0
         val rangeM = ((vd.rangeKm ?: 0f) * 1000).toInt()
+        if (batteryWh <= 0 || capacityWh <= 0 || rangeM <= 0) {
+            return rejectCurrentEnergyModel(reason, "no-ev-snapshot")
+        }
         val chargeW = vd.evChargeRateW?.toInt() ?: 0
         DiagnosticLog.i(
             "vem",
-            "forceSendEnergyModel: level=${batteryWh}Wh cap=${capacityWh}Wh range=${rangeM}m charge=${chargeW}W${evTuningSummary(batteryWh, rangeM)}",
+            "sendCurrentEnergyModel[$reason]: level=${batteryWh}Wh cap=${capacityWh}Wh range=${rangeM}m charge=${chargeW}W${evTuningSummary(batteryWh, rangeM)}",
         )
         sendEnergyModelWithTuning(session, batteryWh, capacityWh, rangeM, chargeW)
         return true
     }
+
+    fun forceSendEnergyModel(): Boolean = sendCurrentEnergyModel("manual")
 
     /** Snapshot of the currently matched EV profile, for the tuning UI. */
     data class EvProfileMatch(

--- a/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
@@ -1,0 +1,130 @@
+package com.openautolink.app.session
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VehicleEnergyReconnectContractTest {
+
+    @Test
+    fun `vehicle energy subscription immediately replays the current model`() {
+        val source = sessionManagerSource()
+        val start = source.indexOf("private fun onPhoneSubscribedSensor(sensorType: Int)")
+        val end = source.indexOf("private fun seedCurrentUiNightMode", startIndex = start)
+
+        assertTrue("Sensor subscription handler must exist", start >= 0)
+        assertTrue("Sensor subscription handler must have a boundary", end > start)
+        assertTrue(
+            "Vehicle energy model sensor type must remain protocol ordinal 23",
+            source.contains("private const val SENSOR_TYPE_VEHICLE_ENERGY_MODEL = 23"),
+        )
+
+        val handler = source.substring(start, end)
+        val energyDispatch = handler.indexOf(
+            "if (sensorType == SENSOR_TYPE_VEHICLE_ENERGY_MODEL)",
+        )
+        val genericSessionGuard = handler.indexOf("val session = aasdkSession ?: return")
+        assertTrue(
+            "Type 23 must enter its diagnostic-aware replay before the generic session guard",
+            energyDispatch >= 0 && energyDispatch < genericSessionGuard,
+        )
+        assertTrue(
+            "Type 23 subscription must actively replay the current VEM",
+            handler.contains("sendCurrentEnergyModel(\"sensor-subscribe\")"),
+        )
+    }
+
+    @Test
+    fun `transport reconnect retains cached vehicle data without resurrecting its owner`() {
+        val source = sessionManagerSource()
+        val start = source.indexOf("session.onNativeSessionStarting = {")
+        val end = source.indexOf("AaWirelessBtControl.sessionIsStreaming", startIndex = start)
+
+        assertTrue("Native restart hook must exist", start >= 0)
+        assertTrue("Native restart hook must have a boundary", end > start)
+        val hook = source.substring(start, end)
+        val adopt = hook.indexOf("aasdkSession = session")
+        val collectors = hook.indexOf("bindSessionCollectors(session)")
+        assertTrue("Native restart must re-adopt its session", adopt >= 0)
+        assertTrue("Native restart must retain collector rebinding", collectors > adopt)
+        assertFalse(
+            "Native-start callbacks must not create/start a VHAL owner that explicit stop can race",
+            hook.contains("ensureVehicleDataForwarder()?.start()"),
+        )
+
+        val reconnect = source.substringAfter("private fun doReconnectAfterCancel(")
+            .substringBefore("fun onSystemWake()")
+        assertTrue("Reconnect must pause VHAL while replacing the protocol session",
+            reconnect.contains("_vehicleDataForwarder?.stop()"))
+        assertFalse(
+            "Reconnect must retain the cached VHAL snapshot for type-23 replay",
+            reconnect.contains("_vehicleDataForwarder = null"),
+        )
+    }
+
+    @Test
+    fun `failed current model replay records the rejected precondition`() {
+        val source = sessionManagerSource()
+        val start = source.indexOf("private fun sendCurrentEnergyModel(reason: String)")
+        val end = source.indexOf("fun forceSendEnergyModel()", startIndex = start)
+
+        assertTrue("Current VEM replay helper must exist", start >= 0)
+        assertTrue("Current VEM replay helper must have a boundary", end > start)
+        val helper = source.substring(start, end)
+        assertTrue(helper.contains("return rejectCurrentEnergyModel(reason, \"no-session\")"))
+        assertTrue(helper.contains("return rejectCurrentEnergyModel(reason, \"no-forwarder\")"))
+        assertTrue(helper.contains("return rejectCurrentEnergyModel(reason, \"no-ev-snapshot\")"))
+        assertTrue(
+            "Rejected replay must be persisted at warning level with provenance",
+            source.contains(
+                "DiagnosticLog.w(\"vem\", \"sendCurrentEnergyModel[${'$'}reason] rejected: ${'$'}detail\")",
+            ),
+        )
+    }
+
+    @Test
+    fun `native energy send reports every guard and successful queue`() {
+        val source = projectFile("app/src/main/cpp/jni_session.cpp").readText()
+        val start = source.indexOf("void JniSession::sendEnergyModelSensor")
+        val end = source.indexOf("void JniSession::sendAccelerometerSensor", startIndex = start)
+
+        assertTrue("Native VEM sender must exist", start >= 0)
+        assertTrue("Native VEM sender must have a boundary", end > start)
+        val sender = source.substring(start, end)
+        val guardPath = sender.substringBefore("ioService_->post(")
+        assertFalse(
+            "Native guard paths run off-strand and must not touch the JNI callback",
+            guardPath.contains("nativeDiag(") || guardPath.contains("logEnergyModelDiagOnce("),
+        )
+        assertTrue(sender.contains("sendEnergyModel queued: level="))
+        assertTrue(
+            "The queued outcome must be logged at most once per native session",
+            sender.contains("logEnergyModelDiagOnce("),
+        )
+        val helper = source.substringAfter("void JniSession::logEnergyModelDiagOnce(")
+            .substringBefore("void JniSession::reportGal6StartEnvelope")
+        assertTrue(
+            "Do not consume the once bit when no safe Kotlin callback exists",
+            helper.indexOf("if (!cbMethods_.onNativeLog || !callbackRef_) return") in
+                0 until helper.indexOf("energyModelDiagMask_.fetch_or"),
+        )
+        val header = projectFile("app/src/main/cpp/jni_session.h").readText()
+        assertTrue(header.contains("std::atomic<uint32_t> energyModelDiagMask_{0}"))
+        val nativeStart = source.substringAfter("void JniSession::start(")
+            .substringBefore("void JniSession::stop()")
+        assertTrue(nativeStart.contains("energyModelDiagMask_ = 0"))
+    }
+
+    private fun sessionManagerSource(): String = projectFile(
+        "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+    ).readText()
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+}


### PR DESCRIPTION
## Summary
- replay the cached Vehicle Energy Model whenever Android Auto subscribes to sensor type 23
- preserve the cached VHAL snapshot across transport reconnects without resurrecting its lifecycle owner
- add bounded native confirmation that a VEM was queued
- add reconnect and lifecycle regression contracts

## Verification
- 350 app unit tests passed; 0 failures/errors
- `:app:externalNativeBuildDebug` passed for both packaged ABIs
- `:app:assembleDebug` passed
- built APK contains the Kotlin replay marker and native queue marker in arm64-v8a and x86_64
- independent pre-commit review passed

## Runtime proof still required
After the Play build reaches the car, the next reconnect capture must show:
`phone subscribed sensor type=23` -> `sendCurrentEnergyModel[sensor-subscribe]` -> `sendEnergyModel queued` and Maps must restore EV battery/range data.
