### PR TITLE
Complete GAL compatibility ladder

### DIFF
--- a/app/src/main/cpp/gal_version_policy.h
+++ b/app/src/main/cpp/gal_version_policy.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+namespace openautolink::jni::gal {
+
+inline bool reportedVersionIsAtLeastRequested(
+    uint16_t reportedMajor,
+    uint16_t reportedMinor,
+    int requestedMajor,
+    int requestedMinor) {
+    return reportedMajor > requestedMajor ||
+        (reportedMajor == requestedMajor && reportedMinor >= requestedMinor);
+}
+
+inline bool versionResponseIsAccepted(
+    bool requireMinimumCompatibleResponse,
+    uint16_t reportedMajor,
+    uint16_t reportedMinor,
+    int requestedMajor,
+    int requestedMinor,
+    int rawStatus,
+    int successStatus) {
+    if (rawStatus != successStatus) return false;
+    return !requireMinimumCompatibleResponse ||
+        reportedVersionIsAtLeastRequested(
+            reportedMajor, reportedMinor, requestedMajor, requestedMinor);
+}
+
+inline int mediaAckSessionId(bool useActiveSessionId, int activeSessionId) {
+    return useActiveSessionId ? activeSessionId : 0;
+}
+
+} // namespace openautolink::jni::gal

--- a/app/src/main/cpp/gal_video_policy.h
+++ b/app/src/main/cpp/gal_video_policy.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <aap_protobuf/service/media/sink/message/VideoConfiguration.pb.h>
+
+namespace openautolink::jni::gal {
+
+template <typename CodecType>
+CodecType selectTopLevelVideoCodec(
+    bool singleVideoCodecFamily,
+    CodecType selectedVideoCodec,
+    CodecType legacyVideoCodec) {
+    return singleVideoCodecFamily ? selectedVideoCodec : legacyVideoCodec;
+}
+
+inline bool applyVideoMarginsAndHiddenUi(
+    aap_protobuf::service::media::sink::message::VideoConfiguration* videoConfig,
+    int widthMargin,
+    int heightMargin,
+    bool modernDisplayPolicy,
+    bool hideClock,
+    bool hideBattery,
+    bool hideSignal) {
+    if (videoConfig == nullptr) return false;
+
+    const bool hasHiddenUi = modernDisplayPolicy &&
+        (hideClock || hideBattery || hideSignal);
+    if (widthMargin > 0 || heightMargin > 0 || hasHiddenUi) {
+        auto* ui = videoConfig->mutable_ui_config();
+        auto* margins = ui->mutable_margins();
+        margins->set_left(widthMargin / 2);
+        margins->set_right((widthMargin + 1) / 2);
+        margins->set_top(heightMargin / 2);
+        margins->set_bottom((heightMargin + 1) / 2);
+    }
+
+    if (hasHiddenUi) {
+        auto* ui = videoConfig->mutable_ui_config();
+        if (hideClock) ui->add_hidden_ui_elements(1);
+        if (hideBattery) ui->add_hidden_ui_elements(2);
+        if (hideSignal) ui->add_hidden_ui_elements(3);
+    }
+    return hasHiddenUi;
+}
+
+} // namespace openautolink::jni::gal

--- a/app/src/main/cpp/jni_channel_handlers.cpp
+++ b/app/src/main/cpp/jni_channel_handlers.cpp
@@ -173,7 +173,7 @@ void JniAudioSinkHandler::onMediaChannelStartIndication(
     logProtoRaw("AudioStart", indication);
     char channelName[32];
     snprintf(channelName, sizeof(channelName), "audio[%d]", static_cast<int>(type_));
-    session_.reportGal6StartEnvelope(channelName, indication);
+    session_.reportGalStartEnvelope(channelName, indication);
     channel_->receive(shared_from_this());
 }
 
@@ -195,7 +195,7 @@ void JniAudioSinkHandler::onMediaWithTimestampIndication(
     // compatibility fallback.
     if (session_.shouldSendAudioAcks()) {
         aap_protobuf::service::media::source::message::Ack ack;
-        ack.set_session_id(session_.mediaAckSessionId(activeSessionId_.load()));
+        ack.set_session_id(session_.audioAckSessionId(activeSessionId_.load()));
         ack.set_ack(1);
         auto promise = aasdk::channel::SendPromise::defer(strand_);
         promise->then([]() {}, [](const auto&) {});
@@ -220,7 +220,7 @@ void JniAudioSinkHandler::onMediaOptions(const aasdk::common::DataConstBuffer& b
 {
     char channelName[32];
     snprintf(channelName, sizeof(channelName), "audio[%d]", static_cast<int>(type_));
-    session_.reportGal6RawEnvelope(channelName, "GAL6 MediaOptions", buffer);
+    session_.reportMediaOptions(channelName, buffer);
 }
 
 void JniAudioSinkHandler::onChannelError(const aasdk::error::Error& e)
@@ -798,7 +798,7 @@ void JniNavStatusHandler::onCurrentPosition(
 void JniNavStatusHandler::onVehicleEnergyForecast(
     const aasdk::common::DataConstBuffer& buffer)
 {
-    session_.reportGal6RawEnvelope("navigation", "GAL6 VehicleEnergyForecast", buffer);
+    session_.reportVehicleEnergyForecast(buffer);
 }
 
 void JniNavStatusHandler::onChannelError(const aasdk::error::Error& e)

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -10,6 +10,8 @@
 #include "jni_session.h"
 #include "jni_transport.h"
 #include "jni_channel_handlers.h"
+#include "gal_video_policy.h"
+#include "gal_version_policy.h"
 
 #include <android/log.h>
 #include <cmath>
@@ -83,6 +85,7 @@ static std::string hexCompact(const uint8_t* data, size_t len) {
     }
     return result;
 }
+
 
 // Log raw bytes + unknown fields for any protobuf message
 template<typename T>
@@ -262,8 +265,6 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     sdrConfig_.gpsForwarding = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "gpsForwarding", "Z"));
     sdrConfig_.autoNegotiate = env->GetBooleanField(sdrConfig, env->GetFieldID(sdrClass, "autoNegotiate", "Z"));
     sdrConfig_.videoCodec = readString("videoCodec");
-    sdrConfig_.experimentalGal6 = env->GetBooleanField(
-        sdrConfig, env->GetFieldID(sdrClass, "experimentalGal6", "Z")) != JNI_FALSE;
     sdrConfig_.requestedGalMajor = env->GetIntField(
         sdrConfig, env->GetFieldID(sdrClass, "requestedGalMajor", "I"));
     sdrConfig_.requestedGalMinor = env->GetIntField(
@@ -272,6 +273,14 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
         sdrConfig, env->GetFieldID(sdrClass, "mediaSetupMaxUnacked", "I"));
     sdrConfig_.sendAudioAcks = env->GetBooleanField(
         sdrConfig, env->GetFieldID(sdrClass, "sendAudioAcks", "Z")) != JNI_FALSE;
+    sdrConfig_.requireMinimumCompatibleResponse = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "requireMinimumCompatibleResponse", "Z")) != JNI_FALSE;
+    sdrConfig_.modernDisplayPolicy = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "modernDisplayPolicy", "Z")) != JNI_FALSE;
+    sdrConfig_.singleVideoCodecFamily = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "singleVideoCodecFamily", "Z")) != JNI_FALSE;
+    sdrConfig_.useActiveMediaSessionIds = env->GetBooleanField(
+        sdrConfig, env->GetFieldID(sdrClass, "useActiveMediaSessionIds", "Z")) != JNI_FALSE;
     sdrConfig_.hevcKeyframeIntervalSeconds = env->GetIntField(
         sdrConfig, env->GetFieldID(sdrClass, "hevcKeyframeIntervalSeconds", "I"));
     sdrConfig_.realDensity = env->GetIntField(sdrConfig, env->GetFieldID(sdrClass, "realDensity", "I"));
@@ -307,15 +316,19 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     requestedGalMajor_.store(requestedMajor);
     requestedGalMinor_.store(requestedMinor);
     const int expectedGop = expectedHevcGopFrames();
-    LOGI("GAL policy: requested=%d.%d experimental=%d maxUnacked=%d "
-         "audioAcks=%d expectedHevcGopFrames=%d",
-         requestedMajor, requestedMinor, sdrConfig_.experimentalGal6 ? 1 : 0,
-         mediaSetupMaxUnacked(), shouldSendAudioAcks() ? 1 : 0, expectedGop);
-    nativeDiag(1, "gal6", "GAL policy: requested=" + std::to_string(requestedMajor) +
+    LOGI("GAL policy: requested=%d.%d modernDisplay=%d singleCodec=%d maxUnacked=%d "
+         "audioAcks=%d activeSessionIds=%d expectedHevcGopFrames=%d",
+         requestedMajor, requestedMinor, sdrConfig_.modernDisplayPolicy ? 1 : 0,
+         sdrConfig_.singleVideoCodecFamily ? 1 : 0, mediaSetupMaxUnacked(),
+         shouldSendAudioAcks() ? 1 : 0, sdrConfig_.useActiveMediaSessionIds ? 1 : 0,
+         expectedGop);
+    nativeDiag(1, "gal", "GAL policy: requested=" + std::to_string(requestedMajor) +
                "." + std::to_string(requestedMinor) +
-               " experimental=" + (sdrConfig_.experimentalGal6 ? "true" : "false") +
+               " modernDisplay=" + (sdrConfig_.modernDisplayPolicy ? "true" : "false") +
+               " singleCodec=" + (sdrConfig_.singleVideoCodecFamily ? "true" : "false") +
                " maxUnacked=" + std::to_string(mediaSetupMaxUnacked()) +
                " audioAcks=" + (shouldSendAudioAcks() ? "true" : "false") +
+               " activeSessionIds=" + (sdrConfig_.useActiveMediaSessionIds ? "true" : "false") +
                " expectedHevcGopFrames=" + std::to_string(expectedGop));
 
     LOGI("Starting session: video=%dx%d@%dfps dpi=%d realDpi=%d pixelAspect=%d marginW=%d marginH=%d viewDistMm=%d decAddDepth=%d autoNeg=%d codec=%s targetLayoutDp=%d",
@@ -597,17 +610,17 @@ void JniSession::logEnergyModelDiagOnce(
     if ((previous & outcomeBit) == 0) nativeDiag(level, "vem", msg);
 }
 
-void JniSession::reportGal6StartEnvelope(
+void JniSession::reportGalStartEnvelope(
     const char* channel,
     const aap_protobuf::service::media::shared::message::Start& indication)
 {
-    if (!sdrConfig_.experimentalGal6) return;
+    if (!sdrConfig_.modernDisplayPolicy) return;
     const int unknownCount = indication.unknown_fields().field_count();
     const auto bytes = indication.ByteSizeLong();
     const int sessionType = indication.has_session_type() ? indication.session_type() : -1;
     const size_t mediaConfigBytes = indication.has_media_config()
         ? indication.media_config().size() : 0;
-    const std::string msg = "GAL6 " + std::string(channel) +
+    const std::string msg = "GAL " + std::string(channel) +
         " Start envelope: session=" + std::to_string(indication.session_id()) +
         " config_idx=" + std::to_string(indication.configuration_index()) +
         " session_type=" + std::to_string(sessionType) +
@@ -615,44 +628,93 @@ void JniSession::reportGal6StartEnvelope(
         " bytes=" + std::to_string(bytes) +
         " unknown_fields=" + std::to_string(unknownCount);
     LOGI("%s", msg.c_str());
-    nativeDiag(1, "gal6", msg);
+    nativeDiag(1, "gal", msg);
+
+    if (indication.has_media_config()) {
+        aap_protobuf::service::media::shared::message::MediaConfig config;
+        if (config.ParseFromString(indication.media_config())) {
+            nativeDiag(1, "gal", "MediaConfig typed channel=" +
+                std::string(channel) + " summary=" +
+                config.ShortDebugString().substr(0, 300));
+        } else {
+            nativeDiag(2, "gal", "MediaConfig typed parse_failed channel=" +
+                std::string(channel) + " bytes=" +
+                std::to_string(indication.media_config().size()));
+        }
+    }
 
     std::string raw;
     indication.SerializeToString(&raw);
-    reportGal6Payload(channel, "Start",
+    reportGalPayload(channel, "Start",
         reinterpret_cast<const uint8_t*>(raw.data()), raw.size());
 }
 
-void JniSession::reportGal6RawEnvelope(
+void JniSession::reportGalRawEnvelope(
     const char* channel,
     const char* envelope,
     const aasdk::common::DataConstBuffer& buffer)
 {
-    reportGal6Payload(channel, envelope, buffer.cdata, buffer.size);
+    reportGalPayload(channel, envelope, buffer.cdata, buffer.size);
 }
 
-void JniSession::reportGal6Payload(
+void JniSession::reportMediaOptions(
+    const char* channel,
+    const aasdk::common::DataConstBuffer& buffer)
+{
+    aap_protobuf::service::media::shared::message::MediaOptions options;
+    if (options.ParseFromArray(buffer.cdata, static_cast<int>(buffer.size))) {
+        nativeDiag(1, "gal", "MediaOptions typed channel=" +
+            std::string(channel) + " summary=" +
+            options.ShortDebugString().substr(0, 300));
+    } else {
+        nativeDiag(2, "gal", "MediaOptions typed parse_failed channel=" +
+            std::string(channel) + " bytes=" + std::to_string(buffer.size));
+    }
+    reportGalRawEnvelope(channel, "MediaOptions", buffer);
+}
+
+void JniSession::reportVehicleEnergyForecast(
+    const aasdk::common::DataConstBuffer& buffer)
+{
+    aap_protobuf::service::navigationstatus::VehicleEnergyForecastMessage outer;
+    if (outer.ParseFromArray(buffer.cdata, static_cast<int>(buffer.size))) {
+        std::string summary = outer.ShortDebugString();
+        bool innerParsed = false;
+        if (outer.has_vehicle_energy_forecast()) {
+            aap_protobuf::service::navigationstatus::VehicleEnergyForecast inner;
+            innerParsed = inner.ParseFromString(outer.vehicle_energy_forecast());
+            if (innerParsed) summary = inner.ShortDebugString();
+        }
+        nativeDiag(1, "gal", "VehicleEnergyForecast typed inner_parsed=" +
+            std::string(innerParsed ? "true" : "false") + " summary=" +
+            summary.substr(0, 300));
+    } else {
+        nativeDiag(2, "gal", "VehicleEnergyForecast typed parse_failed bytes=" +
+            std::to_string(buffer.size));
+    }
+    reportGalRawEnvelope("navigation", "VehicleEnergyForecast", buffer);
+}
+
+void JniSession::reportGalPayload(
     const char* channel,
     const char* envelope,
     const uint8_t* data,
     size_t size)
 {
-    if (!sdrConfig_.experimentalGal6) return;
-
     // DiagnosticLog truncates messages at 500 characters. Compact-hex chunks
     // preserve the complete opaque payload in uploaded logs for later decoding.
-    static constexpr size_t GAL6_PAYLOAD_CHUNK_BYTES = 128;
-    const uint64_t id = gal6EnvelopeSequence_.fetch_add(1) + 1;
+    static constexpr size_t GAL_PAYLOAD_CHUNK_BYTES = 128;
+    const uint64_t id = galEnvelopeSequence_.fetch_add(1) + 1;
     const size_t totalChunks = std::max<size_t>(1,
-        (size + GAL6_PAYLOAD_CHUNK_BYTES - 1) / GAL6_PAYLOAD_CHUNK_BYTES);
+        (size + GAL_PAYLOAD_CHUNK_BYTES - 1) / GAL_PAYLOAD_CHUNK_BYTES);
 
     for (size_t chunk = 0; chunk < totalChunks; ++chunk) {
-        const size_t offset = chunk * GAL6_PAYLOAD_CHUNK_BYTES;
+        const size_t offset = chunk * GAL_PAYLOAD_CHUNK_BYTES;
         const size_t chunkBytes = offset < size
-            ? std::min(GAL6_PAYLOAD_CHUNK_BYTES, size - offset) : 0;
+            ? std::min(GAL_PAYLOAD_CHUNK_BYTES, size - offset) : 0;
         const std::string hex = chunkBytes > 0
             ? hexCompact(data + offset, chunkBytes) : std::string();
-        const std::string line = "GAL6 payload id=" + std::to_string(id) +
+        const std::string line = "GAL payload id=" + std::to_string(id) +
             " envelope=" + envelope +
             " channel=" + channel +
             " bytes=" + std::to_string(size) +
@@ -662,9 +724,9 @@ void JniSession::reportGal6Payload(
             " hex=" + hex;
         if (line.size() <= 500) {
             LOGI("%s", line.c_str());
-            nativeDiag(1, "gal6", line);
+            nativeDiag(1, "gal", line);
         } else {
-            nativeDiag(3, "gal6", "GAL6 payload chunk formatting overflow id=" +
+            nativeDiag(3, "gal", "GAL payload chunk formatting overflow id=" +
                 std::to_string(id));
         }
     }
@@ -686,25 +748,50 @@ void JniSession::notifySensorSubscribed(int sensorType)
 // IControlServiceChannelEventHandler — AA handshake + session control
 // ============================================================================
 
+void JniSession::onVersionResponseMalformed(size_t payloadSize)
+{
+    const std::string reason = "GAL version response malformed: bytes=" +
+        std::to_string(payloadSize) + " required=6";
+    nativeDiag(3, "gal", reason);
+    triggerAbort(reason);
+}
+
 void JniSession::onVersionResponse(uint16_t majorCode, uint16_t minorCode,
                                     aap_protobuf::shared::MessageStatus status)
 {
-    LOGI("Version response: %d.%d status=%d (requested=%d.%d experimental=%d)",
-         majorCode, minorCode, static_cast<int>(status),
-         requestedGalMajor_.load(), requestedGalMinor_.load(),
-         sdrConfig_.experimentalGal6 ? 1 : 0);
-    nativeDiag(1, "gal6", "GAL negotiated: requested=" +
+    onVersionResponse(majorCode, minorCode, status, aasdk::common::DataConstBuffer());
+}
+
+void JniSession::onVersionResponse(uint16_t majorCode, uint16_t minorCode,
+                                    aap_protobuf::shared::MessageStatus status,
+                                    const aasdk::common::DataConstBuffer& trailingBytes)
+{
+    LOGI("Version response: %d.%d status=%d trailing=%zu (requested=%d.%d)",
+         majorCode, minorCode, static_cast<int>(status), trailingBytes.size,
+         requestedGalMajor_.load(), requestedGalMinor_.load());
+    nativeDiag(1, "gal", "GAL negotiated: requested=" +
                std::to_string(requestedGalMajor_.load()) + "." +
                std::to_string(requestedGalMinor_.load()) + " response=" +
                std::to_string(majorCode) + "." + std::to_string(minorCode) +
-               " status=" + std::to_string(static_cast<int>(status)));
+               " status=" + std::to_string(static_cast<int>(status)) +
+               " trailing_bytes=" + std::to_string(trailingBytes.size));
+    if (trailingBytes.size > 0) {
+        reportGalPayload("control", "VersionResponseTrailing",
+            trailingBytes.cdata, trailingBytes.size);
+    }
 
-    if (status != aap_protobuf::shared::STATUS_SUCCESS) {
+    if (!gal::versionResponseIsAccepted(
+            sdrConfig_.requireMinimumCompatibleResponse,
+            majorCode, minorCode,
+            requestedGalMajor_.load(), requestedGalMinor_.load(),
+            static_cast<int>(status),
+            static_cast<int>(aap_protobuf::shared::STATUS_SUCCESS))) {
         const std::string reason = "GAL version negotiation rejected: requested=" +
             std::to_string(requestedGalMajor_.load()) + "." +
-            std::to_string(requestedGalMinor_.load()) +
+            std::to_string(requestedGalMinor_.load()) + " response=" +
+            std::to_string(majorCode) + "." + std::to_string(minorCode) +
             " status=" + std::to_string(static_cast<int>(status));
-        nativeDiag(3, "gal6", reason);
+        nativeDiag(3, "gal", reason);
         triggerAbort(reason);
         return;
     }
@@ -1142,7 +1229,7 @@ void JniSession::onMediaChannelStartIndication(
     LOGI("Video stream starting: session=%d config_idx=%d",
          indication.session_id(), indication.configuration_index());
     logProtoRaw("VideoStart", indication);
-    reportGal6StartEnvelope("video", indication);
+    reportGalStartEnvelope("video", indication);
     nativeDiag(1, "video", "phone->us VideoStart session=" +
                std::to_string(indication.session_id()) + " config_idx=" +
                std::to_string(indication.configuration_index()) +
@@ -1175,7 +1262,7 @@ void JniSession::onMediaWithTimestampIndication(
 {
     // Hot path Ã¢â‚¬â€ video frame. Send ACK immediately (flow control).
     aap_protobuf::service::media::source::message::Ack ack;
-    ack.set_session_id(mediaAckSessionId(activeVideoSessionId_.load()));
+    ack.set_session_id(videoAckSessionId(activeVideoSessionId_.load()));
     ack.set_ack(1);
     auto promise = aasdk::channel::SendPromise::defer(*strand_);
     promise->then([]() {}, [](const auto&) {});
@@ -1265,7 +1352,7 @@ void JniSession::onMediaIndication(const aasdk::common::DataConstBuffer& buffer)
 
 void JniSession::onMediaOptions(const aasdk::common::DataConstBuffer& buffer)
 {
-    reportGal6RawEnvelope("video", "GAL6 MediaOptions", buffer);
+    reportMediaOptions("video", buffer);
 }
 
 void JniSession::onVideoFocusRequest(
@@ -1460,7 +1547,17 @@ void JniSession::buildServiceDiscoveryResponse(
     { auto* svc = response.add_channels();
       svc->set_id(2); // VIDEO — Java uses 2 (MEDIA_SINK), works with localhost proxy
       auto* ms = svc->mutable_media_sink_service();
-      ms->set_available_type(aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H264_BP);
+      const bool useH265 = (sdrConfig_.videoCodec == "h265" ||
+                            sdrConfig_.videoCodec == "hevc");
+      const auto selectedVideoCodec = useH265
+          ? aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H265
+          : aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H264_BP;
+      const bool singleVideoCodecFamily = sdrConfig_.singleVideoCodecFamily;
+      const auto topLevelVideoCodec = gal::selectTopLevelVideoCodec(
+          singleVideoCodecFamily,
+          selectedVideoCodec,
+          aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H264_BP);
+      ms->set_available_type(topLevelVideoCodec);
       ms->set_available_while_in_call(true);
 
       using VRes = aap_protobuf::service::media::sink::message::VideoCodecResolutionType;
@@ -1537,36 +1634,17 @@ void JniSession::buildServiceDiscoveryResponse(
           }
           if (wm > 0) vc->set_width_margin(wm);
           if (hm > 0) vc->set_height_margin(hm);
-          // Mirror GM: split the margin half/half via UiConfig.margins so
-          // the phone centers its UI inside the inner rect. Without this,
-          // the phone is free to place the entire margin on one side
-          // (observed: bottom-only) which doesn't match our renderer's
-          // centred zoom-and-clip and looks "shifted".
-          if (wm > 0 || hm > 0) {
-              auto* margins = vc->mutable_ui_config()->mutable_margins();
-              if (wm > 0) {
-                  margins->set_left(wm / 2);
-                  margins->set_right((wm + 1) / 2);
-              }
-              if (hm > 0) {
-                  margins->set_top(hm / 2);
-                  margins->set_bottom((hm + 1) / 2);
-              }
-          }
+          // Mirror GM: split total margins between all four field-1 edges.
+          // When hidden UI exists, the helper emits explicit zero edges too.
+          gal::applyVideoMarginsAndHiddenUi(
+              vc, wm, hm,
+              sdrConfig_.modernDisplayPolicy,
+              sdrConfig_.hideClock, sdrConfig_.hideBattery, sdrConfig_.hideSignal);
           if (sdrConfig_.pixelAspectE4 > 0) vc->set_pixel_aspect_ratio_e4(sdrConfig_.pixelAspectE4);
           if (sdrConfig_.realDensity > 0) vc->set_real_density(sdrConfig_.realDensity);
           if (sdrConfig_.viewingDistanceMm > 0) vc->set_viewing_distance(sdrConfig_.viewingDistanceMm);
           if (sdrConfig_.decoderAdditionalDepth > 0) vc->set_decoder_additional_depth(sdrConfig_.decoderAdditionalDepth);
           applySafeArea(vc);
-          // GAL 4.3+ stops deriving these ownership flags from the legacy
-          // ServiceDiscoveryResponse.session_configuration bitmask. Preserve
-          // the existing user choices in the modern UiConfig envelope.
-          if (sdrConfig_.experimentalGal6) {
-              auto* ui = vc->mutable_ui_config();
-              if (sdrConfig_.hideClock) ui->add_hidden_ui_elements(1);
-              if (sdrConfig_.hideBattery) ui->add_hidden_ui_elements(2);
-              if (sdrConfig_.hideSignal) ui->add_hidden_ui_elements(3);
-          }
       };
 
       auto computeDensity = [&](int tier) -> int {
@@ -1592,8 +1670,6 @@ void JniSession::buildServiceDiscoveryResponse(
           //
           // Mirrors GM's GALDisplayManager.getVideoConfigList() which only
           // ever advertises H.264 BP at [1920x1080, 1280x720, 800x480].
-          bool useH265 = (sdrConfig_.videoCodec == "h265" ||
-                          sdrConfig_.videoCodec == "hevc");
           bool portrait = (sdrConfig_.panelWidth > 0 &&
                            sdrConfig_.panelHeight > 0 &&
                            sdrConfig_.panelWidth < sdrConfig_.panelHeight);
@@ -1602,9 +1678,7 @@ void JniSession::buildServiceDiscoveryResponse(
           // needed for 1440p / 4K.
           int tiers[5];
           int tierCount;
-          auto codecType = useH265
-              ? aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H265
-              : aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H264_BP;
+
           if (useH265) {
               if (portrait) {
                   tiers[0] = 9; tiers[1] = 8; tiers[2] = 7; tiers[3] = 6;
@@ -1631,7 +1705,7 @@ void JniSession::buildServiceDiscoveryResponse(
               vc->set_codec_resolution(static_cast<VRes>(t));
               vc->set_frame_rate(fps);
               vc->set_density(computeDensity(t));
-              vc->set_video_codec_type(codecType);
+              vc->set_video_codec_type(selectedVideoCodec);
               applyVideoConfig(vc, t);
           }
           advertisedVideoConfigCount_.store(tierCount);
@@ -1648,14 +1722,11 @@ void JniSession::buildServiceDiscoveryResponse(
                   break;
               }
           }
-          auto codecType = (sdrConfig_.videoCodec == "h264")
-              ? aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H264_BP
-              : aap_protobuf::service::media::shared::message::MEDIA_CODEC_VIDEO_H265;
           auto* vc = ms->add_video_configs();
           vc->set_codec_resolution(static_cast<VRes>(tier));
           vc->set_frame_rate(fps);
           vc->set_density(computeDensity(tier));
-          vc->set_video_codec_type(codecType);
+          vc->set_video_codec_type(selectedVideoCodec);
           applyVideoConfig(vc, tier);
           advertisedVideoConfigCount_.store(1);
       }

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include "gal_version_policy.h"
+
 #include <memory>
 #include <thread>
 #include <atomic>
@@ -53,6 +55,9 @@
 #include <aasdk/Channel/MediaPlaybackStatus/IMediaPlaybackStatusServiceEventHandler.hpp>
 #include <aasdk/Channel/PhoneStatus/PhoneStatusService.hpp>
 #include <aasdk/Channel/PhoneStatus/IPhoneStatusServiceEventHandler.hpp>
+#include <aap_protobuf/service/media/shared/message/MediaConfig.pb.h>
+#include <aap_protobuf/service/media/shared/message/MediaOptions.pb.h>
+#include <aap_protobuf/service/navigationstatus/VehicleEnergyForecast.pb.h>
 
 namespace openautolink::jni {
 
@@ -159,6 +164,10 @@ public:
     // ---- IControlServiceChannelEventHandler ----
     void onVersionResponse(uint16_t majorCode, uint16_t minorCode,
                            aap_protobuf::shared::MessageStatus status) override;
+    void onVersionResponse(uint16_t majorCode, uint16_t minorCode,
+                           aap_protobuf::shared::MessageStatus status,
+                           const aasdk::common::DataConstBuffer& trailingBytes) override;
+    void onVersionResponseMalformed(size_t payloadSize) override;
     void onHandshake(const aasdk::common::DataConstBuffer& payload) override;
     void onServiceDiscoveryRequest(
         const aap_protobuf::service::control::message::ServiceDiscoveryRequest& request) override;
@@ -295,7 +304,7 @@ private:
     std::atomic<int> activeVideoSessionId_{0};
     std::atomic<int> requestedGalMajor_{1};
     std::atomic<int> requestedGalMinor_{7};
-    std::atomic<uint64_t> gal6EnvelopeSequence_{0};
+    std::atomic<uint64_t> galEnvelopeSequence_{0};
     std::atomic<uint32_t> energyModelDiagMask_{0};
 
     // Current video focus state for the main display.
@@ -322,25 +331,33 @@ private:
 
 public:
     bool shouldSendAudioAcks() const { return sdrConfig_.sendAudioAcks; }
-    int mediaAckSessionId(int activeSessionId) const {
-        return sdrConfig_.experimentalGal6 ? activeSessionId : 0;
+    int audioAckSessionId(int activeSessionId) const {
+        return gal::mediaAckSessionId(sdrConfig_.useActiveMediaSessionIds, activeSessionId);
+    }
+    int videoAckSessionId(int activeSessionId) const {
+        return gal::mediaAckSessionId(sdrConfig_.useActiveMediaSessionIds, activeSessionId);
     }
     int mediaSetupMaxUnacked() const { return sdrConfig_.mediaSetupMaxUnacked; }
     int expectedHevcGopFrames() const {
         return sdrConfig_.hevcKeyframeIntervalSeconds * std::max(0, sdrConfig_.videoFps);
     }
-    void reportGal6StartEnvelope(
+    void reportGalStartEnvelope(
         const char* channel,
         const aap_protobuf::service::media::shared::message::Start& indication);
-    void reportGal6RawEnvelope(
+    void reportGalRawEnvelope(
         const char* channel,
         const char* envelope,
         const aasdk::common::DataConstBuffer& buffer);
-    void reportGal6Payload(
+    void reportGalPayload(
         const char* channel,
         const char* envelope,
         const uint8_t* data,
         size_t size);
+    void reportMediaOptions(
+        const char* channel,
+        const aasdk::common::DataConstBuffer& buffer);
+    void reportVehicleEnergyForecast(
+        const aasdk::common::DataConstBuffer& buffer);
 
     /**
      * Centralized channel-error reporting. Called by per-channel handlers.
@@ -388,11 +405,14 @@ private:
         bool gpsForwarding = true;
         bool autoNegotiate = true;
         std::string videoCodec = "h265";
-        bool experimentalGal6 = false;
         int requestedGalMajor = 1;
         int requestedGalMinor = 7;
         int mediaSetupMaxUnacked = 30;
         bool sendAudioAcks = true;
+        bool requireMinimumCompatibleResponse = false;
+        bool modernDisplayPolicy = false;
+        bool singleVideoCodecFamily = false;
+        bool useActiveMediaSessionIds = false;
         int hevcKeyframeIntervalSeconds = 60;
         int realDensity = 0;
         int safeAreaTop = 0;

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.openautolink.app.transport.aasdk.GalProtocolPolicy
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -33,6 +34,8 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val VIDEO_AUTO_NEGOTIATE = booleanPreferencesKey("video_auto_negotiate")
         val VIDEO_CODEC = stringPreferencesKey("video_codec")
         val VIDEO_FPS = intPreferencesKey("video_fps")
+        val GAL_VERSION = stringPreferencesKey("gal_version")
+        /** Retained only to migrate installs that used the former Boolean toggle. */
         val EXPERIMENTAL_GAL6 = booleanPreferencesKey("experimental_gal6")
         val DISPLAY_MODE = stringPreferencesKey("display_mode")
         val MIC_SOURCE = stringPreferencesKey("mic_source")
@@ -249,7 +252,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_VIDEO_AUTO_NEGOTIATE = true
         const val DEFAULT_VIDEO_CODEC = "h264"
         const val DEFAULT_VIDEO_FPS = 60
-        const val DEFAULT_EXPERIMENTAL_GAL6 = false
+        const val DEFAULT_GAL_VERSION = "1.7"
         const val DEFAULT_DISPLAY_MODE = "fullscreen_immersive"
         const val DEFAULT_MIC_SOURCE = "car"
         const val DEFAULT_BT_MAC_OVERRIDE = ""
@@ -393,8 +396,11 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         prefs[VIDEO_FPS] ?: DEFAULT_VIDEO_FPS
     }
 
-    val experimentalGal6: Flow<Boolean> = dataStore.data.map { prefs ->
-        prefs[EXPERIMENTAL_GAL6] ?: DEFAULT_EXPERIMENTAL_GAL6
+    val galVersion: Flow<String> = dataStore.data.map { prefs ->
+        GalProtocolPolicy.resolvePersistedVersion(
+            configuredVersion = prefs[GAL_VERSION],
+            legacyEnabled = prefs[EXPERIMENTAL_GAL6],
+        )
     }
 
     val displayMode: Flow<String> = dataStore.data.map { prefs ->
@@ -728,8 +734,13 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         dataStore.edit { it[VIDEO_FPS] = fps }
     }
 
-    suspend fun setExperimentalGal6(enabled: Boolean) {
-        dataStore.edit { it[EXPERIMENTAL_GAL6] = enabled }
+    suspend fun setGalVersion(version: String) {
+        val safeVersion = version.takeIf { it in GalProtocolPolicy.supportedVersions }
+            ?: DEFAULT_GAL_VERSION
+        dataStore.edit {
+            it[GAL_VERSION] = safeVersion
+            it.remove(EXPERIMENTAL_GAL6)
+        }
     }
 
     suspend fun setDisplayMode(mode: String) {

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -38,7 +38,8 @@ import kotlinx.coroutines.runBlocking
  *   video_auto_negotiate --ez bvalue <bool>    true/false
  *   video_codec         --es svalue <str>      h264, h265
  *   video_fps           --ei value <int>       30, 60
- *   experimental_gal6   --ez bvalue <bool>     request GAL/PDK 6.0 (experimental)
+ *   gal_version         --es svalue <1.7|4.3|5.0|5.1|6.0>
+ *   experimental_gal6   --ez bvalue <bool>     legacy alias for 1.7/6.0
  *   direct_transport    --es svalue <str>      hotspot, usb
  *   drive_side          --es svalue <str>      left, right
  *   manual_ip_enabled   --ez bvalue <bool>     true/false
@@ -111,9 +112,18 @@ class SettingsReceiver : BroadcastReceiver() {
                     val v = intent.getIntExtra("value", -1)
                     if (v > 0) { prefs.setVideoFps(v); log("video_fps=$v") }
                 }
+                "gal_version" -> {
+                    val v = intent.getStringExtra("svalue") ?: return@runBlocking
+                    val safeVersion = com.openautolink.app.transport.aasdk.GalProtocolPolicy
+                        .resolvePersistedVersion(v, null)
+                    prefs.setGalVersion(safeVersion); log("gal_version=$safeVersion")
+                }
+                // Backward-compatible maintainer command for scripts that still
+                // set the former Boolean toggle.
                 "experimental_gal6" -> {
                     val v = intent.getBooleanExtra("bvalue", false)
-                    prefs.setExperimentalGal6(v); log("experimental_gal6=$v")
+                    val version = if (v) "6.0" else "1.7"
+                    prefs.setGalVersion(version); log("gal_version=$version (legacy toggle)")
                 }
                 "direct_transport" -> {
                     val v = intent.getStringExtra("svalue") ?: return@runBlocking
@@ -194,7 +204,7 @@ class SettingsReceiver : BroadcastReceiver() {
                     gpsForwarding = prefs.gpsForwarding.first(),
                     manualIpAddress = if (prefs.manualIpEnabled.first())
                         prefs.manualIpAddress.first().takeIf { it.isNotBlank() } else null,
-                    experimentalGal6 = prefs.experimentalGal6.first(),
+                    galVersion = prefs.galVersion.first(),
                 )
                 OalLog.i("SettingsRcv", "RECONNECT: triggered")
             } catch (e: Exception) {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -928,7 +928,7 @@ class SessionManager(
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
-        experimentalGal6: Boolean = false,
+        galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
     ) {
         // Cache for later reconnects that don't know the resolved IP (e.g.
         // Settings "Save & Reconnect" in Car Hotspot mode).
@@ -1141,7 +1141,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
                 safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding, experimentalGal6)
+                gpsForwarding, galVersion)
         }
 
         // Listen for system sleep so we can gracefully tear down before the
@@ -1165,7 +1165,7 @@ class SessionManager(
         manualIpAddress: String? = null,
         safeAreaTop: Int = 0, safeAreaBottom: Int = 0, safeAreaLeft: Int = 0, safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
-        experimentalGal6: Boolean = false,
+        galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
     ) {
         aasdkSession?.stop()
         _transportMode.value = directTransport
@@ -1410,7 +1410,7 @@ class SessionManager(
             gpsForwarding = gpsForwarding,
             autoNegotiate = videoAutoNegotiate,
             videoCodec = codec,
-            experimentalGal6 = experimentalGal6,
+            galVersion = galVersion,
             // realDensity removed — interferes with pixel_aspect_ratio_e4 on some AA versions
             safeAreaTop = effSafeTop,
             safeAreaBottom = effSafeBottom,
@@ -1727,7 +1727,7 @@ class SessionManager(
         safeAreaLeft: Int = 0,
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
-        experimentalGal6: Boolean = false,
+        galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
     ) {
         // "Save & Reconnect" from Settings doesn't know the resolved Car
         // Hotspot IP — fall back to the last value we successfully used so
@@ -1746,7 +1746,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery,
                 volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                 effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding, experimentalGal6,
+                gpsForwarding, galVersion,
             )
             return
         }
@@ -1828,7 +1828,7 @@ class SessionManager(
                     videoFps, driveSide, hideClock, hideSignal, hideBattery,
                     volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                     effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                    gpsForwarding, experimentalGal6,
+                    gpsForwarding, galVersion,
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
@@ -1855,7 +1855,7 @@ class SessionManager(
         manualIpAddress: String?,
         safeAreaTop: Int, safeAreaBottom: Int, safeAreaLeft: Int, safeAreaRight: Int,
         gpsForwarding: Boolean,
-        experimentalGal6: Boolean,
+        galVersion: String,
     ) {
         observeJob = null
         decoderWatchJob = null
@@ -1917,7 +1917,7 @@ class SessionManager(
                 driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                 manualIpAddress,
                 safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding, experimentalGal6)
+                gpsForwarding, galVersion)
         }
 
         // 9. Re-establish cluster binding — GM Templates Host may have killed

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
@@ -71,8 +71,8 @@ class AasdkSdrConfig(
     /** Video codec preference for manual mode: "h264" or "h265". */
     @JvmField val videoCodec: String = "h265",
 
-    /** Request experimental GAL/PDK 6.0 compatibility instead of legacy 1.7. */
-    @JvmField val experimentalGal6: Boolean = false,
+    /** Raw GAL/PDK version requested from the phone. */
+    @JvmField val galVersion: String = "1.7",
 
     /** Physical pixel density of the AAOS display (from DisplayMetrics.densityDpi). */
     @JvmField val realDensity: Int = 0,
@@ -125,12 +125,16 @@ class AasdkSdrConfig(
     @JvmField val panelWidth: Int = 0,
     @JvmField val panelHeight: Int = 0,
 ) {
-    private val galPolicy = GalProtocolPolicy.forExperimentalGal6(experimentalGal6)
+    private val galPolicy = GalProtocolPolicy.forVersion(galVersion)
 
     /** Materialized policy fields consumed directly by JNI; do not re-derive natively. */
     @JvmField val requestedGalMajor: Int = galPolicy.requestedVersion.major
     @JvmField val requestedGalMinor: Int = galPolicy.requestedVersion.minor
     @JvmField val mediaSetupMaxUnacked: Int = galPolicy.maxUnacked
     @JvmField val sendAudioAcks: Boolean = galPolicy.sendAudioAcks
+    @JvmField val requireMinimumCompatibleResponse: Boolean = galPolicy.requireMinimumCompatibleResponse
+    @JvmField val modernDisplayPolicy: Boolean = galPolicy.modernDisplayPolicy
+    @JvmField val singleVideoCodecFamily: Boolean = galPolicy.singleVideoCodecFamily
+    @JvmField val useActiveMediaSessionIds: Boolean = galPolicy.useActiveMediaSessionIds
     @JvmField val hevcKeyframeIntervalSeconds: Int = galPolicy.hevcKeyframeIntervalSeconds
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
@@ -1,53 +1,61 @@
 package com.openautolink.app.transport.aasdk
 
 /** Raw GAL protocol version requested by the head unit before TLS. */
-data class GalProtocolVersion(val major: Int, val minor: Int)
+data class GalProtocolVersion(val major: Int, val minor: Int) : Comparable<GalProtocolVersion> {
+    override fun compareTo(other: GalProtocolVersion): Int =
+        compareValuesBy(this, other, GalProtocolVersion::major, GalProtocolVersion::minor)
 
-/**
- * Behavior selected by the experimental GAL 6 compatibility toggle.
- *
- * GAL 6.0 is not just a version label: Gearhead switches audio to ackless,
- * enriches AV start envelopes, and selects the HEVC encoder's short (2-second)
- * keyframe interval. The setup window remains OAL's proven value of 30.
- */
+    override fun toString(): String = "$major.$minor"
+}
+
+/** Cumulative behavior selected solely from the raw HU-requested GAL version. */
 data class GalProtocolConfig(
     val requestedVersion: GalProtocolVersion,
     val maxUnacked: Int,
+    val requireMinimumCompatibleResponse: Boolean,
+    val modernDisplayPolicy: Boolean,
     val sendAudioAcks: Boolean,
+    val singleVideoCodecFamily: Boolean,
+    val useActiveMediaSessionIds: Boolean,
     val hevcKeyframeIntervalSeconds: Int,
 )
 
 object GalProtocolPolicy {
-    private const val LEGACY_KEYFRAME_INTERVAL_SECONDS = 60
-    private const val GAL6_KEYFRAME_INTERVAL_SECONDS = 2
+    private val GAL_1_7 = GalProtocolVersion(1, 7)
+    private val GAL_4_3 = GalProtocolVersion(4, 3)
+    private val GAL_5_0 = GalProtocolVersion(5, 0)
+    private val GAL_5_1 = GalProtocolVersion(5, 1)
+    private val GAL_6_0 = GalProtocolVersion(6, 0)
 
-    fun forExperimentalGal6(enabled: Boolean): GalProtocolConfig =
-        if (enabled) {
-            GalProtocolConfig(
-                requestedVersion = GalProtocolVersion(6, 0),
-                // The audited GAL gates require only a positive setup value;
-                // ackless audio does not consume this as per-buffer credit.
-                maxUnacked = 30,
-                sendAudioAcks = false,
-                hevcKeyframeIntervalSeconds = GAL6_KEYFRAME_INTERVAL_SECONDS,
-            )
-        } else {
-            GalProtocolConfig(
-                requestedVersion = GalProtocolVersion(1, 7),
-                maxUnacked = 30,
-                sendAudioAcks = true,
-                hevcKeyframeIntervalSeconds = LEGACY_KEYFRAME_INTERVAL_SECONDS,
-            )
+    val supportedVersions: List<String> = listOf(GAL_1_7, GAL_4_3, GAL_5_0, GAL_5_1, GAL_6_0)
+        .map(GalProtocolVersion::toString)
+
+    private val versionsByName = supportedVersions.zip(
+        listOf(GAL_1_7, GAL_4_3, GAL_5_0, GAL_5_1, GAL_6_0),
+    ).toMap()
+
+    fun forVersion(configuredVersion: String): GalProtocolConfig {
+        val requested = versionsByName[configuredVersion] ?: GAL_1_7
+        return GalProtocolConfig(
+            requestedVersion = requested,
+            maxUnacked = 30,
+            requireMinimumCompatibleResponse = requested >= GAL_4_3,
+            modernDisplayPolicy = requested >= GAL_4_3,
+            sendAudioAcks = requested < GAL_5_0,
+            singleVideoCodecFamily = requested >= GAL_5_0,
+            useActiveMediaSessionIds = requested >= GAL_4_3,
+            hevcKeyframeIntervalSeconds = if (requested >= GAL_6_0) 2 else 60,
+        )
+    }
+
+    /** Resolve the new string setting with a one-way fallback to the former Boolean. */
+    fun resolvePersistedVersion(configuredVersion: String?, legacyEnabled: Boolean?): String =
+        when {
+            configuredVersion in supportedVersions -> configuredVersion!!
+            legacyEnabled == true -> "6.0"
+            else -> "1.7"
         }
 
-    /**
-     * Expected OMX HEVC GOP frame count.
-     *
-     * AOSP converts I-frame seconds to frames using configured fps. This is a
-     * diagnostic prediction, not a guarantee for every vendor encoder.
-     */
-    fun expectedHevcGopFrames(experimentalGal6: Boolean, advertisedFps: Int): Int {
-        return forExperimentalGal6(experimentalGal6).hevcKeyframeIntervalSeconds *
-            advertisedFps.coerceAtLeast(0)
-    }
+    fun expectedHevcGopFrames(configuredVersion: String, advertisedFps: Int): Int =
+        forVersion(configuredVersion).hevcKeyframeIntervalSeconds * advertisedFps.coerceAtLeast(0)
 }

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -590,7 +590,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             val aaDecAddDepth = preferences.aaDecoderAdditionalDepth.first()
             val aaAutoM = preferences.aaAutoMargins.first()
             val videoFps = preferences.videoFps.first()
-            val experimentalGal6 = preferences.experimentalGal6.first()
+            val galVersion = preferences.galVersion.first()
             val driveSide = preferences.driveSide.first()
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
@@ -800,7 +800,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
-                experimentalGal6 = experimentalGal6,
+                galVersion = galVersion,
             )
     }
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -73,6 +73,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 
 import com.openautolink.app.session.SessionState
 import com.openautolink.app.data.AppPreferences
+import com.openautolink.app.transport.aasdk.GalProtocolPolicy
 import com.openautolink.app.ui.components.LocalEchoTextField
 import androidx.compose.material3.FilterChip
 
@@ -1188,43 +1189,48 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Spacer(modifier = Modifier.height(4.dp))
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(0.7f)
-                .clickable { viewModel.updateExperimentalGal6(!uiState.experimentalGal6) }
-                .padding(vertical = 10.dp)
-                .testTag("experimentalGal6Toggle"),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Switch(
-                checked = uiState.experimentalGal6,
-                onCheckedChange = viewModel::updateExperimentalGal6,
-            )
-            Spacer(modifier = Modifier.width(12.dp))
-            Column {
-                Text(
-                    text = "Experimental GAL 6.0",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
+        Text(
+            text = "GAL / PDK protocol version",
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            text = "The requested version activates cumulative phone behavior. Use 1.7 as the " +
+                    "compatibility fallback; 6.0 enables modern video envelopes and the short HEVC keyframe policy.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+        GalProtocolPolicy.supportedVersions.forEach { version ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .clickable { viewModel.updateGalVersion(version) }
+                    .padding(vertical = 6.dp)
+                    .testTag("galVersion_$version"),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                RadioButton(
+                    selected = uiState.galVersion == version,
+                    onClick = { viewModel.updateGalVersion(version) },
                 )
+                Spacer(modifier = Modifier.width(12.dp))
                 Text(
-                    text = if (uiState.experimentalGal6) {
-                        "Enabled — Save & Reconnect to request the modern media protocol"
-                    } else {
-                        "Off (recommended until tested in your vehicle)"
+                    text = when (version) {
+                        "1.7" -> "1.7 — legacy compatibility"
+                        "4.3" -> "4.3 — modern display metadata"
+                        "5.0" -> "5.0 — ackless audio, one codec family"
+                        "5.1" -> "5.1 — media options and EV forecast"
+                        else -> "6.0 — modern video and short HEVC keyframes"
                     },
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyLarge,
                 )
             }
         }
-
         Text(
-            text = "Requests Gearhead GAL/PDK 6.0. This enables modern media envelopes, " +
-                    "ackless audio, and the short HEVC keyframe policy that may remove " +
-                    "H.265 startup green. It is compatibility-tested only at build level " +
-                    "and may affect audio, navigation, or video until road-tested.",
-            style = MaterialTheme.typography.bodyMedium,
+            text = "Save & Reconnect applies the selected raw HU-requested version. " +
+                    "GAL 6.0 remains an implementation attempt until an in-car log confirms the 6.x response and runtime paths.",
+            style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.error,
             modifier = Modifier.padding(bottom = 20.dp),
         )
@@ -1276,8 +1282,8 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
             text = "Video codec the phone uses to encode the AA stream. " +
                     "H.264 is the safe default — instant clean startup, capped at 1080p. " +
                     "H.265 supports up to 4K but legacy GAL can take roughly two minutes " +
-                    "to deliver a full content IDR at 60 FPS. The experimental GAL 6.0 " +
-                    "toggle requests Gearhead's short HEVC keyframe policy.",
+                    "to deliver a full content IDR at 60 FPS. GAL 6.0 requests " +
+                    "Gearhead's short HEVC keyframe policy.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 12.dp)

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -30,7 +30,7 @@ data class SettingsUiState(
     val videoAutoNegotiate: Boolean = AppPreferences.DEFAULT_VIDEO_AUTO_NEGOTIATE,
     val videoCodec: String = AppPreferences.DEFAULT_VIDEO_CODEC,
     val videoFps: Int = AppPreferences.DEFAULT_VIDEO_FPS,
-    val experimentalGal6: Boolean = AppPreferences.DEFAULT_EXPERIMENTAL_GAL6,
+    val galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
     val displayMode: String = AppPreferences.DEFAULT_DISPLAY_MODE,
     val micSource: String = AppPreferences.DEFAULT_MIC_SOURCE,
     val btMacOverride: String = AppPreferences.DEFAULT_BT_MAC_OVERRIDE,
@@ -205,10 +205,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         SettingsUiState()
     )
 
-    val experimentalGal6: StateFlow<Boolean> = preferences.experimentalGal6.stateIn(
+    val galVersion: StateFlow<String> = preferences.galVersion.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5000),
-        AppPreferences.DEFAULT_EXPERIMENTAL_GAL6,
+        AppPreferences.DEFAULT_GAL_VERSION,
     )
 
     private val _hotspotSsidOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_SSID)
@@ -254,7 +254,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _wppLocalIpOverride,
         _wppApInterfaceOverride,
         _wppChannelMhzOverride,
-        experimentalGal6,
+        galVersion,
     ) { arr ->
         val state = arr[0] as SettingsUiState
         state.copy(
@@ -263,7 +263,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             wppLocalIp = arr[5] as String,
             wppApInterface = arr[6] as String,
             wppChannelMhz = arr[7] as String,
-            experimentalGal6 = arr[8] as Boolean,
+            galVersion = arr[8] as String,
         )
     }.stateIn(
         viewModelScope,
@@ -395,8 +395,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch { preferences.setVideoFps(fps) }
     }
 
-    fun updateExperimentalGal6(enabled: Boolean) {
-        viewModelScope.launch { preferences.setExperimentalGal6(enabled) }
+    fun updateGalVersion(version: String) {
+        viewModelScope.launch { preferences.setGalVersion(version) }
     }
 
     fun updateDisplayMode(mode: String) {
@@ -629,7 +629,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val aaDecAddDepth = preferences.aaDecoderAdditionalDepth.first()
             val aaAutoM = preferences.aaAutoMargins.first()
             val videoFps = preferences.videoFps.first()
-            val experimentalGal6 = preferences.experimentalGal6.first()
+            val galVersion = preferences.galVersion.first()
             val driveSide = preferences.driveSide.first()
             val hideClock = preferences.hideAaClock.first()
             val hideSignal = preferences.hidePhoneSignal.first()
@@ -676,7 +676,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 safeAreaLeft = saLeft,
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
-                experimentalGal6 = experimentalGal6,
+                galVersion = galVersion,
             )
         }
     }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6ModernMessageContractTest.kt
@@ -14,78 +14,120 @@ class Gal6ModernMessageContractTest {
     }
 
     @Test
-    fun `aasdk explicitly accepts GAL6 media options on video and audio`() {
+    fun `version response parser bounds checks endian decodes and preserves trailing bytes`() {
+        val control = projectFile("external/opencardev-aasdk/src/Channel/Control/ControlServiceChannel.cpp")
+        val parser = projectFile("external/opencardev-aasdk/include/aasdk/Channel/Control/VersionResponseParser.hpp")
+        val api = projectFile("external/opencardev-aasdk/include/aasdk/Channel/Control/IControlServiceChannelEventHandler.hpp")
+
+        assertTrue(parser.contains("size < VERSION_RESPONSE_PREFIX_SIZE"))
+        assertTrue(parser.contains("readBigEndianUint16(data"))
+        assertTrue(parser.contains("data + VERSION_RESPONSE_PREFIX_SIZE"))
+        assertTrue(parser.contains("size - VERSION_RESPONSE_PREFIX_SIZE"))
+        assertTrue(control.contains("parseVersionResponse(payload.cdata"))
+        assertTrue(control.contains("onVersionResponseMalformed(payload.size)"))
+        assertTrue(api.contains("const common::DataConstBuffer &trailingBytes"))
+        assertTrue(api.contains("onVersionResponseMalformed(size_t)"))
+    }
+
+    @Test
+    fun `modern display always emits four companion inset edges with hidden UI`() {
+        val videoConfig = projectFile("app/src/main/cpp/gal_video_policy.h")
+
+        assertTrue(videoConfig.contains("hasHiddenUi"))
+        assertTrue(videoConfig.contains("widthMargin > 0 || heightMargin > 0 || hasHiddenUi"))
+        assertTrue(videoConfig.contains("margins->set_left(widthMargin / 2)"))
+        assertTrue(videoConfig.contains("margins->set_right((widthMargin + 1) / 2)"))
+        assertTrue(videoConfig.contains("margins->set_top(heightMargin / 2)"))
+        assertTrue(videoConfig.contains("margins->set_bottom((heightMargin + 1) / 2)"))
+    }
+
+    @Test
+    fun `modern top level codec matches the advertised codec family`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val policy = projectFile("app/src/main/cpp/gal_video_policy.h")
+        assertTrue(native.contains("const auto selectedVideoCodec"))
+        assertTrue(policy.contains("singleVideoCodecFamily ? selectedVideoCodec"))
+        assertTrue(native.contains("ms->set_available_type(topLevelVideoCodec)"))
+    }
+
+    @Test
+    fun `aasdk explicitly accepts typed media options on video and audio`() {
         val ids = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/sink/MediaMessageId.proto")
+        val mediaOptions = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/MediaOptions.proto")
         val videoApi = projectFile("external/opencardev-aasdk/include/aasdk/Channel/MediaSink/Video/IVideoMediaSinkServiceEventHandler.hpp")
         val audioApi = projectFile("external/opencardev-aasdk/include/aasdk/Channel/MediaSink/Audio/IAudioMediaSinkServiceEventHandler.hpp")
         val video = projectFile("external/opencardev-aasdk/src/Channel/MediaSink/Video/VideoMediaSinkService.cpp")
         val audio = projectFile("external/opencardev-aasdk/src/Channel/MediaSink/Audio/AudioMediaSinkService.cpp")
-        val appHeader = projectFile("app/src/main/cpp/jni_session.h")
-        val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
         val app = projectFile("app/src/main/cpp/jni_session.cpp")
         val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
 
         assertTrue(ids.contains("MEDIA_MESSAGE_MEDIA_OPTIONS = 32788"))
+        assertTrue(mediaOptions.contains("message MediaOptions"))
         assertTrue(videoApi.contains("onMediaOptions"))
         assertTrue(audioApi.contains("onMediaOptions"))
         assertTrue(video.contains("MEDIA_MESSAGE_MEDIA_OPTIONS"))
         assertTrue(audio.contains("MEDIA_MESSAGE_MEDIA_OPTIONS"))
-        assertTrue(appHeader.contains("onMediaOptions"))
-        assertTrue(handlerHeader.contains("onMediaOptions"))
-        assertTrue(app.contains("GAL6 MediaOptions"))
-        assertTrue(handlers.contains("GAL6 MediaOptions"))
+        assertTrue(app.contains("reportMediaOptions(\"video\""))
+        assertTrue(handlers.contains("reportMediaOptions(channelName"))
+        assertTrue(app.contains("MediaOptions typed"))
     }
 
     @Test
-    fun `opaque GAL6 payloads are fully reconstructable below the diagnostic line cap`() {
+    fun `opaque GAL payloads remain fully reconstructable below the diagnostic line cap`() {
         val native = projectFile("app/src/main/cpp/jni_session.cpp")
         val header = projectFile("app/src/main/cpp/jni_session.h")
 
-        assertTrue(native.contains("GAL6_PAYLOAD_CHUNK_BYTES = 128"))
-        assertTrue(header.contains("gal6EnvelopeSequence_"))
+        assertTrue(native.contains("GAL_PAYLOAD_CHUNK_BYTES = 128"))
+        assertTrue(header.contains("galEnvelopeSequence_"))
         assertTrue(native.contains("chunk="))
         assertTrue(native.contains("total_chunks="))
         assertTrue(native.contains("offset="))
         assertTrue(native.contains("indication.SerializeToString(&raw)"))
-        assertTrue(native.contains("reportGal6Payload(channel, \"Start\""))
-        assertTrue(native.contains("reportGal6Payload(channel, envelope, buffer.cdata, buffer.size)"))
+        assertTrue(native.contains("reportGalPayload(channel, \"Start\""))
+        assertTrue(native.contains("reportGalPayload(channel, envelope, buffer.cdata, buffer.size)"))
         assertTrue(native.contains("line.size() <= 500"))
     }
 
     @Test
-    fun `GAL6 preserves HU-provided status UI ownership in modern UiConfig`() {
+    fun `modern UiConfig preserves requested status ownership`() {
         val uiConfig = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/UiConfig.proto")
-        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val policy = projectFile("app/src/main/cpp/gal_video_policy.h")
 
         assertTrue(uiConfig.contains("repeated int32 hidden_ui_elements = 5"))
-        assertTrue(native.contains("add_hidden_ui_elements(1)"))
-        assertTrue(native.contains("add_hidden_ui_elements(2)"))
-        assertTrue(native.contains("add_hidden_ui_elements(3)"))
+        assertTrue(policy.contains("add_hidden_ui_elements(1)"))
+        assertTrue(policy.contains("add_hidden_ui_elements(2)"))
+        assertTrue(policy.contains("add_hidden_ui_elements(3)"))
     }
 
     @Test
-    fun `GAL6 enriched start envelope fields are parsed and reported`() {
+    fun `enriched start fields are parsed typed and reported`() {
         val startProto = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/Start.proto")
+        val mediaConfig = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/media/shared/message/MediaConfig.proto")
         val native = projectFile("app/src/main/cpp/jni_session.cpp")
 
         assertTrue(startProto.contains("optional int32 session_type = 3"))
         assertTrue(startProto.contains("optional bytes media_config = 4"))
+        assertTrue(mediaConfig.contains("message MediaConfig"))
         assertTrue(native.contains("session_type="))
-        assertTrue(native.contains("media_config_bytes="))
+        assertTrue(native.contains("MediaConfig typed"))
     }
 
     @Test
-    fun `aasdk explicitly accepts GAL5_1 vehicle energy forecast`() {
+    fun `aasdk explicitly accepts typed GAL5_1 vehicle energy forecast`() {
         val ids = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/navigationstatus/NavigationStatusMessageId.proto")
+        val forecast = projectFile("external/opencardev-aasdk/protobuf/aap_protobuf/service/navigationstatus/VehicleEnergyForecast.proto")
         val api = projectFile("external/opencardev-aasdk/include/aasdk/Channel/NavigationStatus/INavigationStatusServiceEventHandler.hpp")
         val service = projectFile("external/opencardev-aasdk/src/Channel/NavigationStatus/NavigationStatusService.cpp")
         val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
         val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
 
         assertTrue(ids.contains("INSTRUMENT_CLUSTER_VEHICLE_ENERGY_FORECAST = 32776"))
+        assertTrue(forecast.contains("message VehicleEnergyForecastMessage"))
         assertTrue(api.contains("onVehicleEnergyForecast"))
         assertTrue(service.contains("INSTRUMENT_CLUSTER_VEHICLE_ENERGY_FORECAST"))
         assertTrue(handlerHeader.contains("onVehicleEnergyForecast"))
-        assertTrue(handlers.contains("GAL6 VehicleEnergyForecast"))
+        assertTrue(handlers.contains("reportVehicleEnergyForecast"))
+        assertTrue(native.contains("VehicleEnergyForecast typed"))
     }
 }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
@@ -10,26 +10,29 @@ import org.junit.Test
 class Gal6PreferenceContractTest {
 
     @Test
-    fun `SDR config materializes tested GAL policy for JNI`() {
-        val legacy = AasdkSdrConfig(experimentalGal6 = false)
-        assertEquals(1, legacy.requestedGalMajor)
-        assertEquals(7, legacy.requestedGalMinor)
-        assertEquals(30, legacy.mediaSetupMaxUnacked)
-        assertTrue(legacy.sendAudioAcks)
-        assertEquals(60, legacy.hevcKeyframeIntervalSeconds)
+    fun `SDR config materializes every tested GAL policy for JNI`() {
+        GalProtocolPolicy.supportedVersions.forEach { version ->
+            val expected = GalProtocolPolicy.forVersion(version)
+            val actual = AasdkSdrConfig(galVersion = version)
 
-        val modern = AasdkSdrConfig(experimentalGal6 = true)
-        assertEquals(6, modern.requestedGalMajor)
-        assertEquals(0, modern.requestedGalMinor)
-        assertEquals(30, modern.mediaSetupMaxUnacked)
-        assertFalse(modern.sendAudioAcks)
-        assertEquals(2, modern.hevcKeyframeIntervalSeconds)
+            assertEquals(expected.requestedVersion.major, actual.requestedGalMajor)
+            assertEquals(expected.requestedVersion.minor, actual.requestedGalMinor)
+            assertEquals(30, actual.mediaSetupMaxUnacked)
+            assertEquals(expected.sendAudioAcks, actual.sendAudioAcks)
+            assertEquals(expected.requireMinimumCompatibleResponse, actual.requireMinimumCompatibleResponse)
+            assertEquals(expected.modernDisplayPolicy, actual.modernDisplayPolicy)
+            assertEquals(expected.singleVideoCodecFamily, actual.singleVideoCodecFamily)
+            assertEquals(expected.useActiveMediaSessionIds, actual.useActiveMediaSessionIds)
+            assertEquals(expected.hevcKeyframeIntervalSeconds, actual.hevcKeyframeIntervalSeconds)
+        }
     }
 
     @Test
-    fun `experimental GAL 6 mode is off by default through every user-facing layer`() {
-        assertFalse(AppPreferences.DEFAULT_EXPERIMENTAL_GAL6)
-        assertFalse(SettingsUiState().experimentalGal6)
-        assertFalse(AasdkSdrConfig().experimentalGal6)
+    fun `GAL defaults remain legacy until explicitly selected`() {
+        assertEquals("1.7", AppPreferences.DEFAULT_GAL_VERSION)
+        assertEquals("1.7", SettingsUiState().galVersion)
+        assertEquals("1.7", AasdkSdrConfig().galVersion)
+        assertTrue(AasdkSdrConfig().sendAudioAcks)
+        assertFalse(AasdkSdrConfig().modernDisplayPolicy)
     }
 }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
@@ -15,70 +15,87 @@ class Gal6WiringContractTest {
     }
 
     @Test
-    fun `experimental toggle is writable visible and carried into every session path`() {
+    fun `GAL version ladder is writable visible and carried into every session path`() {
         val preferences = projectFile("app/src/main/java/com/openautolink/app/data/AppPreferences.kt")
         val settingsVm = projectFile("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
         val settingsUi = projectFile("app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt")
         val projectionVm = projectFile("app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt")
+        val settingsReceiver = projectFile("app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt")
         val sessionManager = projectFile("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
 
-        assertTrue(preferences.contains("val experimentalGal6: Flow<Boolean>"))
-        assertTrue(preferences.contains("suspend fun setExperimentalGal6"))
-        assertTrue(settingsVm.contains("fun updateExperimentalGal6"))
-        assertTrue(settingsVm.contains("val experimentalGal6: StateFlow<Boolean>"))
-        assertTrue(settingsVm.contains("experimentalGal6 = arr[8] as Boolean"))
-        assertTrue(settingsUi.contains("testTag(\"experimentalGal6Toggle\")"))
-        assertTrue(settingsUi.contains("Experimental GAL 6.0"))
-        assertTrue(projectionVm.contains("preferences.experimentalGal6.first()"))
-        assertTrue(projectionVm.contains("experimentalGal6 = experimentalGal6"))
-        assertTrue(sessionManager.contains("experimentalGal6: Boolean = false"))
-        assertTrue(sessionManager.contains("experimentalGal6 = experimentalGal6"))
+        assertTrue(preferences.contains("val galVersion: Flow<String>"))
+        assertTrue(preferences.contains("suspend fun setGalVersion"))
+        assertTrue(preferences.contains("prefs[EXPERIMENTAL_GAL6]"))
+        assertTrue(settingsVm.contains("fun updateGalVersion"))
+        assertTrue(settingsVm.contains("val galVersion: StateFlow<String>"))
+        assertTrue(settingsUi.contains("testTag(\"galVersion_"))
+        assertTrue(settingsUi.contains("GalProtocolPolicy.supportedVersions.forEach"))
+        assertTrue(projectionVm.contains("preferences.galVersion.first()"))
+        assertTrue(settingsReceiver.contains("galVersion = prefs.galVersion.first()"))
+        assertTrue(sessionManager.contains("galVersion: String = AppPreferences.DEFAULT_GAL_VERSION"))
+        assertTrue(sessionManager.contains("galVersion = galVersion"))
     }
 
     @Test
-    fun `native session applies GAL6 version media window ack and session policy`() {
+    fun `native session applies cumulative GAL version media and session policy`() {
         val native = projectFile("app/src/main/cpp/jni_session.cpp")
         val nativeHeader = projectFile("app/src/main/cpp/jni_session.h")
         val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
         val handlerHeader = projectFile("app/src/main/cpp/jni_channel_handlers.h")
 
-        assertTrue(native.contains("experimentalGal6"))
+        assertTrue(native.contains("modernDisplayPolicy"))
+        assertTrue(native.contains("singleVideoCodecFamily"))
+        assertTrue(native.contains("useActiveMediaSessionIds"))
         assertTrue(native.contains("requestedGalMajor_"))
         assertTrue(native.contains("requestedGalMinor_"))
         assertTrue(native.contains("GAL policy: requested="))
         assertTrue(native.contains("activeVideoSessionId_"))
-        assertTrue(native.contains("ack.set_session_id(mediaAckSessionId(activeVideoSessionId_.load()))"))
+        assertTrue(native.contains("videoAckSessionId(activeVideoSessionId_.load())"))
         assertTrue(native.contains("mediaSetupMaxUnacked()"))
         assertTrue(native.contains("expectedHevcGopFrames"))
         assertTrue(nativeHeader.contains("shouldSendAudioAcks"))
-        assertTrue(nativeHeader.contains("return sdrConfig_.experimentalGal6 ? activeSessionId : 0"))
+        assertTrue(nativeHeader.contains("audioAckSessionId"))
+        assertTrue(nativeHeader.contains("videoAckSessionId"))
         assertTrue(handlers.contains("activeSessionId_"))
         assertTrue(handlers.contains("session_.shouldSendAudioAcks()"))
-        assertTrue(handlers.contains("session_.mediaAckSessionId(activeSessionId_.load())"))
+        assertTrue(handlers.contains("session_.audioAckSessionId(activeSessionId_.load())"))
         assertTrue(handlerHeader.contains("activeSessionId_"))
     }
 
     @Test
-    fun `rejected GAL version aborts before TLS handshake`() {
+    fun `lower modern GAL version response aborts before TLS handshake`() {
         val native = projectFile("app/src/main/cpp/jni_session.cpp")
         val response = native.substringAfter("void JniSession::onVersionResponse")
             .substringBefore("void JniSession::onAuthComplete")
 
-        val rejection = response.indexOf("status != aap_protobuf::shared::STATUS_SUCCESS")
-        val abort = response.indexOf("GAL version negotiation rejected")
+        val admission = response.indexOf("gal::versionResponseIsAccepted")
+        val abort = response.indexOf("GAL version negotiation rejected", startIndex = admission)
         val handshake = response.indexOf("cryptor_->doHandshake()")
-        assertTrue(rejection >= 0)
-        assertTrue(abort > rejection)
+        assertTrue(admission >= 0)
+        assertTrue(abort > admission)
         assertTrue(handshake > abort)
     }
 
     @Test
-    fun `GAL6 enriched envelopes remain observable without rejecting unknown fields`() {
+    fun `malformed GAL response aborts immediately with a named diagnostic`() {
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val malformed = native.substringAfter("void JniSession::onVersionResponseMalformed")
+            .substringBefore("void JniSession::onVersionResponse")
+
+        assertTrue(malformed.contains("GAL version response malformed"))
+        assertTrue(malformed.contains("triggerAbort(reason)"))
+    }
+
+    @Test
+    fun `enriched envelopes remain typed and reconstructable without rejecting unknown fields`() {
         val native = projectFile("app/src/main/cpp/jni_session.cpp")
         val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp")
 
-        assertTrue(native.contains("reportGal6StartEnvelope(\"video\", indication)"))
-        assertTrue(handlers.contains("session_.reportGal6StartEnvelope(channelName, indication)"))
+        assertTrue(native.contains("reportGalStartEnvelope(\"video\", indication)"))
+        assertTrue(handlers.contains("session_.reportGalStartEnvelope(channelName, indication)"))
+        assertTrue(native.contains("MediaOptions typed"))
+        assertTrue(handlers.contains("reportVehicleEnergyForecast"))
         assertTrue(native.contains("unknown_fields="))
+        assertTrue(native.contains("total_chunks="))
     }
 }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
@@ -8,30 +8,72 @@ import org.junit.Test
 class GalProtocolPolicyTest {
 
     @Test
-    fun `legacy mode requests GAL 1_7 and keeps media acknowledgements`() {
-        val config = GalProtocolPolicy.forExperimentalGal6(enabled = false)
-
-        assertEquals(GalProtocolVersion(1, 7), config.requestedVersion)
-        assertEquals(30, config.maxUnacked)
-        assertTrue(config.sendAudioAcks)
-        assertEquals(60, config.hevcKeyframeIntervalSeconds)
+    fun `supported versions expose the accepted production ladder`() {
+        assertEquals(listOf("1.7", "4.3", "5.0", "5.1", "6.0"), GalProtocolPolicy.supportedVersions)
     }
 
     @Test
-    fun `experimental mode requests GAL 6_0 and makes audio ackless without changing setup window`() {
-        val config = GalProtocolPolicy.forExperimentalGal6(enabled = true)
+    fun `GAL thresholds are cumulative from the raw requested version`() {
+        data class Expected(
+            val version: String,
+            val modernDisplay: Boolean,
+            val audioAcks: Boolean,
+            val singleCodec: Boolean,
+            val activeSessionIds: Boolean,
+            val hevcIntervalSeconds: Int,
+        )
 
-        assertEquals(GalProtocolVersion(6, 0), config.requestedVersion)
-        assertEquals(30, config.maxUnacked)
-        assertFalse(config.sendAudioAcks)
-        assertEquals(2, config.hevcKeyframeIntervalSeconds)
+        val cases = listOf(
+            Expected("1.7", false, true, false, false, 60),
+            Expected("4.3", true, true, false, true, 60),
+            Expected("5.0", true, false, true, true, 60),
+            Expected("5.1", true, false, true, true, 60),
+            Expected("6.0", true, false, true, true, 2),
+        )
+
+        cases.forEach { expected ->
+            val config = GalProtocolPolicy.forVersion(expected.version)
+            assertEquals(expected.version, config.requestedVersion.toString())
+            assertEquals(30, config.maxUnacked)
+            assertEquals(expected.modernDisplay, config.requireMinimumCompatibleResponse)
+            assertEquals(expected.modernDisplay, config.modernDisplayPolicy)
+            assertEquals(expected.audioAcks, config.sendAudioAcks)
+            assertEquals(expected.singleCodec, config.singleVideoCodecFamily)
+            assertEquals(expected.activeSessionIds, config.useActiveMediaSessionIds)
+            assertEquals(expected.hevcIntervalSeconds, config.hevcKeyframeIntervalSeconds)
+        }
     }
 
     @Test
-    fun `expected HEVC GOP uses negotiated encoder policy and advertised fps`() {
-        assertEquals(3_600, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = false, advertisedFps = 60))
-        assertEquals(1_800, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = false, advertisedFps = 30))
-        assertEquals(120, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = true, advertisedFps = 60))
-        assertEquals(60, GalProtocolPolicy.expectedHevcGopFrames(experimentalGal6 = true, advertisedFps = 30))
+    fun `invalid or future configured versions safely fall back to legacy`() {
+        listOf("", " 6.0", "6.0 ", "4.03", "6.1", "garbage").forEach { value ->
+            assertEquals(GalProtocolVersion(1, 7), GalProtocolPolicy.forVersion(value).requestedVersion)
+        }
+    }
+
+    @Test
+    fun `persisted version migration preserves legacy users and gives new value precedence`() {
+        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion(null, null))
+        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion(null, false))
+        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion(null, true))
+        assertEquals("5.1", GalProtocolPolicy.resolvePersistedVersion("5.1", true))
+        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion("invalid", false))
+        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion("invalid", true))
+    }
+
+    @Test
+    fun `expected HEVC GOP uses requested policy and advertised fps`() {
+        assertEquals(3_600, GalProtocolPolicy.expectedHevcGopFrames("1.7", 60))
+        assertEquals(1_800, GalProtocolPolicy.expectedHevcGopFrames("5.1", 30))
+        assertEquals(120, GalProtocolPolicy.expectedHevcGopFrames("6.0", 60))
+        assertEquals(60, GalProtocolPolicy.expectedHevcGopFrames("6.0", 30))
+        assertEquals(0, GalProtocolPolicy.expectedHevcGopFrames("6.0", -1))
+    }
+
+    @Test
+    fun `numeric protocol version ordering does not use floating point`() {
+        assertTrue(GalProtocolVersion(4, 3) < GalProtocolVersion(5, 0))
+        assertTrue(GalProtocolVersion(5, 1) < GalProtocolVersion(6, 0))
+        assertFalse(GalProtocolVersion(6, 0) < GalProtocolVersion(5, 1))
     }
 }

--- a/app/src/test/native/gal_version_policy_test.cpp
+++ b/app/src/test/native/gal_version_policy_test.cpp
@@ -1,0 +1,22 @@
+#include <cassert>
+
+#include "gal_version_policy.h"
+
+int main() {
+  using openautolink::jni::gal::versionResponseIsAccepted;
+  using openautolink::jni::gal::mediaAckSessionId;
+
+  assert(versionResponseIsAccepted(false, 1, 7, 1, 7, 0, 0));
+  assert(versionResponseIsAccepted(false, 6, 1, 1, 7, 0, 0));
+  assert(!versionResponseIsAccepted(false, 1, 7, 1, 7, 1, 0));
+
+  assert(!versionResponseIsAccepted(true, 5, 1, 6, 0, 0, 0));
+  assert(versionResponseIsAccepted(true, 6, 0, 6, 0, 0, 0));
+  assert(versionResponseIsAccepted(true, 6, 1, 6, 0, 0, 0));
+  assert(versionResponseIsAccepted(true, 5, 1, 5, 0, 0, 0));
+  assert(!versionResponseIsAccepted(true, 4, 3, 5, 0, 0, 0));
+  assert(!versionResponseIsAccepted(true, 6, 1, 6, 0, 2, 0));
+  assert(mediaAckSessionId(false, 73) == 0);
+  assert(mediaAckSessionId(true, 73) == 73);
+  return 0;
+}

--- a/app/src/test/native/gal_video_policy_test.cpp
+++ b/app/src/test/native/gal_video_policy_test.cpp
@@ -1,0 +1,48 @@
+#include <cassert>
+#include <string>
+
+#include "gal_video_policy.h"
+
+int main() {
+  using aap_protobuf::service::media::sink::message::VideoConfiguration;
+  using openautolink::jni::gal::applyVideoMarginsAndHiddenUi;
+  using openautolink::jni::gal::selectTopLevelVideoCodec;
+
+  VideoConfiguration legacy;
+  assert(!applyVideoMarginsAndHiddenUi(&legacy, 0, 0, false, true, true, true));
+  assert(!legacy.has_ui_config());
+
+  VideoConfiguration modernZero;
+  assert(applyVideoMarginsAndHiddenUi(&modernZero, 0, 0, true, true, false, false));
+  assert(modernZero.has_ui_config());
+  assert(modernZero.ui_config().has_margins());
+  const auto& zero = modernZero.ui_config().margins();
+  assert(zero.has_left() && zero.left() == 0);
+  assert(zero.has_right() && zero.right() == 0);
+  assert(zero.has_top() && zero.top() == 0);
+  assert(zero.has_bottom() && zero.bottom() == 0);
+  assert(modernZero.ui_config().hidden_ui_elements_size() == 1);
+  assert(modernZero.ui_config().hidden_ui_elements(0) == 1);
+
+  std::string wire;
+  assert(modernZero.SerializeToString(&wire));
+  const std::string expectedZeroInsetWire(
+      "\x5a\x0c\x0a\x08\x08\x00\x10\x00\x18\x00\x20\x00\x28\x01", 14);
+  assert(wire == expectedZeroInsetWire);
+  VideoConfiguration roundTrip;
+  assert(roundTrip.ParseFromString(wire));
+  assert(roundTrip.ui_config().margins().has_left());
+  assert(roundTrip.ui_config().margins().has_right());
+  assert(roundTrip.ui_config().margins().has_top());
+  assert(roundTrip.ui_config().margins().has_bottom());
+
+  VideoConfiguration nonZero;
+  assert(!applyVideoMarginsAndHiddenUi(&nonZero, 5, 3, false, false, false, false));
+  const auto& split = nonZero.ui_config().margins();
+  assert(split.left() == 2 && split.right() == 3);
+  assert(split.top() == 1 && split.bottom() == 2);
+
+  assert(selectTopLevelVideoCodec(true, 7, 1) == 7);
+  assert(selectTopLevelVideoCodec(false, 7, 1) == 1);
+  return 0;
+}

--- a/app/src/test/native/version_response_parser_test.cpp
+++ b/app/src/test/native/version_response_parser_test.cpp
@@ -1,0 +1,27 @@
+#include <array>
+#include <cassert>
+#include <cstdint>
+
+#include <aasdk/Channel/Control/VersionResponseParser.hpp>
+
+int main() {
+  using namespace aasdk::channel::control;
+  const std::array<uint8_t, 9> accepted{0x00, 0x06, 0x00, 0x01, 0x00, 0x00,
+                                         0xaa, 0xbb, 0xcc};
+  ParsedVersionResponse parsed;
+  assert(parseVersionResponse(accepted.data(), accepted.size(), parsed));
+  assert(parsed.major == 6 && parsed.minor == 1 && parsed.status == 0);
+  assert(parsed.trailingSize == 3);
+  assert(parsed.trailingData[0] == 0xaa && parsed.trailingData[2] == 0xcc);
+
+  for (size_t size = 0; size < VERSION_RESPONSE_PREFIX_SIZE; ++size) {
+    ParsedVersionResponse truncated;
+    assert(!parseVersionResponse(accepted.data(), size, truncated));
+  }
+
+  const std::array<uint8_t, 6> rejected{0x00, 0x06, 0x00, 0x00, 0xff, 0xff};
+  ParsedVersionResponse failure;
+  assert(parseVersionResponse(rejected.data(), rejected.size(), failure));
+  assert(failure.status == -1);
+  return 0;
+}

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -1,73 +1,79 @@
-# Experimental GAL/PDK 6.0 compatibility mode
+# GAL/PDK compatibility versions
 
-OpenAutoLink normally requests Android Auto GAL 1.7. The **Experimental GAL 6.0**
-toggle in **Settings → Video** changes only the next AA session; use **Save &
-Reconnect** after changing it.
+OpenAutoLink exposes a **GAL / PDK protocol version** selector in **Settings → Video**. The selected raw head-unit-requested version applies on the next Android Auto session; use **Save & Reconnect** after changing it.
 
-The toggle is **off by default**.
+The safe default and fallback remain **1.7**. Existing installations that had the former Experimental GAL 6.0 Boolean enabled migrate to **6.0**; all other installations remain at 1.7.
 
-## What enabling it changes
+## Cumulative version policy
 
-- Requests raw GAL/PDK version **6.0** instead of 1.7 during the pre-TLS version
-  exchange; a rejected version response aborts before TLS instead of continuing
-  under an invalid assumption.
-- Preserves OAL's proven 30-frame AV setup window; GAL 5+ ackless audio no
-  longer uses this value as per-buffer ACK credit.
-- Treats phone-to-head-unit audio as ackless; legacy sessions continue sending
-  per-frame audio ACKs.
-- Preserves the legacy `session_id=0` ACK behavior when disabled; GAL 6 uses the
-  active `Start.session_id` for video ACKs. GAL 6 audio is ackless.
-- Parses and logs GAL 5/6 `Start` extensions (`session_type` and raw
-  `media_config`).
-- Explicitly accepts and logs standalone audio/video `MediaOptions` (`0x8014`).
-- Explicitly accepts and logs navigation `VehicleEnergyForecast` (`0x8008`).
-- Writes complete Start, MediaOptions, and VehicleEnergyForecast protobuf bytes
-  as numbered compact-hex chunks. Each line stays below DiagnosticLog's
-  500-character cap, so uploaded logs can reconstruct opaque payloads exactly.
-- Sends modern `UiConfig.hidden_ui_elements` values for the existing hide-clock,
-  hide-battery, and hide-signal preferences; the legacy session bitmask remains
-  populated too.
+The raw requested version—not a higher compatible tuple reported by the phone—is the sole local policy input.
+
+| Requested version | OAL behavior |
+|---|---|
+| 1.7 | Legacy display policy and per-packet audio ACKs. |
+| 4.3 | Modern display ownership metadata and active media session IDs. |
+| 5.0 | Ackless phone-to-HU audio and one advertised codec family per display. |
+| 5.1 | Adds typed and raw handling for audio `MediaOptions` (`0x8014`) and navigation `VehicleEnergyForecast` (`0x8008`). |
+| 6.0 | Adds typed and raw modern video Start/MediaConfig and video `MediaOptions`, and activates Gearhead's short HEVC keyframe policy. |
+
+All versions retain OAL's proven `max_unacked=30`. Video remains ACKed at every version: legacy 1.7 preserves `session_id=0`, while GAL 4.3+ uses the active video `Start.session_id`. Modern audio is ackless.
+
+## Version-response admission
+
+The AASDK control parser now:
+
+- rejects every response shorter than the six-byte fixed prefix;
+- safely decodes major, minor, and raw status as big-endian 16-bit words;
+- preserves every trailing response byte for reconstructable diagnostics;
+- requires `MATCH`/success;
+- for requested 4.3 or newer, requires the reported tuple to be numerically equal or higher;
+- accepts 6.1 for a 6.0 request;
+- rejects a lower modern response before TLS.
+
+## Display and codec correctness
+
+For GAL 4.3+, hidden clock/battery/signal ownership is serialized in modern `UiConfig`. Whenever hidden UI exists, field-1 margins contain all four explicit edges, including zero values, while legacy total margins remain unchanged.
+
+For GAL 5.0+, the media sink's top-level codec declaration matches the selected codec family in its video configurations. Legacy 1.7/4.3 retain the prior top-level H.264 declaration for compatibility.
+
+## Modern message diagnostics
+
+Known modern envelopes are parsed into typed protobufs without assigning unproven semantics. Complete original bytes are also written as numbered compact-hex chunks below DiagnosticLog's 500-character cap, preserving unknown fields and allowing exact reconstruction.
+
+Typed handling covers:
+
+- rich Start fields and nested `MediaConfig`;
+- audio and video `MediaOptions` (`0x8014`);
+- navigation `VehicleEnergyForecast` (`0x8008`), including its nested forecast.
+
+Malformed optional modern messages are logged and retained; they do not invent replies or alter session policy.
 
 ## Expected H.265 effect
 
-Gearhead's legacy wireless HEVC policy uses a 60-second I-frame interval. Android's
-OMX codec path converts that to a frame count using the configured frame rate, so
-60 FPS produces an approximately 3600-frame GOP. OAL measured normal real HEVC
-IDRs at 3575–3641-frame intervals.
+Gearhead's legacy wireless HEVC policy uses a 60-second I-frame interval. GAL 6.0 selects its two-second interval.
 
-Gearhead's GAL 6 path selects its 2-second HEVC interval. Predictions:
-
-| Advertised FPS | Legacy GAL | GAL 6.0 |
+| Advertised FPS | GAL 1.7–5.1 | GAL 6.0 |
 |---:|---:|---:|
 | 60 | ~3600 frames | ~120 frames |
 | 30 | ~1800 frames | ~60 frames |
 
 These are framework-derived predictions, not vehicle verification.
 
-## Runtime evidence
+## Runtime evidence required
 
-Uploaded diagnostic logs use the `gal6` tag. A useful GAL 6 test must contain:
+A useful GAL 6 in-car capture must contain:
 
-- `GAL policy: requested=6.0 experimental=true`
-- `GAL negotiated: requested=6.0 response=... status=...`
-- `GAL6 video Start envelope: ... session_type=... media_config_bytes=...`
-- any `GAL6 MediaOptions ...` and `GAL6 VehicleEnergyForecast ...` lines
-- matching `GAL6 payload id=... chunk=... total_chunks=... hex=...` lines for
-  every opaque Start, MediaOptions, and VehicleEnergyForecast envelope
-- `H265-IDR` and `H265-pflow` lines
-- continuous `vflow` after the session reaches streaming
+- `GAL policy: requested=6.0 modernDisplay=true singleCodec=true`
+- `GAL negotiated: requested=6.0 response=... status=... trailing_bytes=...`
+- `GAL video Start envelope: ... session_type=... media_config_bytes=...`
+- typed `MediaConfig`, `MediaOptions`, or `VehicleEnergyForecast` lines when those conditional messages are delivered
+- matching `GAL payload id=... chunk=... total_chunks=... hex=...` lines
+- `H265-IDR`, `H265-pflow`, and continuous `vflow`
 
-The positive success signal is not merely a 6.x version response. It is a stable
-end-to-end session with video, audio, touch, navigation, and substantially shorter
-**frame-count** spacing between real H.265 IDRs.
+The positive success signal is not merely a 6.x response. It is a stable end-to-end session with video, audio, touch, navigation, assistant, and approximately 120-frame real H.265 IDR spacing at advertised 60 FPS.
 
 ## Risk and fallback
 
-GAL 5.0+ changes audio flow control and AV start envelopes; GAL 5.1+ adds
-asynchronous MediaOptions and VehicleEnergyForecast; GAL 6.0 changes video media
-options and HEVC behavior. The mode is therefore experimental even though OAL
-accepts these known envelopes.
+If projection, audio, touch, or navigation regresses, select **1.7** and use **Save & Reconnect**. Do not use video-focus bouncing as a keyframe workaround; it caused a verified encoder-throttle regression.
 
-If projection, audio, touch, or navigation regresses, turn the toggle off and use
-**Save & Reconnect** to return to GAL 1.7. Do not use video-focus bouncing as a
-keyframe workaround: it caused a verified encoder-throttle regression.
+A Play release containing this code is an implementation attempt until the next in-vehicle upload proves the selected policy ran and projection remained healthy.

--- a/scripts/build-aasdk-android.sh
+++ b/scripts/build-aasdk-android.sh
@@ -194,6 +194,46 @@ if [ ! -f "$HOST_PROTOC" ]; then
     find "$HOST_BUILD_DIR" -name "libaasdk.a" 2>&1
 fi
 
+# Run the GAL compatibility tests against the host-generated protobuf objects.
+# These exercise the exact parser/admission helpers and assert serialized field
+# presence for explicit zero insets before any Android prebuilt is published.
+echo ""
+echo "=== Running host GAL protocol tests ==="
+GAL_TEST_DIR="$SHARED_DIR/gal-tests"
+mkdir -p "$GAL_TEST_DIR"
+HOST_CXX="${CXX:-g++}"
+
+"$HOST_CXX" -std=c++20 -Wall -Wextra \
+    -I"$AASDK_NATIVE/include" \
+    "$REPO_ROOT/app/src/test/native/version_response_parser_test.cpp" \
+    -o "$GAL_TEST_DIR/version_response_parser_test"
+"$GAL_TEST_DIR/version_response_parser_test"
+
+"$HOST_CXX" -std=c++20 -Wall -Wextra \
+    -I"$REPO_ROOT/app/src/main/cpp" \
+    -I"$HOST_BUILD_DIR/protobuf" \
+    -I"$HOST_BUILD_DIR/_deps/protobuf-src/src" \
+    -I"$HOST_BUILD_DIR/_deps/abseil-src" \
+    "$REPO_ROOT/app/src/test/native/gal_version_policy_test.cpp" \
+    -o "$GAL_TEST_DIR/gal_version_policy_test"
+"$GAL_TEST_DIR/gal_version_policy_test"
+
+"$HOST_CXX" -std=c++20 -Wall -Wextra \
+    -I"$REPO_ROOT/app/src/main/cpp" \
+    -I"$HOST_BUILD_DIR/protobuf" \
+    -I"$HOST_BUILD_DIR/_deps/protobuf-src/src" \
+    -I"$HOST_BUILD_DIR/_deps/abseil-src" \
+    "$REPO_ROOT/app/src/test/native/gal_video_policy_test.cpp" \
+    -Wl,--start-group \
+    "$HOST_BUILD_DIR/lib/libaap_protobuf.a" \
+    "$HOST_BUILD_DIR/lib/libprotobuf.a" \
+    "$HOST_BUILD_DIR"/lib/libabsl_*.a \
+    "$HOST_BUILD_DIR"/lib/libutf8_*.a \
+    -Wl,--end-group -pthread \
+    -o "$GAL_TEST_DIR/gal_video_policy_test"
+"$GAL_TEST_DIR/gal_video_policy_test"
+echo "GAL protocol tests passed"
+
 # Step 2: Cross-compile aasdk for Android.
 echo ""
 echo "=== Configuring aasdk for Android $TARGET_ABI (cross-compile) ==="


### PR DESCRIPTION
## Summary

- replace the Boolean experimental toggle with a cumulative GAL 1.7/4.3/5.0/5.1/6.0 selector and migrate existing enabled users to 6.0
- safely decode version responses, preserve trailing bytes, reject malformed/lower modern responses before TLS, and retain a true 1.7 fallback
- align modern codec declarations, serialize explicit zero insets with hidden UI, preserve video ACKs and GAL-specific session IDs, and add typed plus reconstructable raw modern-message diagnostics
- rebuild and verify both AASDK ABIs, add host-native parser/admission/wire tests, and document the runtime validation contract

## Verification

- focused GAL JVM tests: 21 passed
- full app JVM suite: 357 passed, 0 failed
- host-native parser/admission/serialized-wire tests: passed
- `:app:externalNativeBuildDebug --rerun-tasks`: passed for arm64-v8a and x86_64
- exact new markers found in both JNI binaries and the final AAB; prior source did not contain the malformed-response marker
- independent final review: passed with no security or logic blockers

## Distribution

Released to Play `automotive:internal` as `0.1.452` / versionCode `452`, status `completed`.

This remains an implementation attempt until the next in-car log proves the selected GAL path runs and projection remains healthy.
