### PR TITLE
feat(ev): surface Maps arrival SOC

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -221,6 +221,7 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
         "(Ljava/lang/String;Ljava/lang/String;[BIILjava/lang/String;Ljava/lang/String;"
         "Ljava/lang/String;Ljava/lang/String;I"
         "Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JILjava/lang/String;Ljava/lang/String;)V");
+    cbMethods_.onVehicleEnergyForecast = env->GetMethodID(cbClass, "onVehicleEnergyForecast", "(IIIIIIIIII)V");
     cbMethods_.onMediaMetadata = env->GetMethodID(cbClass, "onMediaMetadata",
         "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[B)V");
     cbMethods_.onMediaPlayback = env->GetMethodID(cbClass, "onMediaPlayback", "(IJ)V");
@@ -683,7 +684,67 @@ void JniSession::reportVehicleEnergyForecast(
         if (outer.has_vehicle_energy_forecast()) {
             aap_protobuf::service::navigationstatus::VehicleEnergyForecast inner;
             innerParsed = inner.ParseFromString(outer.vehicle_energy_forecast());
-            if (innerParsed) summary = inner.ShortDebugString();
+            if (innerParsed) {
+                summary = inner.ShortDebugString();
+
+                int nextDistance = -1;
+                int nextArrivalWh = -1;
+                int nextTime = -1;
+                if (inner.has_energy_at_next_stop()) {
+                    const auto& next = inner.energy_at_next_stop();
+                    nextDistance = next.has_distance_meters() ? next.distance_meters() : -1;
+                    nextArrivalWh = next.has_arrival_battery_energy_wh()
+                        ? next.arrival_battery_energy_wh() : -1;
+                    nextTime = next.has_time_to_arrival_seconds()
+                        ? next.time_to_arrival_seconds() : -1;
+                }
+
+                int emptyDistance = -1;
+                int emptyArrivalWh = -1;
+                int emptyTime = -1;
+                if (inner.has_distance_to_empty()) {
+                    const auto& empty = inner.distance_to_empty();
+                    emptyDistance = empty.has_distance_meters() ? empty.distance_meters() : -1;
+                    emptyArrivalWh = empty.has_arrival_battery_energy_wh()
+                        ? empty.arrival_battery_energy_wh() : -1;
+                    emptyTime = empty.has_time_to_arrival_seconds()
+                        ? empty.time_to_arrival_seconds() : -1;
+                }
+
+                int minimumDepartureWh = -1;
+                int maximumPowerW = -1;
+                int chargingTime = -1;
+                if (inner.has_next_charging_stop()) {
+                    const auto& charging = inner.next_charging_stop();
+                    minimumDepartureWh = charging.has_min_departure_energy_wh()
+                        ? charging.min_departure_energy_wh() : -1;
+                    maximumPowerW = charging.has_max_rated_power_watts()
+                        ? charging.max_rated_power_watts() : -1;
+                    chargingTime = charging.has_estimated_charging_time_seconds()
+                        ? charging.estimated_charging_time_seconds() : -1;
+                }
+
+                const int quality = inner.has_forecast_quality()
+                    ? static_cast<int>(inner.forecast_quality()) : 0;
+                if (cbMethods_.onVehicleEnergyForecast && callbackRef_) {
+                    bool attached;
+                    JNIEnv* env = getEnv(attached);
+                    if (env) {
+                        env->CallVoidMethod(callbackRef_, cbMethods_.onVehicleEnergyForecast,
+                            static_cast<jint>(nextDistance),
+                            static_cast<jint>(nextArrivalWh),
+                            static_cast<jint>(nextTime),
+                            static_cast<jint>(emptyDistance),
+                            static_cast<jint>(emptyArrivalWh),
+                            static_cast<jint>(emptyTime),
+                            static_cast<jint>(quality),
+                            static_cast<jint>(minimumDepartureWh),
+                            static_cast<jint>(maximumPowerW),
+                            static_cast<jint>(chargingTime));
+                    }
+                    releaseEnv(attached);
+                }
+            }
         }
         nativeDiag(1, "gal", "VehicleEnergyForecast typed inner_parsed=" +
             std::string(innerParsed ? "true" : "false") + " summary=" +
@@ -2208,12 +2269,10 @@ void JniSession::sendEnergyModelSensor(int batteryLevelWh, int batteryCapacityWh
         batt->set_regen_braking_capable(true);
 
         // Charge/discharge power — needed for server-side EV routing computation
-        int chargePower;
-        if (maxChargeWOverride > 0) {
-            chargePower = maxChargeWOverride;
-        } else {
-            chargePower = (chargeRateW > 0) ? chargeRateW : 150000;
-        }
+        // Instantaneous VHAL pack flow is not the vehicle's charging capability.
+        // Use a curated/profile override when available, otherwise the existing
+        // conservative generic capability.
+        int chargePower = maxChargeWOverride > 0 ? maxChargeWOverride : 150000;
         batt->set_max_charge_power_w(chargePower);
         batt->set_max_discharge_power_w(maxDischargeWOverride > 0 ? maxDischargeWOverride : 150000);
 
@@ -2223,8 +2282,11 @@ void JniSession::sendEnergyModelSensor(int batteryLevelWh, int batteryCapacityWh
                                 static_cast<float>(rangeM)) * 1000.0f;
         float whPerKm = (drivingWhPerKmOverride >= 0.0f) ? drivingWhPerKmOverride : derivedWhPerKm;
         cons->mutable_driving()->set_rate(whPerKm);
-        cons->mutable_auxiliary()->set_rate(auxWhPerKmOverride >= 0.0f ? auxWhPerKmOverride : 2.0f);
-        cons->mutable_aerodynamic()->set_rate(aeroCoefOverride >= 0.0f ? aeroCoefOverride : 0.36f);
+        // The range-derived driving rate already reflects the car's current
+        // climate/temperature/drag conditions. Do not add synthetic components
+        // on top unless the user selected an independent tuned/profile model.
+        cons->mutable_auxiliary()->set_rate(auxWhPerKmOverride >= 0.0f ? auxWhPerKmOverride : 0.0f);
+        cons->mutable_aerodynamic()->set_rate(aeroCoefOverride >= 0.0f ? aeroCoefOverride : 0.0f);
 
         // Charging prefs
         vem.mutable_charging_prefs()->set_mode(1);  // standard

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -448,6 +448,7 @@ private:
         jmethodID onNavigationTurn = nullptr;
         jmethodID onNavigationDistance = nullptr;
         jmethodID onNavigationFullState = nullptr;
+        jmethodID onVehicleEnergyForecast = nullptr;
         jmethodID onMediaMetadata = nullptr;
         jmethodID onMediaPlayback = nullptr;
         jmethodID onPhoneStatus = nullptr;

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
@@ -1,5 +1,6 @@
 package com.openautolink.app.cluster
 
+import android.os.SystemClock
 import android.content.Intent
 import android.util.Log
 import com.openautolink.app.diagnostics.DiagnosticLog
@@ -8,6 +9,7 @@ import androidx.car.app.Screen
 import androidx.car.app.Session
 import androidx.car.app.model.Action
 import androidx.car.app.model.ActionStrip
+import androidx.car.app.model.CarText
 import androidx.car.app.model.Template
 import androidx.car.app.navigation.NavigationManager
 import androidx.car.app.navigation.NavigationManagerCallback
@@ -20,11 +22,13 @@ import androidx.car.app.navigation.model.Trip
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.openautolink.app.navigation.ManeuverState
+import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -170,7 +174,10 @@ class ClusterMainSession : Session() {
     private suspend fun collectNavigationState() {
         var debounceJob: Job? = null
 
-        ClusterNavigationState.state.collectLatest { maneuver ->
+        combine(
+            ClusterNavigationState.state,
+            ClusterNavigationState.vehicleEnergyForecast,
+        ) { maneuver, _ -> maneuver }.collectLatest { maneuver ->
             debounceJob?.cancel()
             debounceJob = scope?.launch {
                 delay(200)
@@ -284,7 +291,15 @@ class ClusterMainSession : Session() {
             } else {
                 eta
             }
-            val destEstimate = TravelEstimate.Builder(destDistance, destEta).build()
+            val destEstimateBuilder = TravelEstimate.Builder(destDistance, destEta)
+            val forecast = ClusterNavigationState.vehicleEnergyForecast.value
+            if (VehicleEnergyForecastPolicy.isFresh(forecast, SystemClock.elapsedRealtime())) {
+                VehicleEnergyForecastPolicy.tripText(
+                    forecast,
+                    ClusterNavigationState.batteryCapacityWh,
+                )?.let { destEstimateBuilder.setTripText(CarText.create(it)) }
+            }
+            val destEstimate = destEstimateBuilder.build()
             tripBuilder.addDestination(destBuilder.build(), destEstimate)
         }
 

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationState.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationState.kt
@@ -1,6 +1,7 @@
 package com.openautolink.app.cluster
 
 import com.openautolink.app.navigation.ManeuverState
+import com.openautolink.app.navigation.VehicleEnergyForecast
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,6 +20,10 @@ object ClusterNavigationState {
     private val _state = MutableStateFlow<ManeuverState?>(null)
     val state: StateFlow<ManeuverState?> = _state.asStateFlow()
 
+    /** Latest route-aware result from Maps and the VEM capacity snapshot used with it. */
+    val vehicleEnergyForecast = MutableStateFlow<VehicleEnergyForecast?>(null)
+    @Volatile var batteryCapacityWh: Int = 0
+
     /** Distance unit preference: "auto", "metric", or "imperial". */
     @Volatile
     var distanceUnits: String = "auto"
@@ -32,6 +37,7 @@ object ClusterNavigationState {
 
     fun clear() {
         _state.value = null
+        vehicleEnergyForecast.value = null
     }
 }
 

--- a/app/src/main/java/com/openautolink/app/cluster/OalClusterSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/OalClusterSession.kt
@@ -1,5 +1,6 @@
 package com.openautolink.app.cluster
 
+import android.os.SystemClock
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.util.Base64
@@ -10,6 +11,7 @@ import androidx.car.app.Session
 import androidx.car.app.model.Action
 import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.CarIcon
+import androidx.car.app.model.CarText
 import androidx.car.app.model.Template
 import androidx.car.app.navigation.NavigationManager
 import androidx.car.app.navigation.NavigationManagerCallback
@@ -28,12 +30,14 @@ import androidx.lifecycle.LifecycleOwner
 import com.openautolink.app.navigation.ManeuverIconRenderer
 import com.openautolink.app.navigation.ManeuverState
 import com.openautolink.app.navigation.ManeuverType
+import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import com.openautolink.app.navigation.LaneInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -106,7 +110,10 @@ class OalClusterSession : Session() {
 
     private suspend fun collectNavigationState() {
         var debounceJob: Job? = null
-        ClusterNavigationState.state.collectLatest { maneuver ->
+        combine(
+            ClusterNavigationState.state,
+            ClusterNavigationState.vehicleEnergyForecast,
+        ) { maneuver, _ -> maneuver }.collectLatest { maneuver ->
             debounceJob?.cancel()
             debounceJob = scope?.launch {
                 delay(200)
@@ -198,7 +205,15 @@ class OalClusterSession : Session() {
             } else {
                 eta
             }
-            val destEstimate = TravelEstimate.Builder(destDistance, destEta).build()
+            val destEstimateBuilder = TravelEstimate.Builder(destDistance, destEta)
+            val forecast = ClusterNavigationState.vehicleEnergyForecast.value
+            if (VehicleEnergyForecastPolicy.isFresh(forecast, SystemClock.elapsedRealtime())) {
+                VehicleEnergyForecastPolicy.tripText(
+                    forecast,
+                    ClusterNavigationState.batteryCapacityWh,
+                )?.let { destEstimateBuilder.setTripText(CarText.create(it)) }
+            }
+            val destEstimate = destEstimateBuilder.build()
             tripBuilder.addDestination(destBuilder.build(), destEstimate)
         }
 

--- a/app/src/main/java/com/openautolink/app/input/EvEnergyValuePolicy.kt
+++ b/app/src/main/java/com/openautolink/app/input/EvEnergyValuePolicy.kt
@@ -1,0 +1,14 @@
+package com.openautolink.app.input
+
+/** Unit and provenance rules for EV values crossing from VHAL into Maps' VEM. */
+object EvEnergyValuePolicy {
+    private const val DEFAULT_MAX_CHARGE_POWER_W = 150_000
+
+    /** AOSP defines EV_BATTERY_INSTANTANEOUS_CHARGE_RATE in milliwatts. */
+    fun instantaneousMilliwattsToWatts(valueMilliwatts: Float?): Float? =
+        valueMilliwatts?.div(1_000f)
+
+    /** Maximum capability comes from a vehicle profile, never a live pack-flow sample. */
+    fun maxChargePowerWatts(profileMaximumWatts: Int?): Int =
+        profileMaximumWatts?.takeIf { it > 0 } ?: DEFAULT_MAX_CHARGE_POWER_W
+}

--- a/app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt
+++ b/app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt
@@ -670,7 +670,9 @@ class VehicleDataForwarderImpl(
         } else null
 
         val ambientTemp = tempId?.let { currentValues[it] as? Float }
-        val chargeRate = chargeRateId?.let { currentValues[it] as? Float }
+        val chargeRate = EvEnergyValuePolicy.instantaneousMilliwattsToWatts(
+            chargeRateId?.let { currentValues[it] as? Float },
+        )
         val rangeRemaining = rangeId?.let { (currentValues[it] as? Float)?.let { v -> v / 1000f } } // m → km
         val rpmRaw = rpmId?.let { currentValues[it] as? Float }
         val rpmE3 = rpmRaw?.let { (it * 1000).toInt() }

--- a/app/src/main/java/com/openautolink/app/navigation/VehicleEnergyForecast.kt
+++ b/app/src/main/java/com/openautolink/app/navigation/VehicleEnergyForecast.kt
@@ -1,0 +1,55 @@
+package com.openautolink.app.navigation
+
+import kotlin.math.roundToInt
+
+/** Route-aware energy result calculated by Google Maps and returned over GAL 5.1+. */
+data class VehicleEnergyForecast(
+    val energyAtNextStop: EnergyAtDistance? = null,
+    val distanceToEmpty: EnergyAtDistance? = null,
+    val forecastQuality: Int = QUALITY_UNKNOWN,
+    val nextChargingStop: ChargingStationDetails? = null,
+    val receivedAtElapsedMs: Long,
+) {
+    companion object {
+        const val QUALITY_UNKNOWN = 0
+        const val QUALITY_LOW = 1
+        const val QUALITY_HIGH = 2
+    }
+}
+
+data class EnergyAtDistance(
+    val distanceMeters: Int,
+    val arrivalBatteryEnergyWh: Int,
+    val timeToArrivalSeconds: Int,
+)
+
+data class ChargingStationDetails(
+    val minimumDepartureEnergyWh: Int,
+    val maximumRatedPowerWatts: Int,
+    val estimatedChargingTimeSeconds: Int,
+)
+
+/** Formatting and validity rules shared by projection, diagnostics, and cluster output. */
+object VehicleEnergyForecastPolicy {
+    const val MAX_AGE_MS = 120_000L
+
+    fun arrivalPercent(forecast: VehicleEnergyForecast?, batteryCapacityWh: Int): Int? {
+        val arrivalWh = forecast?.energyAtNextStop?.arrivalBatteryEnergyWh ?: return null
+        if (arrivalWh < 0 || batteryCapacityWh <= 0) return null
+        return (arrivalWh.toDouble() / batteryCapacityWh.toDouble() * 100.0)
+            .roundToInt()
+            .coerceIn(0, 100)
+    }
+
+    fun tripText(forecast: VehicleEnergyForecast?, batteryCapacityWh: Int): String? {
+        val percent = arrivalPercent(forecast, batteryCapacityWh) ?: return null
+        val approximate = forecast?.forecastQuality != VehicleEnergyForecast.QUALITY_HIGH
+        return if (approximate) "Arrive ~$percent%" else "Arrive $percent%"
+    }
+
+    fun isFresh(forecast: VehicleEnergyForecast?, nowElapsedMs: Long): Boolean {
+        forecast ?: return false
+        val age = nowElapsedMs - forecast.receivedAtElapsedMs
+        return age in 0..MAX_AGE_MS
+    }
+}

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -29,6 +29,8 @@ import com.openautolink.app.media.OalMediaSessionManager
 import com.openautolink.app.navigation.ManeuverState
 import com.openautolink.app.navigation.NavigationDisplay
 import com.openautolink.app.navigation.NavigationDisplayImpl
+import com.openautolink.app.navigation.VehicleEnergyForecast
+import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import com.openautolink.app.transport.AudioPurpose
 import com.openautolink.app.transport.ConnectionState
 import com.openautolink.app.transport.ControlMessage
@@ -277,6 +279,7 @@ class SessionManager(
 
     /** Collectors bound to one AasdkSession, cancelled when it is replaced. */
     private var sessionCollectors: kotlinx.coroutines.Job? = null
+    private var forecastExpiryJob: kotlinx.coroutines.Job? = null
 
     /**
      * Subscribe to everything a session produces: frames, control messages,
@@ -315,6 +318,23 @@ class SessionManager(
                 session.controlMessages.collect { message ->
                     lastActiveTimestamp = SystemClock.elapsedRealtime()
                     handleControlMessage(message)
+                }
+            }
+            launch {
+                session.vehicleEnergyForecast.collect { forecast ->
+                    forecastExpiryJob?.cancel()
+                    _vehicleEnergyForecast.value = forecast
+                    ClusterNavigationState.vehicleEnergyForecast.value = forecast
+                    forecastExpiryJob = if (forecast != null) {
+                        scope.launch {
+                            delay(VehicleEnergyForecastPolicy.MAX_AGE_MS)
+                            if (_vehicleEnergyForecast.value === forecast) {
+                                DiagnosticLog.i("vem", "Maps forecast expired after 120s")
+                                _vehicleEnergyForecast.value = null
+                                ClusterNavigationState.vehicleEnergyForecast.value = null
+                            }
+                        }
+                    } else null
                 }
             }
             launch(videoDispatcher) {
@@ -548,6 +568,12 @@ class SessionManager(
     // Navigation display
     private val _navigationDisplay: NavigationDisplay = NavigationDisplayImpl()
     val navigationDisplay: NavigationDisplay get() = _navigationDisplay
+
+    private val _vehicleEnergyForecast = MutableStateFlow<VehicleEnergyForecast?>(null)
+    val vehicleEnergyForecast: StateFlow<VehicleEnergyForecast?> =
+        _vehicleEnergyForecast.asStateFlow()
+    private val _vehicleBatteryCapacityWh = MutableStateFlow(0)
+    val vehicleBatteryCapacityWh: StateFlow<Int> = _vehicleBatteryCapacityWh.asStateFlow()
 
     // Diagnostics
     private var _remoteDiagnostics: RemoteDiagnosticsImpl? = null
@@ -813,6 +839,10 @@ class SessionManager(
             val capacityWh = vd.evBatteryCapacityWh?.toInt() ?: 0
             val rangeM = ((vd.rangeKm ?: 0f) * 1000).toInt()
             val chargeW = vd.evChargeRateW?.toInt() ?: 0
+            if (capacityWh > 0) {
+                _vehicleBatteryCapacityWh.value = capacityWh
+                ClusterNavigationState.batteryCapacityWh = capacityWh
+            }
             val now = SystemClock.elapsedRealtime()
             evLearnedEstimator?.onVehicleTick(vd, now)
             refreshEvProfileLookup(vd)
@@ -1643,6 +1673,8 @@ class SessionManager(
         videoStallWatchJob = null
         callStateJob?.cancel()
         callStateJob = null
+        sessionCollectors?.cancel()
+        sessionCollectors = null
         aasdkSession?.stop()
         aasdkSession = null
         stopDirectLocationForwarding()
@@ -1660,6 +1692,9 @@ class SessionManager(
         _vehicleDataForwarder = null
         _imuForwarder?.stop()
         _imuForwarder = null
+        forecastExpiryJob?.cancel()
+        forecastExpiryJob = null
+        _vehicleEnergyForecast.value = null
         _navigationDisplay.clear()
         ClusterNavigationState.clear()
         // Do NOT release the MediaSession — it's the process-wide singleton and
@@ -2596,6 +2631,7 @@ class SessionManager(
             }
             is ControlMessage.NavStateClear -> {
                 _navigationDisplay.clear()
+                _vehicleEnergyForecast.value = null
                 ClusterNavigationState.clear()
             }
             is ControlMessage.MediaMetadata -> {

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -1,9 +1,13 @@
 package com.openautolink.app.transport.aasdk
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.Log
 import com.openautolink.app.audio.AudioFrame
 import com.openautolink.app.diagnostics.OalLog
+import com.openautolink.app.navigation.ChargingStationDetails
+import com.openautolink.app.navigation.EnergyAtDistance
+import com.openautolink.app.navigation.VehicleEnergyForecast
 import com.openautolink.app.transport.AudioPurpose
 import com.openautolink.app.transport.ConnectionState
 import com.openautolink.app.transport.ControlMessage
@@ -82,6 +86,10 @@ class AasdkSession(
 
     private val _controlMessages = MutableSharedFlow<ControlMessage>(extraBufferCapacity = 64)
     val controlMessages: Flow<ControlMessage> = _controlMessages.asSharedFlow()
+
+    private val _vehicleEnergyForecast = MutableStateFlow<VehicleEnergyForecast?>(null)
+    val vehicleEnergyForecast: StateFlow<VehicleEnergyForecast?> =
+        _vehicleEnergyForecast.asStateFlow()
 
     // -- Config (set before start()) --
 
@@ -671,6 +679,7 @@ class AasdkSession(
 
     override fun onSessionStopped(reason: String) {
         OalLog.i(TAG, "AA session stopped: $reason")
+        _vehicleEnergyForecast.value = null
         // Clean up dead transport
         transportPipe?.close()
         transportPipe = null
@@ -852,6 +861,7 @@ class AasdkSession(
         scope.launch {
             com.openautolink.app.diagnostics.DiagnosticLog.i("nav", "Status: $status (${if (status == 1) "ACTIVE" else "INACTIVE"})")
             if (status != 1) { // not ACTIVE
+                _vehicleEnergyForecast.value = null
                 _controlMessages.emit(ControlMessage.NavStateClear)
             }
         }
@@ -919,6 +929,51 @@ class AasdkSession(
                 destDistanceUnit = destDistUnit
             ))
         }
+    }
+
+    override fun onVehicleEnergyForecast(
+        nextStopDistanceMeters: Int,
+        nextStopArrivalEnergyWh: Int,
+        nextStopTimeSeconds: Int,
+        distanceToEmptyMeters: Int,
+        distanceToEmptyEnergyWh: Int,
+        distanceToEmptyTimeSeconds: Int,
+        forecastQuality: Int,
+        minimumDepartureEnergyWh: Int,
+        maximumRatedPowerWatts: Int,
+        estimatedChargingTimeSeconds: Int,
+    ) {
+        _vehicleEnergyForecast.value = VehicleEnergyForecast(
+            energyAtNextStop = if (nextStopArrivalEnergyWh >= 0) {
+                EnergyAtDistance(
+                    nextStopDistanceMeters,
+                    nextStopArrivalEnergyWh,
+                    nextStopTimeSeconds,
+                )
+            } else null,
+            distanceToEmpty = if (distanceToEmptyMeters >= 0) {
+                EnergyAtDistance(
+                    distanceToEmptyMeters,
+                    distanceToEmptyEnergyWh,
+                    distanceToEmptyTimeSeconds,
+                )
+            } else null,
+            forecastQuality = forecastQuality,
+            nextChargingStop = if (maximumRatedPowerWatts >= 0 || minimumDepartureEnergyWh >= 0) {
+                ChargingStationDetails(
+                    minimumDepartureEnergyWh,
+                    maximumRatedPowerWatts,
+                    estimatedChargingTimeSeconds,
+                )
+            } else null,
+            receivedAtElapsedMs = SystemClock.elapsedRealtime(),
+        )
+        com.openautolink.app.diagnostics.DiagnosticLog.i(
+            "vem",
+            "Maps forecast received: arrival=${nextStopArrivalEnergyWh}Wh " +
+                "distance=${nextStopDistanceMeters}m quality=$forecastQuality " +
+                "charge=${maximumRatedPowerWatts}W",
+        )
     }
 
     /**

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
@@ -74,6 +74,20 @@ interface AasdkSessionCallback {
         destDistDisplay: String?, destDistUnit: String?
     )
 
+    /** Google Maps route-energy result returned on navigation message 0x8008 (GAL 5.1+). */
+    fun onVehicleEnergyForecast(
+        nextStopDistanceMeters: Int,
+        nextStopArrivalEnergyWh: Int,
+        nextStopTimeSeconds: Int,
+        distanceToEmptyMeters: Int,
+        distanceToEmptyEnergyWh: Int,
+        distanceToEmptyTimeSeconds: Int,
+        forecastQuality: Int,
+        minimumDepartureEnergyWh: Int,
+        maximumRatedPowerWatts: Int,
+        estimatedChargingTimeSeconds: Int,
+    )
+
     /** Media metadata update (track info). */
     fun onMediaMetadata(title: String, artist: String, album: String, albumArt: ByteArray?)
 

--- a/app/src/main/java/com/openautolink/app/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/diagnostics/DiagnosticsScreen.kt
@@ -1275,6 +1275,28 @@ private fun CarTab(car: CarInfo) {
                 val capStr = car.evBatteryCapacityWh?.let { c -> " / ${"%.0f".format(c)}" } ?: ""
                 DiagRow("Battery Energy", "${"%.0f".format(it)}$capStr Wh")
             }
+            car.mapsArrivalBatteryPct?.let {
+                val quality = when (car.mapsForecastQuality) {
+                    2 -> "high"
+                    1 -> "low"
+                    else -> "unknown"
+                }
+                DiagRow(
+                    "Maps Arrival",
+                    "$it% ($quality confidence)",
+                    valueColor = when {
+                        it > 50 -> Color(0xFF4CAF50)
+                        it > 20 -> Color(0xFFFFC107)
+                        else -> Color(0xFFFF5722)
+                    },
+                )
+            }
+            car.mapsNextChargePowerW?.let {
+                val time = car.mapsChargingTimeSec?.let { seconds ->
+                    " • ${seconds / 60} min"
+                } ?: ""
+                DiagRow("Maps Next Charge", "${it / 1000} kW$time")
+            }
             car.evCurrentBatteryCapacityWh?.let {
                 DiagRow("Usable Capacity", "${"%.0f".format(it)} Wh")
             }

--- a/app/src/main/java/com/openautolink/app/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/diagnostics/DiagnosticsViewModel.kt
@@ -10,6 +10,8 @@ import android.view.WindowManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.openautolink.app.data.AppPreferences
+import com.openautolink.app.navigation.VehicleEnergyForecast
+import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import com.openautolink.app.session.SessionManager
 import com.openautolink.app.session.SessionState
 import com.openautolink.app.transport.ControlMessage
@@ -97,6 +99,10 @@ data class CarInfo(
     val evChargeRateW: Float? = null,
     val evBatteryLevelWh: Float? = null,
     val evBatteryCapacityWh: Float? = null,
+    val mapsArrivalBatteryPct: Int? = null,
+    val mapsForecastQuality: Int? = null,
+    val mapsNextChargePowerW: Int? = null,
+    val mapsChargingTimeSec: Int? = null,
     // Extended EV properties
     val evChargeState: Int? = null,
     val evChargeTimeRemainingSec: Int? = null,
@@ -276,6 +282,24 @@ class DiagnosticsViewModel(application: Application) : AndroidViewModel(applicat
         DiagnosticsUiState(system = _system.value)
     )
 
+    private fun withMapsForecast(
+        car: CarInfo,
+        forecast: VehicleEnergyForecast?,
+    ): CarInfo {
+        val capacityWh = car.evBatteryCapacityWh?.toInt() ?: 0
+        return car.copy(
+            mapsArrivalBatteryPct = VehicleEnergyForecastPolicy.arrivalPercent(
+                forecast,
+                capacityWh,
+            ),
+            mapsForecastQuality = forecast?.forecastQuality,
+            mapsNextChargePowerW = forecast?.nextChargingStop?.maximumRatedPowerWatts
+                ?.takeIf { it >= 0 },
+            mapsChargingTimeSec = forecast?.nextChargingStop?.estimatedChargingTimeSeconds
+                ?.takeIf { it >= 0 },
+        )
+    }
+
     init {
         // Start local log capture while diagnostics is open
         com.openautolink.app.diagnostics.DiagnosticLog.startLocalCapture()
@@ -314,7 +338,7 @@ class DiagnosticsViewModel(application: Application) : AndroidViewModel(applicat
 
         viewModelScope.launch {
             forwarder.latestVehicleData.collect { vd ->
-                _car.value = CarInfo(
+                _car.value = withMapsForecast(CarInfo(
                     isActive = forwarder.isActive,
                     speedKmh = vd.speedKmh,
                     gear = vd.gear,
@@ -352,7 +376,13 @@ class DiagnosticsViewModel(application: Application) : AndroidViewModel(applicat
                     evMotorPowerW = vd.evMotorPowerW,
                     evMotorTorqueNm = vd.evMotorTorqueNm,
                     propertyStatus = forwarder.propertyStatus,
-                )
+                ), sessionManager.vehicleEnergyForecast.value)
+            }
+        }
+
+        viewModelScope.launch {
+            sessionManager.vehicleEnergyForecast.collect { forecast ->
+                _car.value = withMapsForecast(_car.value, forecast)
             }
         }
 

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
@@ -726,6 +726,22 @@ fun ProjectionScreen(
             }
         }
 
+        uiState.arrivalBatteryText?.let { arrivalText ->
+            Text(
+                text = arrivalText,
+                color = Color.White,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(12.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.Black.copy(alpha = 0.72f))
+                    .padding(horizontal = 14.dp, vertical = 8.dp)
+                    .testTag("mapsArrivalBatteryBadge"),
+            )
+        }
+
         // Stats overlay panel — bottom-left
         if (uiState.showStats) {
             VideoStatsOverlay(

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -23,6 +23,8 @@ import com.openautolink.app.input.SteeringWheelController
 import com.openautolink.app.input.TouchForwarder
 import com.openautolink.app.input.TouchForwarderImpl
 import com.openautolink.app.navigation.ManeuverState
+import com.openautolink.app.navigation.VehicleEnergyForecast
+import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import com.openautolink.app.session.SessionManager
 import com.openautolink.app.session.SessionState
 import com.openautolink.app.video.VideoStats
@@ -52,6 +54,7 @@ data class ProjectionUiState(
     val audioStats: AudioStats = AudioStats(),
     val showStats: Boolean = false,
     val maneuver: ManeuverState? = null,
+    val arrivalBatteryText: String? = null,
     val phoneBatteryLevel: Int? = null,
     val phoneBatteryCritical: Boolean = false,
     val voiceSessionActive: Boolean = false,
@@ -257,6 +260,8 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         preferences.overlayStatsButton,
         preferences.overlayPhoneSwitchButton,
         preferences.overlayReconnectButton,
+        sessionManager.vehicleEnergyForecast,
+        sessionManager.vehicleBatteryCapacityWh,
     ) { values ->
         ProjectionUiState(
             sessionState = values[0] as SessionState,
@@ -293,6 +298,10 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             overlayStatsButton = values[31] as Boolean,
             overlayPhoneSwitchButton = values[32] as Boolean,
             overlayReconnectButton = values[33] as Boolean,
+            arrivalBatteryText = VehicleEnergyForecastPolicy.tripText(
+                values[34] as? VehicleEnergyForecast,
+                values[35] as Int,
+            ),
         )
     }.stateIn(
         viewModelScope,

--- a/app/src/test/java/com/openautolink/app/input/EvEnergyValuePolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/input/EvEnergyValuePolicyTest.kt
@@ -1,0 +1,21 @@
+package com.openautolink.app.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EvEnergyValuePolicyTest {
+    @Test
+    fun `instantaneous VHAL battery power converts milliwatts to watts`() {
+        assertEquals(35_500f, EvEnergyValuePolicy.instantaneousMilliwattsToWatts(35_500_000f))
+        assertEquals(-2_500f, EvEnergyValuePolicy.instantaneousMilliwattsToWatts(-2_500_000f))
+        assertNull(EvEnergyValuePolicy.instantaneousMilliwattsToWatts(null))
+    }
+
+    @Test
+    fun `maximum charging capability never comes from instantaneous pack power`() {
+        assertEquals(190_000, EvEnergyValuePolicy.maxChargePowerWatts(190_000))
+        assertEquals(150_000, EvEnergyValuePolicy.maxChargePowerWatts(null))
+        assertEquals(150_000, EvEnergyValuePolicy.maxChargePowerWatts(0))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastPolicyTest.kt
@@ -1,0 +1,62 @@
+package com.openautolink.app.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VehicleEnergyForecastPolicyTest {
+    private fun forecast(
+        arrivalWh: Int = 35_700,
+        quality: Int = VehicleEnergyForecast.QUALITY_HIGH,
+        receivedAtMs: Long = 1_000L,
+    ) = VehicleEnergyForecast(
+        energyAtNextStop = EnergyAtDistance(
+            distanceMeters = 100_000,
+            arrivalBatteryEnergyWh = arrivalWh,
+            timeToArrivalSeconds = 3_600,
+        ),
+        distanceToEmpty = EnergyAtDistance(250_000, 0, 9_000),
+        forecastQuality = quality,
+        nextChargingStop = ChargingStationDetails(20_000, 190_000, 1_200),
+        receivedAtElapsedMs = receivedAtMs,
+    )
+
+    @Test
+    fun `arrival percentage uses Maps energy and the VEM capacity snapshot`() {
+        assertEquals(42, VehicleEnergyForecastPolicy.arrivalPercent(forecast(), 85_000))
+    }
+
+    @Test
+    fun `arrival percentage rejects missing or invalid energy`() {
+        assertNull(VehicleEnergyForecastPolicy.arrivalPercent(forecast(arrivalWh = -1), 85_000))
+        assertNull(VehicleEnergyForecastPolicy.arrivalPercent(forecast(), 0))
+        assertNull(VehicleEnergyForecastPolicy.arrivalPercent(null, 85_000))
+    }
+
+    @Test
+    fun `arrival percentage clamps malformed over capacity forecasts`() {
+        assertEquals(100, VehicleEnergyForecastPolicy.arrivalPercent(forecast(arrivalWh = 100_000), 85_000))
+    }
+
+    @Test
+    fun `cluster text distinguishes high and lower confidence forecasts`() {
+        assertEquals("Arrive 42%", VehicleEnergyForecastPolicy.tripText(forecast(), 85_000))
+        assertEquals(
+            "Arrive ~42%",
+            VehicleEnergyForecastPolicy.tripText(
+                forecast(quality = VehicleEnergyForecast.QUALITY_LOW),
+                85_000,
+            ),
+        )
+    }
+
+    @Test
+    fun `forecast freshness is bounded and monotonic`() {
+        val value = forecast(receivedAtMs = 1_000L)
+        assertTrue(VehicleEnergyForecastPolicy.isFresh(value, nowElapsedMs = 120_999L))
+        assertFalse(VehicleEnergyForecastPolicy.isFresh(value, nowElapsedMs = 121_001L))
+        assertFalse(VehicleEnergyForecastPolicy.isFresh(value, nowElapsedMs = 999L))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastWiringContractTest.kt
@@ -1,0 +1,92 @@
+package com.openautolink.app.navigation
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VehicleEnergyForecastWiringContractTest {
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun `typed GAL forecast reaches a process scoped Kotlin state flow`() {
+        val callback = projectFile("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt")
+        val session = projectFile("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt")
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val header = projectFile("app/src/main/cpp/jni_session.h")
+        val manager = projectFile("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+
+        assertTrue(callback.contains("fun onVehicleEnergyForecast("))
+        assertTrue(header.contains("jmethodID onVehicleEnergyForecast"))
+        assertTrue(native.contains("GetMethodID(cbClass, \"onVehicleEnergyForecast\""))
+        assertTrue(native.contains("CallVoidMethod(callbackRef_, cbMethods_.onVehicleEnergyForecast"))
+        assertTrue(session.contains("val vehicleEnergyForecast: StateFlow<VehicleEnergyForecast?>"))
+        assertTrue(session.contains("override fun onVehicleEnergyForecast("))
+        assertTrue(manager.contains("val vehicleEnergyForecast: StateFlow<VehicleEnergyForecast?>"))
+        assertTrue(manager.contains("session.vehicleEnergyForecast.collect"))
+    }
+
+    @Test
+    fun `route and session termination clear stale forecast state`() {
+        val session = projectFile("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt")
+        val manager = projectFile("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+
+        val stopStart = session.indexOf("override fun onSessionStopped(reason: String)")
+        val stopEnd = session.indexOf("override fun onVideoFrame", stopStart)
+        assertTrue(stopStart >= 0 && stopEnd > stopStart)
+        assertTrue(session.substring(stopStart, stopEnd).contains("_vehicleEnergyForecast.value = null"))
+
+        val navStart = session.indexOf("override fun onNavigationStatus(status: Int)")
+        val navEnd = session.indexOf("override fun onNavigationTurn", navStart)
+        assertTrue(navStart >= 0 && navEnd > navStart)
+        assertTrue(session.substring(navStart, navEnd).contains("_vehicleEnergyForecast.value = null"))
+        assertTrue(manager.contains("_vehicleEnergyForecast.value = null"))
+        assertTrue(manager.contains("delay(VehicleEnergyForecastPolicy.MAX_AGE_MS)"))
+        assertTrue(manager.contains("forecastExpiryJob?.cancel()"))
+
+        val managerStopStart = manager.indexOf("fun stop()")
+        val managerStopEnd = manager.indexOf("fun reconnect(", managerStopStart)
+        assertTrue(managerStopStart >= 0 && managerStopEnd > managerStopStart)
+        val managerStop = manager.substring(managerStopStart, managerStopEnd)
+        assertTrue(managerStop.contains("sessionCollectors?.cancel()"))
+        assertTrue(
+            managerStop.indexOf("sessionCollectors?.cancel()") <
+                managerStop.indexOf("_vehicleEnergyForecast.value = null"),
+        )
+    }
+
+    @Test
+    fun `both cluster paths publish Maps arrival SOC through TravelEstimate trip text`() {
+        for (path in listOf(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
+            "app/src/main/java/com/openautolink/app/cluster/OalClusterSession.kt",
+        )) {
+            val source = projectFile(path)
+            assertTrue("$path must consume the shared forecast", source.contains("ClusterNavigationState.vehicleEnergyForecast"))
+            assertTrue("$path must use the VEM capacity snapshot", source.contains("ClusterNavigationState.batteryCapacityWh"))
+            assertTrue("$path must publish trip text", source.contains("setTripText"))
+        }
+    }
+
+    @Test
+    fun `VHAL charge power is converted from milliwatts and never becomes max capability`() {
+        val forwarder = projectFile("app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt")
+        val native = projectFile("app/src/main/cpp/jni_session.cpp")
+        val start = native.indexOf("void JniSession::sendEnergyModelSensor")
+        val end = native.indexOf("void JniSession::sendAccelerometerSensor", start)
+        assertTrue(start >= 0 && end > start)
+        val sender = native.substring(start, end)
+
+        assertTrue(forwarder.contains("EvEnergyValuePolicy.instantaneousMilliwattsToWatts"))
+        assertTrue(sender.contains("maxChargeWOverride > 0 ? maxChargeWOverride : 150000"))
+        assertFalse(sender.contains("chargeRateW > 0"))
+        assertTrue(sender.contains("auxWhPerKmOverride >= 0.0f ? auxWhPerKmOverride : 0.0f"))
+        assertTrue(sender.contains("aeroCoefOverride >= 0.0f ? aeroCoefOverride : 0.0f"))
+    }
+}

--- a/docs/ev-energy-model-reverse-engineering.md
+++ b/docs/ev-energy-model-reverse-engineering.md
@@ -333,7 +333,7 @@ Our app (`VehicleDataForwarderImpl.kt`) already subscribes to:
 | `EV_BATTERY_LEVEL` | 0x11600309 | CAR_ENERGY | Current battery Wh |
 | `INFO_EV_BATTERY_CAPACITY` | 0x11600106 | CAR_INFO | Max capacity Wh |
 | `RANGE_REMAINING` | 0x11600308 | CAR_ENERGY | Range in meters |
-| `EV_BATTERY_INSTANTANEOUS_CHARGE_RATE` | 0x1160030C | CAR_ENERGY | Charge rate W |
+| `EV_BATTERY_INSTANTANEOUS_CHARGE_RATE` | 0x1160030C | CAR_ENERGY | Instantaneous pack flow in mW (converted to W by OAL) |
 | `EV_BATTERY_AVERAGE_TEMPERATURE` | 0x1160030E | CAR_ENERGY | Pack temp ┬░C |
 | `INFO_FUEL_TYPE` | (runtime) | CAR_INFO | Fuel type list |
 | `INFO_EV_CONNECTOR_TYPE` | (runtime) | CAR_INFO | Connector type list |
@@ -426,11 +426,11 @@ battery.max_capacity.watt_hours = capacityWh          // EV_CURRENT_BATTERY_CAPA
 battery.min_usable_capacity.watt_hours = currentWh     // from EV_BATTERY_LEVEL — Maps reads this as current SOC!
 battery.reserve_energy.watt_hours = capacityWh * 0.05
 battery.regen_braking_capable = true
-battery.max_charge_power_w = EV_CHARGE_RATE or 150000  // needed for server-side routing
+battery.max_charge_power_w = curated vehicle profile or 150000 // instantaneous pack flow is not capability
 battery.max_discharge_power_w = 150000
 consumption.driving.rate = (currentWh / rangeM) * 1000  // Wh/km from car's own range estimate
-consumption.auxiliary.rate = 2.0                         // typical aux consumption
-consumption.aerodynamic.rate = 0.36                      // drag coefficient contribution
+consumption.auxiliary.rate = 0.0                         // range-derived driving rate already includes current auxiliaries
+consumption.aerodynamic.rate = 0.0                       // only nonzero in an independent tuned/profile model
 charging_prefs.mode = 1                                  // standard
 ```
 

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -13,7 +13,7 @@ The raw requested versionâ€”not a higher compatible tuple reported by the phoneâ
 | 1.7 | Legacy display policy and per-packet audio ACKs. |
 | 4.3 | Modern display ownership metadata and active media session IDs. |
 | 5.0 | Ackless phone-to-HU audio and one advertised codec family per display. |
-| 5.1 | Adds typed and raw handling for audio `MediaOptions` (`0x8014`) and navigation `VehicleEnergyForecast` (`0x8008`). |
+| 5.1 | Adds typed and raw handling for audio `MediaOptions` (`0x8014`) and exposes Maps' route-aware `VehicleEnergyForecast` (`0x8008`) to the cluster, projection badge, and diagnostics. |
 | 6.0 | Adds typed and raw modern video Start/MediaConfig and video `MediaOptions`, and activates Gearhead's short HEVC keyframe policy. |
 
 All versions retain OAL's proven `max_unacked=30`. Video remains ACKed at every version: legacy 1.7 preserves `session_id=0`, while GAL 4.3+ uses the active video `Start.session_id`. Modern audio is ackless.
@@ -47,6 +47,12 @@ Typed handling covers:
 - navigation `VehicleEnergyForecast` (`0x8008`), including its nested forecast.
 
 Malformed optional modern messages are logged and retained; they do not invent replies or alter session policy.
+
+When Maps supplies `VehicleEnergyForecast`, OAL formats its returned arrival
+energy against the same VEM capacity snapshot sent to the phone. High-quality
+forecasts render as `Arrive 42%`; lower/unknown quality renders as
+`Arrive ~42%`. Forecast state is cleared with the route/session and expires after
+two minutes so stale route energy cannot survive a navigation change.
 
 ## Expected H.265 effect
 


### PR DESCRIPTION
## What changed
- decode GAL 5.1+ `VehicleEnergyForecast` into Kotlin state
- show Maps arrival SOC in both cluster paths, a projection badge, and diagnostics
- expire/clear route forecasts on route/session teardown
- convert VHAL instantaneous charge rate from mW to W
- stop using instantaneous pack flow as maximum charging capability
- keep range-derived VEM internally coherent by avoiding synthetic aux/aero add-ons

## Verification
- 368 app unit tests, 0 failures/errors/skips
- `:app:externalNativeBuildDebug` for arm64-v8a and x86_64
- `:app:assembleDebug`
- JNI descriptor verified as `(IIIIIIIIII)V`
- native and DEX artifact markers verified in both ABIs/debug APK
- independent review found and then verified closure of a stale-forecast teardown race

## Runtime status
Implementation is ready to ship, but actual `0x8008` delivery and GM cluster rendering still require an in-car GAL 5.1+ route capture. Default GAL remains 1.7; select 5.1 or 6.0 and Save & Reconnect to exercise it.
