### PR TITLE
docs: mark H.265 startup resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The phone is the access point; the car is a client. Single-phone optimized — s
 - **USB cable support** — AOA v2 direct connection for wired setups
 - **aasdk v1.6 native protocol** — battle-tested C++ AA library via JNI, not a reimplementation
 - **EV battery data in Android Auto** — battery %, range, fuel type, charge port forwarded from VHAL into AA. Google Maps shows battery level alongside navigation
-- **H.264, H.265, and VP9** video with auto-negotiation. Up to 4K with AA Developer Mode
+- **H.264, H.265, and VP9** video with auto-negotiation. Up to 4K with AA Developer Mode. H.265 startup is verified clean over USB and wireless with GAL 6.0
 - **PCM and AAC-LC audio** — PCM for compatibility, AAC-LC for ~10× WiFi bandwidth reduction
 - **Display adaptation** *(work in progress)* — auto-computed AA scaling so wide and ultra-wide AAOS screens use the full panel without stretching the UI
 - **Per-purpose audio volume** — separate sliders for media, navigation, and assistant
@@ -365,6 +365,11 @@ The result is the intended Android Auto call experience: Android Auto displays a
 
 By default, the app uses auto-negotiation — the phone picks the best codec and resolution it supports.
 
+**H.265 startup is verified clean over USB and wireless.** With GAL 6.0,
+Gearhead uses a 120-frame GOP (one IDR after 119 P-frames), replacing the legacy
+approximately 3,600-frame cadence. In vehicle testing at 2560×1440, the first
+rendered frame arrived in 2.208 seconds over USB and 2.479 seconds wirelessly.
+
 ### Display Adaptation
 
 OpenAutoLink auto-computes a scale for the Android Auto UI, but you will want to tune it for your car's screen using the **DPI** setting.
@@ -392,7 +397,6 @@ The original architecture used an SBC (single-board computer) running a C++ brid
 ## Known Issues
 
 - **Android Auto 17.4+ needs the new setup** — wireless works, but only over Wireless (WPP) with Bluetooth paired and the car re-paired after updating. See the [notice at the top](#aa174).
-- **H.265 video may appear green-tinted** on first connection for 30–45 seconds. May be Qualcomm-specific — not yet confirmed on other SoCs
 
 If you encounter other problems, please [open an issue](https://github.com/mossyhub/openautolink/issues).
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -1229,9 +1229,9 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
         }
         Text(
             text = "Save & Reconnect applies the selected raw HU-requested version. " +
-                    "GAL 6.0 remains an implementation attempt until an in-car log confirms the 6.x response and runtime paths.",
+                    "GAL 6.0 is verified over USB and wireless with H.265 at 1440p.",
             style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.error,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 20.dp),
         )
 
@@ -1280,10 +1280,9 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Text(
             text = "Video codec the phone uses to encode the AA stream. " +
-                    "H.264 is the safe default — instant clean startup, capped at 1080p. " +
-                    "H.265 supports up to 4K but legacy GAL can take roughly two minutes " +
-                    "to deliver a full content IDR at 60 FPS. GAL 6.0 requests " +
-                    "Gearhead's short HEVC keyframe policy.",
+                    "H.264 supports resolutions through 1080p. H.265 / HEVC supports " +
+                    "1440p and 4K. With GAL 6.0, H.265 startup is verified over USB and wireless " +
+                    "with one IDR every 120 frames.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 12.dp)
@@ -1291,8 +1290,8 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         val isHighRes = uiState.aaResolution in listOf("1440p", "4k", "1440p_p", "4k_p")
         listOf(
-            Triple("h264", "H.264", " (Recommended)"),
-            Triple("h265", "H.265 / HEVC", if (isHighRes) " — needed for 1440p/4K" else " — green-startup risk"),
+            Triple("h264", "H.264", " — through 1080p"),
+            Triple("h265", "H.265 / HEVC", if (isHighRes) " — selected for 1440p/4K" else " — supports 1440p/4K"),
             Triple("vp9", "VP9", ""),
         ).forEach { (key, label, suffix) ->
             Row(

--- a/app/src/test/java/com/openautolink/app/ui/settings/H265ResolvedDocumentationContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/settings/H265ResolvedDocumentationContractTest.kt
@@ -1,0 +1,61 @@
+package com.openautolink.app.ui.settings
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class H265ResolvedDocumentationContractTest {
+    private val h265GreenWarning = Regex(
+        "(?i)(h\\.265|hevc).{0,160}green|green.{0,160}(h\\.265|hevc)",
+    )
+
+    private fun normalized(text: String): String = text.replace(Regex("\\s+"), " ")
+
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun `public README no longer lists H265 green startup as a known issue`() {
+        val readme = projectFile("README.md")
+
+        assertFalse(readme.contains("H.265 video may appear green-tinted"))
+        assertFalse(h265GreenWarning.containsMatchIn(normalized(readme)))
+        assertTrue(readme.contains("H.265 startup is verified clean over USB and wireless"))
+        assertTrue(readme.contains("120-frame GOP"))
+    }
+
+    @Test
+    fun `video settings present H265 as verified instead of risky`() {
+        val settings = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+        )
+
+        listOf(
+            "green-startup risk",
+            "H.264 (Recommended)",
+            "H.264 is the safe default",
+            "legacy GAL can take roughly two minutes",
+            "GAL 6.0 remains an implementation attempt",
+        ).forEach { stale -> assertFalse("Stale warning remains: $stale", settings.contains(stale)) }
+        assertFalse(h265GreenWarning.containsMatchIn(normalized(settings)))
+
+        assertTrue(settings.contains("verified over USB and wireless"))
+        assertTrue(settings.contains("one IDR every 120 frames"))
+    }
+
+    @Test
+    fun `GAL documentation records verified runtime result`() {
+        val galDoc = projectFile("docs/experimental-gal6.md")
+
+        assertFalse(galDoc.contains("implementation attempt until the next in-vehicle upload"))
+        assertFalse(h265GreenWarning.containsMatchIn(normalized(galDoc)))
+        assertTrue(galDoc.contains("Verified in vehicle"))
+        assertTrue(galDoc.contains("119 P-frames"))
+    }
+}

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -63,7 +63,16 @@ Gearhead's legacy wireless HEVC policy uses a 60-second I-frame interval. GAL 6.
 | 60 | ~3600 frames | ~120 frames |
 | 30 | ~1800 frames | ~60 frames |
 
-These are framework-derived predictions, not vehicle verification.
+The frame-count prediction was subsequently confirmed by the in-vehicle result below.
+
+## Verified in vehicle
+
+Build 0.1.454 verified the GAL 6 H.265 path at 2560×1440 over both USB and
+wireless. Gearhead negotiated 6.1 for the raw 6.0 request and emitted a real IDR
+after exactly 119 P-frames: a 120-frame GOP instead of the legacy approximately
+3,600-frame cadence. The first rendered frame arrived in 2.208 seconds over USB
+and 2.479 seconds wirelessly. Thirteen consecutive USB IDRs repeated the same
+119-P-frame spacing, and the startup image was visually clean on both transports.
 
 ## Runtime evidence required
 
@@ -82,4 +91,5 @@ The positive success signal is not merely a 6.x response. It is a stable end-to-
 
 If projection, audio, touch, or navigation regresses, select **1.7** and use **Save & Reconnect**. Do not use video-focus bouncing as a keyframe workaround; it caused a verified encoder-throttle regression.
 
-A Play release containing this code is an implementation attempt until the next in-vehicle upload proves the selected policy ran and projection remained healthy.
+GAL 6 H.265 startup is verified in vehicle. Select 1.7 only when testing legacy
+phone compatibility or isolating behavior outside the verified GAL 6 path.


### PR DESCRIPTION
## Summary
- remove the obsolete H.265 green-startup Known Issue from the README
- remove H.264-safe-default and H.265-risk wording from the car app
- replace the warning banner with the verified USB/wireless GAL 6 result
- document the measured 120-frame GOP and first-render times
- add a regression contract that rejects future H.265/HEVC green-warning wording across lines

## Verified evidence
Car 0.1.454 requested GAL 6.0 and received 6.1/STATUS_SUCCESS at 2560×1440 HEVC:
- one real IDR after exactly 119 P-frames (120-frame GOP)
- 13 consecutive USB IDRs at the same cadence
- first rendered frame: 2.208s USB, 2.479s wireless
- visually clean startup confirmed on both transports

Issue #18 is closed as verified in vehicle.

## Verification
- strict RED: all 3 documentation contract tests failed before the edits
- focused H.265 documentation contract: 3 passed
- full car app suite: 371 passed
- full companion suite: 57 passed
- app and companion debug Kotlin compilation passed
- independent review: PASS, no blockers
- stale warning searches: zero production/doc hits
- `git diff --check`: clean
