### PR TITLE
feat(protocol): default GAL 6 and remove arrival badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ The result is the intended Android Auto call experience: Android Auto displays a
 | 4K (3840×2160) | H.265, VP9 | Requires AA Developer Mode |
 
 By default, the app uses auto-negotiation — the phone picks the best codec and resolution it supports.
+GAL 6.0 is the default protocol policy for new and upgraded installs; GAL 1.7 remains available as a manual compatibility fallback.
 
 **H.265 startup is verified clean over USB and wireless.** With GAL 6.0,
 Gearhead uses a 120-frame GOP (one IDR after 119 P-frames), replacing the legacy

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -34,8 +34,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val VIDEO_AUTO_NEGOTIATE = booleanPreferencesKey("video_auto_negotiate")
         val VIDEO_CODEC = stringPreferencesKey("video_codec")
         val VIDEO_FPS = intPreferencesKey("video_fps")
-        val GAL_VERSION = stringPreferencesKey("gal_version")
-        /** Retained only to migrate installs that used the former Boolean toggle. */
+        // v2 deliberately starts every existing install on verified GAL 6.0.
+        // Choices made after this migration persist normally under the new key.
+        val GAL_VERSION = stringPreferencesKey("gal_version_v2")
+        /** Retained only to remove the former Boolean toggle on the next write. */
         val EXPERIMENTAL_GAL6 = booleanPreferencesKey("experimental_gal6")
         val DISPLAY_MODE = stringPreferencesKey("display_mode")
         val MIC_SOURCE = stringPreferencesKey("mic_source")
@@ -252,7 +254,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_VIDEO_AUTO_NEGOTIATE = true
         const val DEFAULT_VIDEO_CODEC = "h264"
         const val DEFAULT_VIDEO_FPS = 60
-        const val DEFAULT_GAL_VERSION = "1.7"
+        const val DEFAULT_GAL_VERSION = "6.0"
         const val DEFAULT_DISPLAY_MODE = "fullscreen_immersive"
         const val DEFAULT_MIC_SOURCE = "car"
         const val DEFAULT_BT_MAC_OVERRIDE = ""
@@ -397,10 +399,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
     }
 
     val galVersion: Flow<String> = dataStore.data.map { prefs ->
-        GalProtocolPolicy.resolvePersistedVersion(
-            configuredVersion = prefs[GAL_VERSION],
-            legacyEnabled = prefs[EXPERIMENTAL_GAL6],
-        )
+        GalProtocolPolicy.resolvePersistedVersion(prefs[GAL_VERSION])
     }
 
     val displayMode: Flow<String> = dataStore.data.map { prefs ->

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -115,7 +115,7 @@ class SettingsReceiver : BroadcastReceiver() {
                 "gal_version" -> {
                     val v = intent.getStringExtra("svalue") ?: return@runBlocking
                     val safeVersion = com.openautolink.app.transport.aasdk.GalProtocolPolicy
-                        .resolvePersistedVersion(v, null)
+                        .resolvePersistedVersion(v)
                     prefs.setGalVersion(safeVersion); log("gal_version=$safeVersion")
                 }
                 // Backward-compatible maintainer command for scripts that still

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSdrConfig.kt
@@ -72,7 +72,7 @@ class AasdkSdrConfig(
     @JvmField val videoCodec: String = "h265",
 
     /** Raw GAL/PDK version requested from the phone. */
-    @JvmField val galVersion: String = "1.7",
+    @JvmField val galVersion: String = "6.0",
 
     /** Physical pixel density of the AAOS display (from DisplayMetrics.densityDpi). */
     @JvmField val realDensity: Int = 0,

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/GalProtocolPolicy.kt
@@ -35,7 +35,7 @@ object GalProtocolPolicy {
     ).toMap()
 
     fun forVersion(configuredVersion: String): GalProtocolConfig {
-        val requested = versionsByName[configuredVersion] ?: GAL_1_7
+        val requested = versionsByName[configuredVersion] ?: GAL_6_0
         return GalProtocolConfig(
             requestedVersion = requested,
             maxUnacked = 30,
@@ -48,13 +48,9 @@ object GalProtocolPolicy {
         )
     }
 
-    /** Resolve the new string setting with a one-way fallback to the former Boolean. */
-    fun resolvePersistedVersion(configuredVersion: String?, legacyEnabled: Boolean?): String =
-        when {
-            configuredVersion in supportedVersions -> configuredVersion!!
-            legacyEnabled == true -> "6.0"
-            else -> "1.7"
-        }
+    /** Resolve the rotated setting; absent/invalid values enter verified GAL 6.0. */
+    fun resolvePersistedVersion(configuredVersion: String?): String =
+        configuredVersion?.takeIf { it in supportedVersions } ?: "6.0"
 
     fun expectedHevcGopFrames(configuredVersion: String, advertisedFps: Int): Int =
         forVersion(configuredVersion).hevcKeyframeIntervalSeconds * advertisedFps.coerceAtLeast(0)

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt
@@ -726,22 +726,6 @@ fun ProjectionScreen(
             }
         }
 
-        uiState.arrivalBatteryText?.let { arrivalText ->
-            Text(
-                text = arrivalText,
-                color = Color.White,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(12.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Color.Black.copy(alpha = 0.72f))
-                    .padding(horizontal = 14.dp, vertical = 8.dp)
-                    .testTag("mapsArrivalBatteryBadge"),
-            )
-        }
-
         // Stats overlay panel — bottom-left
         if (uiState.showStats) {
             VideoStatsOverlay(

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -23,8 +23,6 @@ import com.openautolink.app.input.SteeringWheelController
 import com.openautolink.app.input.TouchForwarder
 import com.openautolink.app.input.TouchForwarderImpl
 import com.openautolink.app.navigation.ManeuverState
-import com.openautolink.app.navigation.VehicleEnergyForecast
-import com.openautolink.app.navigation.VehicleEnergyForecastPolicy
 import com.openautolink.app.session.SessionManager
 import com.openautolink.app.session.SessionState
 import com.openautolink.app.video.VideoStats
@@ -54,7 +52,6 @@ data class ProjectionUiState(
     val audioStats: AudioStats = AudioStats(),
     val showStats: Boolean = false,
     val maneuver: ManeuverState? = null,
-    val arrivalBatteryText: String? = null,
     val phoneBatteryLevel: Int? = null,
     val phoneBatteryCritical: Boolean = false,
     val voiceSessionActive: Boolean = false,
@@ -260,8 +257,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         preferences.overlayStatsButton,
         preferences.overlayPhoneSwitchButton,
         preferences.overlayReconnectButton,
-        sessionManager.vehicleEnergyForecast,
-        sessionManager.vehicleBatteryCapacityWh,
     ) { values ->
         ProjectionUiState(
             sessionState = values[0] as SessionState,
@@ -298,10 +293,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             overlayStatsButton = values[31] as Boolean,
             overlayPhoneSwitchButton = values[32] as Boolean,
             overlayReconnectButton = values[33] as Boolean,
-            arrivalBatteryText = VehicleEnergyForecastPolicy.tripText(
-                values[34] as? VehicleEnergyForecast,
-                values[35] as Int,
-            ),
         )
     }.stateIn(
         viewModelScope,

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -1221,7 +1221,7 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
                         "4.3" -> "4.3 — modern display metadata"
                         "5.0" -> "5.0 — ackless audio, one codec family"
                         "5.1" -> "5.1 — media options and EV forecast"
-                        else -> "6.0 — modern video and short HEVC keyframes"
+                        else -> "6.0 — default; modern video and short HEVC keyframes"
                     },
                     style = MaterialTheme.typography.bodyLarge,
                 )

--- a/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/navigation/VehicleEnergyForecastWiringContractTest.kt
@@ -75,6 +75,28 @@ class VehicleEnergyForecastWiringContractTest {
     }
 
     @Test
+    fun `projection omits floating arrival badge while cluster and diagnostics retain forecast`() {
+        val screen = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionScreen.kt",
+        )
+        val viewModel = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
+        )
+        val diagnostics = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/diagnostics/DiagnosticsViewModel.kt",
+        )
+        val cluster = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
+        )
+
+        assertFalse(screen.contains("mapsArrivalBatteryBadge"))
+        assertFalse(screen.contains("arrivalBatteryText"))
+        assertFalse(viewModel.contains("arrivalBatteryText"))
+        assertTrue(diagnostics.contains("mapsArrivalBatteryPct"))
+        assertTrue(cluster.contains("setTripText"))
+    }
+
+    @Test
     fun `VHAL charge power is converted from milliwatts and never becomes max capability`() {
         val forwarder = projectFile("app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt")
         val native = projectFile("app/src/main/cpp/jni_session.cpp")

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6PreferenceContractTest.kt
@@ -28,11 +28,11 @@ class Gal6PreferenceContractTest {
     }
 
     @Test
-    fun `GAL defaults remain legacy until explicitly selected`() {
-        assertEquals("1.7", AppPreferences.DEFAULT_GAL_VERSION)
-        assertEquals("1.7", SettingsUiState().galVersion)
-        assertEquals("1.7", AasdkSdrConfig().galVersion)
-        assertTrue(AasdkSdrConfig().sendAudioAcks)
-        assertFalse(AasdkSdrConfig().modernDisplayPolicy)
+    fun `GAL 6 is the upgrade and fresh default while legacy remains selectable afterward`() {
+        assertEquals("6.0", AppPreferences.DEFAULT_GAL_VERSION)
+        assertEquals("6.0", SettingsUiState().galVersion)
+        assertEquals("6.0", AasdkSdrConfig().galVersion)
+        assertFalse(AasdkSdrConfig().sendAudioAcks)
+        assertTrue(AasdkSdrConfig().modernDisplayPolicy)
     }
 }

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/Gal6WiringContractTest.kt
@@ -25,7 +25,8 @@ class Gal6WiringContractTest {
 
         assertTrue(preferences.contains("val galVersion: Flow<String>"))
         assertTrue(preferences.contains("suspend fun setGalVersion"))
-        assertTrue(preferences.contains("prefs[EXPERIMENTAL_GAL6]"))
+        assertTrue(preferences.contains("stringPreferencesKey(\"gal_version_v2\")"))
+        assertTrue(preferences.contains("remove(EXPERIMENTAL_GAL6)"))
         assertTrue(settingsVm.contains("fun updateGalVersion"))
         assertTrue(settingsVm.contains("val galVersion: StateFlow<String>"))
         assertTrue(settingsUi.contains("testTag(\"galVersion_"))

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/GalProtocolPolicyTest.kt
@@ -45,20 +45,18 @@ class GalProtocolPolicyTest {
     }
 
     @Test
-    fun `invalid or future configured versions safely fall back to legacy`() {
+    fun `invalid or future configured versions fall back to verified GAL6 default`() {
         listOf("", " 6.0", "6.0 ", "4.03", "6.1", "garbage").forEach { value ->
-            assertEquals(GalProtocolVersion(1, 7), GalProtocolPolicy.forVersion(value).requestedVersion)
+            assertEquals(GalProtocolVersion(6, 0), GalProtocolPolicy.forVersion(value).requestedVersion)
         }
     }
 
     @Test
-    fun `persisted version migration preserves legacy users and gives new value precedence`() {
-        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion(null, null))
-        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion(null, false))
-        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion(null, true))
-        assertEquals("5.1", GalProtocolPolicy.resolvePersistedVersion("5.1", true))
-        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion("invalid", false))
-        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion("invalid", true))
+    fun `rotated preference defaults every upgrade to GAL6 and then preserves new selections`() {
+        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion(null))
+        assertEquals("5.1", GalProtocolPolicy.resolvePersistedVersion("5.1"))
+        assertEquals("1.7", GalProtocolPolicy.resolvePersistedVersion("1.7"))
+        assertEquals("6.0", GalProtocolPolicy.resolvePersistedVersion("invalid"))
     }
 
     @Test

--- a/docs/experimental-gal6.md
+++ b/docs/experimental-gal6.md
@@ -2,7 +2,10 @@
 
 OpenAutoLink exposes a **GAL / PDK protocol version** selector in **Settings → Video**. The selected raw head-unit-requested version applies on the next Android Auto session; use **Save & Reconnect** after changing it.
 
-The safe default and fallback remain **1.7**. Existing installations that had the former Experimental GAL 6.0 Boolean enabled migrate to **6.0**; all other installations remain at 1.7.
+The default is **6.0**, verified in vehicle over USB and wireless. **1.7** remains
+available as the manual compatibility fallback. Version 0.1.456 rotates the
+preference key so every upgraded installation starts on 6.0. A selection made
+after that upgrade persists normally, including a later manual choice of 1.7.
 
 ## Cumulative version policy
 
@@ -13,7 +16,7 @@ The raw requested version—not a higher compatible tuple reported by the phone�
 | 1.7 | Legacy display policy and per-packet audio ACKs. |
 | 4.3 | Modern display ownership metadata and active media session IDs. |
 | 5.0 | Ackless phone-to-HU audio and one advertised codec family per display. |
-| 5.1 | Adds typed and raw handling for audio `MediaOptions` (`0x8014`) and exposes Maps' route-aware `VehicleEnergyForecast` (`0x8008`) to the cluster, projection badge, and diagnostics. |
+| 5.1 | Adds typed and raw handling for audio `MediaOptions` (`0x8014`) and exposes Maps' route-aware `VehicleEnergyForecast` (`0x8008`) to the cluster and diagnostics. |
 | 6.0 | Adds typed and raw modern video Start/MediaConfig and video `MediaOptions`, and activates Gearhead's short HEVC keyframe policy. |
 
 All versions retain OAL's proven `max_unacked=30`. Video remains ACKed at every version: legacy 1.7 preserves `session_id=0`, while GAL 4.3+ uses the active video `Start.session_id`. Modern audio is ackless.
@@ -49,10 +52,11 @@ Typed handling covers:
 Malformed optional modern messages are logged and retained; they do not invent replies or alter session policy.
 
 When Maps supplies `VehicleEnergyForecast`, OAL formats its returned arrival
-energy against the same VEM capacity snapshot sent to the phone. High-quality
-forecasts render as `Arrive 42%`; lower/unknown quality renders as
-`Arrive ~42%`. Forecast state is cleared with the route/session and expires after
-two minutes so stale route energy cannot survive a navigation change.
+energy against the same VEM capacity snapshot sent to the phone. The cluster
+shows `Arrive 42%` for high-quality forecasts or `Arrive ~42%` for lower/unknown
+quality; diagnostics retain the percentage and forecast details. Forecast state
+is cleared with the route/session and expires after two minutes so stale route
+energy cannot survive a navigation change.
 
 ## Expected H.265 effect
 


### PR DESCRIPTION
## Summary
- remove the floating Maps arrival-SOC badge from the projection screen
- preserve Maps forecast reception, expiry, cluster trip text, and diagnostics
- make verified GAL 6.0 the policy for every upgraded and fresh installation
- rotate the persisted preference key so pre-0.1.456 selections reset once to 6.0
- keep GAL 1.7 manually selectable afterward; new selections persist normally
- align absent, invalid persisted, invalid direct-config, Settings UI, and JNI defaults on 6.0

## Verification
- strict RED/GREEN coverage for overlay removal, fresh/upgrade defaults, key rotation, manual legacy selection, and invalid fallbacks
- full car app suite: 372 passed, 0 failures/errors/skips
- `:app:compileDebugKotlin --rerun-tasks`: passed
- combine audit: 34 inputs map contiguously to values[0] through values[33]
- no production `arrivalBatteryText` or `mapsArrivalBatteryBadge` references remain
- cluster `setTripText` and diagnostics `mapsArrivalBatteryPct` remain wired
- independent final review: APPROVE; no blockers or warnings
- `git diff --check`: clean

## Distribution
The v0.1.455 APK is retained as a binary control: it contains `mapsArrivalBatteryBadge`. The v0.1.456 artifact must not. Every pre-0.1.456 install lacks `gal_version_v2`, so it enters 6.0 once; choices written after upgrading use the new key and persist.
