### PR TITLE
fix(ev): restore Maps battery model after ignition wake

### DIFF
--- a/app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt
+++ b/app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt
@@ -130,46 +130,119 @@ class VehicleDataForwarderImpl(
     private val _propertyStatus = mutableMapOf<String, String>()
     override val propertyStatus: Map<String, String> get() = _propertyStatus.toMap()
 
-    @Volatile private var startInFlight = false
+    private var startInFlight = false
+    private var desiredActive = false
+    private var lifecycleGeneration = 0L
 
     override fun start() {
-        if (isActive) return
-        // Idempotency guard: if start() is already running on a coroutine,
-        // a second concurrent call must NOT launch another connectToCar +
-        // registerProperties — they race against each other and the
-        // emulator silently fails property subscription.
-        synchronized(this) {
+        val generation = synchronized(this) {
+            desiredActive = true
             if (isActive || startInFlight) return
             startInFlight = true
+            ++lifecycleGeneration
         }
-        // Run on background thread — Car API calls can block (connect, waitForConnected)
+        launchStartAttempt(generation)
+    }
+
+    private fun launchStartAttempt(generation: Long) {
+        // Run on background thread — Car API calls can block (connect, waitForConnected).
+        // Every stage is fenced because stop() may run while this coroutine is blocked.
         scope.launch {
             try {
+                if (!isStartCurrent(generation)) return@launch
                 connectToCar()
+                if (!isStartCurrent(generation)) return@launch
                 readStaticVehicleInfo()
+                if (!isStartCurrent(generation)) return@launch
                 registerProperties()
-                isActive = true
+                if (!isStartCurrent(generation)) return@launch
+
+                val activated = synchronized(this@VehicleDataForwarderImpl) {
+                    if (lifecycleGeneration == generation && desiredActive) {
+                        isActive = true
+                        true
+                    } else {
+                        false
+                    }
+                }
+                if (!activated) return@launch
+
                 Log.i(TAG, "Vehicle data forwarding started")
                 DiagnosticLog.i("vhal", "Vehicle data forwarding started")
                 // Re-emit current data so collectors see isActive=true
                 _latestVehicleData.value = buildVehicleData()
                 startHistoryPoller()
             } catch (e: Exception) {
+                synchronized(this@VehicleDataForwarderImpl) {
+                    if (lifecycleGeneration == generation) desiredActive = false
+                }
                 val root = e.rootCause()
                 Log.w(TAG, "Failed to start vehicle data forwarding: ${root.message}")
                 DiagnosticLog.w("vhal", "Failed to start: ${root.javaClass.simpleName}: ${root.message}")
-                cleanup()
             } finally {
-                startInFlight = false
+                cleanupAfterStartAttempt(generation)
             }
         }
     }
 
+    private fun isStartCurrent(generation: Long): Boolean = synchronized(this) {
+        lifecycleGeneration == generation && desiredActive
+    }
+
+    private fun cleanupAfterStartAttempt(generation: Long) {
+        var nextGeneration: Long? = null
+        var cleanupOutcome: String? = null
+        synchronized(this) {
+            val stale = lifecycleGeneration != generation || !desiredActive
+            if (stale) {
+                isActive = false
+                cleanup()
+                cleanupOutcome = if (desiredActive) {
+                    "Stale VHAL start cleaned before queued restart"
+                } else {
+                    "In-flight VHAL start cleaned after stop"
+                }
+            }
+            startInFlight = false
+            // stop() followed quickly by start() while the old attempt was blocked
+            // leaves desiredActive=true but invalidates the old generation. Relaunch
+            // only after that attempt has cleaned up its partially-created Car state.
+            if (desiredActive && !isActive) {
+                startInFlight = true
+                nextGeneration = ++lifecycleGeneration
+            }
+        }
+        cleanupOutcome?.let {
+            Log.i(TAG, it)
+            DiagnosticLog.i("vhal", it)
+        }
+        nextGeneration?.let(::launchStartAttempt)
+    }
+
     override fun stop() {
-        if (!isActive) return
-        cleanup()
-        isActive = false
-        Log.i(TAG, "Vehicle data forwarding stopped")
+        val (hadWork, cleanupDeferred) = synchronized(this) {
+            val pendingOrActive = isActive || startInFlight || carObject != null
+            val deferred = startInFlight
+            desiredActive = false
+            lifecycleGeneration++
+            // An in-flight attempt owns its partially-created reflection objects;
+            // it observes the generation change in finally and cleans them there.
+            // Otherwise teardown is serialized here so a new start cannot overlap.
+            if (!startInFlight) {
+                isActive = false
+                if (pendingOrActive) cleanup()
+            }
+            pendingOrActive to deferred
+        }
+        if (hadWork) {
+            val outcome = if (cleanupDeferred) {
+                "VHAL stop requested; in-flight startup cleanup pending"
+            } else {
+                "Vehicle data forwarding stopped"
+            }
+            Log.i(TAG, outcome)
+            DiagnosticLog.i("vhal", outcome)
+        }
     }
 
     private fun connectToCar() {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -130,6 +130,7 @@ class SessionManager(
 
     // aasdk JNI session -- native C++ handles AA protocol
     private var aasdkSession: AasdkSession? = null
+    private var retiringAasdkSession: AasdkSession? = null
     private val wirelessAdmissionLock = Any()
     private var wirelessSessionAdmission:
         com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token? = null
@@ -173,6 +174,33 @@ class SessionManager(
     }.asCoroutineDispatcher()
 
     private val sessionStateLock = Any()
+
+    private fun adoptSessionOwnership(session: AasdkSession) {
+        synchronized(sessionStateLock) { aasdkSession = session }
+    }
+
+    /** Caller must hold [sessionStateLock]. */
+    private fun revokeSessionOwnershipLocked(): AasdkSession? {
+        val current = aasdkSession
+        aasdkSession = null
+        if (current != null) retiringAasdkSession = current
+        return current
+    }
+
+    private fun completeSessionRetirement(session: AasdkSession?) {
+        synchronized(sessionStateLock) {
+            if (retiringAasdkSession === session) retiringAasdkSession = null
+        }
+    }
+
+    private fun stopRetiringSession(session: AasdkSession?) {
+        try {
+            session?.stop()
+        } finally {
+            completeSessionRetirement(session)
+        }
+    }
+
     private val _sessionState = MutableStateFlow(SessionState.IDLE)
     val sessionState: StateFlow<SessionState> = _sessionState.asStateFlow()
 
@@ -339,7 +367,7 @@ class SessionManager(
             launch {
                 session.controlMessages.collect { message ->
                     lastActiveTimestamp = SystemClock.elapsedRealtime()
-                    handleControlMessage(message)
+                    handleControlMessage(session, message)
                 }
             }
             launch {
@@ -1481,7 +1509,7 @@ class SessionManager(
         _touchHeight.value = resH
         _effectiveDpi.value = effectiveDpi
 
-        aasdkSession = session
+        adoptSessionOwnership(session)
         // Same surface guarantee for transport restarts, which reuse the decoder
         // and so never trigger onDecoderCreated.
         // A transport restart can begin a native session without re-running the
@@ -1519,10 +1547,10 @@ class SessionManager(
             session.connectionState.collect { connState ->
                 val reportedState = connState.toSessionState()
                 val attempt = _reconnectAttempt.value
-                var startStreamingServices = false
                 synchronized(sessionStateLock) {
+                    if (aasdkSession !== session) return@synchronized
                     val currentState = _sessionState.value
-                    startStreamingServices = shouldStartStreamingServices(
+                    val startStreamingServices = shouldStartStreamingServices(
                         currentState,
                         reportedState,
                     )
@@ -1545,11 +1573,7 @@ class SessionManager(
                                 else "Error"
                         }
                     }
-                }
-                if (startStreamingServices) {
-                    startLocationForwarding(session)
-                    _vehicleDataForwarder?.start()
-                    _imuForwarder?.start()
+                    if (startStreamingServices) startStreamingServicesLocked(session)
                 }
             }
         }
@@ -1576,18 +1600,38 @@ class SessionManager(
         OalLog.i(TAG, "aasdk JNI session started ($directTransport transport)")
     }
 
-    private fun prepareNativeSessionStart(session: AasdkSession) {
+    private fun prepareNativeSessionStart(session: AasdkSession): Boolean {
+        val admitted = synchronized(sessionStateLock) {
+            if (retiringAasdkSession === session) {
+                false
+            } else {
+                if (aasdkSession !== session) {
+                    OalLog.i(TAG, "Re-adopting the session after a transport restart — " +
+                            "without this, touch input and sensor data are silently dropped")
+                }
+                adoptSessionOwnership(session)
+                true
+            }
+        }
+        if (!admitted) {
+            OalLog.i(TAG, "Rejecting native start while this session is retiring")
+            return false
+        }
+
         ensureVideoDecoder()
         ensureAudioPlayer()
-        if (aasdkSession !== session) {
-            OalLog.i(TAG, "Re-adopting the session after a transport restart — " +
-                    "without this, touch input and sensor data are silently dropped")
-        }
-        aasdkSession = session
         bindSessionCollectors(session)
         OalLog.i(TAG, "Native session dependencies ready: " +
                 "decoder=${_videoDecoder != null} surface=${lastKnownSurface != null} " +
                 "audio=${_audioPlayer != null} session=current collectors=bound")
+        return true
+    }
+
+    /** Must be called while holding [sessionStateLock] for the exact current session. */
+    private fun startStreamingServicesLocked(session: AasdkSession) {
+        startLocationForwarding(session)
+        _vehicleDataForwarder?.start()
+        _imuForwarder?.start()
     }
 
     @android.annotation.SuppressLint("MissingPermission")
@@ -1699,10 +1743,20 @@ class SessionManager(
         videoStallWatchJob = null
         callStateJob?.cancel()
         callStateJob = null
+        // Revoke ownership before cancelling collectors or stopping retained
+        // producers. A PhoneConnected callback already executing cannot be
+        // cancelled mid-body; the shared lock makes it either finish its starts
+        // before this teardown (which then stops them), or observe a stale owner
+        // and do nothing afterward.
+        val retiringSession = synchronized(sessionStateLock) {
+            val current = revokeSessionOwnershipLocked()
+            _sessionState.value = SessionState.IDLE
+            _statusMessage.value = "Disconnected"
+            current
+        }
         sessionCollectors?.cancel()
         sessionCollectors = null
-        aasdkSession?.stop()
-        aasdkSession = null
+        stopRetiringSession(retiringSession)
         stopDirectLocationForwarding()
         _videoDecoder?.release()
         _videoDecoder = null
@@ -1714,8 +1768,11 @@ class SessionManager(
         _hfpPresence = null
         _gnssForwarder?.stop()
         _gnssForwarder = null
+        // Preserve the stopped VHAL owner and its last complete EV snapshot across
+        // ignition sleep. The native wake path restarts this same owner before the
+        // phone's type-23 subscription, so Maps receives current battery data even
+        // when the AAOS process survives and full start() is bypassed.
         _vehicleDataForwarder?.stop()
-        _vehicleDataForwarder = null
         _imuForwarder?.stop()
         _imuForwarder = null
         forecastExpiryJob?.cancel()
@@ -1736,10 +1793,6 @@ class SessionManager(
         _telemetryCollector = null
         DiagnosticLog.instance = null
         _remoteDiagnostics = null
-        synchronized(sessionStateLock) {
-            _sessionState.value = SessionState.IDLE
-            _statusMessage.value = "Disconnected"
-        }
         _phoneBatteryLevel.value = null
         _phoneBatteryCritical.value = false
         _voiceSessionActive.value = false
@@ -1927,8 +1980,10 @@ class SessionManager(
         // 2. Stop old AA session + location forwarding. Revoke SDP first so
         // the phone cannot enter through callbacks owned by the retiring session.
         clearWirelessSessionAdmission()
-        aasdkSession?.stop()
-        aasdkSession = null
+        val retiringSession = synchronized(sessionStateLock) {
+            revokeSessionOwnershipLocked()
+        }
+        stopRetiringSession(retiringSession)
         stopDirectLocationForwarding()
 
         // 3. Flush video decoder (codec/scaling may have changed)
@@ -2154,8 +2209,10 @@ class SessionManager(
         // sets that), so the AA session's own retry loop doesn't fire during
         // the sleep window. The wake side will reconnect via the
         // ProjectionViewModel wake collector.
-        aasdkSession?.stop()
-        aasdkSession = null
+        val retiringSession = synchronized(sessionStateLock) {
+            revokeSessionOwnershipLocked()
+        }
+        stopRetiringSession(retiringSession)
         scope.launch {
             kotlinx.coroutines.delay(durationMs)
             OalLog.i(TAG, "DEBUG: simulating car wake (after ${formatGap(durationMs)})")
@@ -2576,30 +2633,41 @@ class SessionManager(
         }
     }
 
-    private fun handleControlMessage(message: ControlMessage) {
-        when (message) {
+    private fun handleControlMessage(sourceSession: AasdkSession, message: ControlMessage) {
+        synchronized(sessionStateLock) {
+            if (aasdkSession !== sourceSession) {
+                OalLog.i(TAG, "Ignoring control message from stale session: ${message::class.simpleName}")
+                return@synchronized
+            }
+            when (message) {
             is ControlMessage.PhoneConnected -> {
                 _remoteDiagnostics?.log(DiagnosticLevel.INFO, "session", "Phone connected: ${message.phoneName}")
                 resetLatchedVehicleSensorState("phone_connected")
                 seedCurrentUiNightMode("phone_connected")
-                val startStreamingServices = synchronized(sessionStateLock) {
-                    shouldStartStreamingServices(
-                        _sessionState.value,
-                        SessionState.STREAMING,
-                    ).also {
+                val accepted = synchronized(sessionStateLock) {
+                    if (aasdkSession === sourceSession) {
+                        val startStreamingServices = shouldStartStreamingServices(
+                            _sessionState.value,
+                            SessionState.STREAMING,
+                        )
                         _sessionState.value = SessionState.STREAMING
                         _statusMessage.value = "Streaming"
+                        if (startStreamingServices) {
+                            startStreamingServicesLocked(sourceSession)
+                        }
+                        true
+                    } else {
+                        false
                     }
+                }
+                if (!accepted) {
+                    OalLog.i(TAG, "Ignoring PhoneConnected effects from stale session")
+                    return
                 }
                 // Reset the stall watchdog baseline: give the fresh session a
                 // full warmup window before it can fire (avoids a stale
                 // timestamp from a prior session tripping it immediately).
                 lastVideoFrameArrivedMs = SystemClock.elapsedRealtime() + VIDEO_STALL_WARMUP_MS
-                if (startStreamingServices) {
-                    aasdkSession?.let { startLocationForwarding(it) }
-                    _vehicleDataForwarder?.start()
-                    _imuForwarder?.start()
-                }
             }
             is ControlMessage.PhoneDisconnected -> {
                 _remoteDiagnostics?.log(DiagnosticLevel.INFO, "session", "Phone disconnected: ${message.reason}")
@@ -2720,6 +2788,7 @@ class SessionManager(
                 _phoneSignalStrength.value = message.signalStrength
             }
             else -> {}
+            }
         }
     }
 

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -264,16 +264,25 @@ class AasdkSession(
 
         OalLog.i(TAG, "Starting aasdk session (WPP transport — phone connects to us)")
         _wppServer?.stop()
-        _wppServer = com.openautolink.app.transport.hotspot.WppTcpServer(
+        lateinit var server: com.openautolink.app.transport.hotspot.WppTcpServer
+        server = com.openautolink.app.transport.hotspot.WppTcpServer(
             scope = scope,
             onSocketReady = { wppSocket ->
                 scope.launch(Dispatchers.IO) {
-                    OalLog.i(TAG, "WPP socket accepted — starting aasdk native session")
-                    handleConnection(wppSocket)
+                    synchronized(connectionStartLock) {
+                        if (_wppServer !== server) {
+                            OalLog.i(TAG, "Retired WPP server delivered a late socket — closing it")
+                            runCatching { wppSocket.close() }
+                        } else {
+                            OalLog.i(TAG, "WPP socket accepted — starting aasdk native session")
+                            handleConnection(wppSocket)
+                        }
+                    }
                 }
             },
         )
-        _wppServer?.start()
+        _wppServer = server
+        server.start()
     }
 
     /**
@@ -288,7 +297,7 @@ class AasdkSession(
      * sure the decoder still has a surface.
      */
     @Volatile
-    var onNativeSessionStarting: (() -> Unit)? = null
+    var onNativeSessionStarting: (() -> Boolean)? = null
 
     /** Tracks the TCP target across every start path, including WPP restart. */
     private val companionDialState = CompanionDialState()
@@ -444,7 +453,12 @@ class AasdkSession(
             _connectionState.value = ConnectionState.CONNECTING
             OalLog.i(TAG, "Starting native aasdk session (USB): " +
                     "${sdrConfig.videoWidth}x${sdrConfig.videoHeight}")
-            onNativeSessionStarting?.invoke()
+            if (onNativeSessionStarting?.invoke() == false) {
+                OalLog.i(TAG, "USB native start rejected by session owner")
+                pipe.close()
+                _connectionState.value = ConnectionState.DISCONNECTED
+                return
+            }
             transportPipe = pipe
 
             try {
@@ -484,6 +498,7 @@ class AasdkSession(
         }
 
     private fun handleConnection(socket: Socket) {
+        synchronized(connectionStartLock) {
         _connectionState.value = ConnectionState.CONNECTING
 
         // Say goodbye to the phone before replacing a live native session.
@@ -525,7 +540,12 @@ class AasdkSession(
         // decoder-created hook never fires — and the reused decoder has no
         // surface after the old one was destroyed. Measured: video ran at 41fps
         // for 25s into a decoder with nothing to render to.
-        onNativeSessionStarting?.invoke()
+        if (onNativeSessionStarting?.invoke() == false) {
+            OalLog.i(TAG, "TCP native start rejected by session owner")
+            runCatching { socket.close() }
+            _connectionState.value = ConnectionState.DISCONNECTED
+            return
+        }
 
         transportPipe = AasdkTransportPipe(input, output)
 
@@ -537,6 +557,7 @@ class AasdkSession(
             transportPipe?.close()
             transportPipe = null
             _connectionState.value = ConnectionState.DISCONNECTED
+        }
         }
     }
 

--- a/app/src/test/java/com/openautolink/app/session/NativeSessionDependencyContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/NativeSessionDependencyContractTest.kt
@@ -20,7 +20,7 @@ class NativeSessionDependencyContractTest {
         val helper = source.substring(start, end)
         assertTrue(helper.contains("ensureVideoDecoder()"))
         assertTrue(helper.contains("ensureAudioPlayer()"))
-        assertTrue(helper.contains("aasdkSession = session"))
+        assertTrue(helper.contains("adoptSessionOwnership(session)"))
         assertTrue(helper.contains("bindSessionCollectors(session)"))
         assertTrue(helper.contains("Native session dependencies ready:"))
 
@@ -29,6 +29,44 @@ class NativeSessionDependencyContractTest {
             Regex("""session\.onNativeSessionStarting\s*=\s*\{\s*prepareNativeSessionStart\(session\)\s*}""")
                 .findAll(source)
                 .count(),
+        )
+
+        assertTrue(
+            "The dependency preparer must reject the exact session while stop is retiring it",
+            helper.contains("retiringAasdkSession === session") &&
+                helper.contains("return false"),
+        )
+        assertTrue(
+            "The dependency preparer must report successful admission",
+            helper.contains("return true"),
+        )
+
+        val aasdk = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        assertTrue(aasdk.contains("var onNativeSessionStarting: (() -> Boolean)?"))
+        assertEquals(
+            "Both USB and TCP native starts must abort when their owner rejects admission",
+            2,
+            Regex(Regex.escape("onNativeSessionStarting?.invoke() == false"))
+                .findAll(aasdk)
+                .count(),
+        )
+        val tcpStart = aasdk.indexOf("private fun handleConnection(socket: Socket)")
+        val tcpEnd = aasdk.indexOf("fun shutdownGracefully", tcpStart)
+        assertTrue(tcpStart >= 0 && tcpEnd > tcpStart)
+        val tcpStartBlock = aasdk.substring(tcpStart, tcpEnd)
+        assertTrue(
+            "WPP and direct TCP starts must share the same stop/start ownership lock",
+            tcpStartBlock.indexOf("synchronized(connectionStartLock)") in
+                0 until tcpStartBlock.indexOf("onNativeSessionStarting?.invoke()"),
+        )
+        val wppStart = aasdk.substringAfter("private fun startWpp(recovery: Boolean = false)")
+            .substringBefore("var onNativeSessionStarting")
+        assertTrue(
+            "A socket queued by a stopped WPP server must not start after retirement clears",
+            wppStart.contains("_wppServer !== server") &&
+                wppStart.contains("wppSocket.close()"),
         )
     }
 

--- a/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
@@ -36,7 +36,7 @@ class VehicleEnergyReconnectContractTest {
     }
 
     @Test
-    fun `transport reconnect retains cached vehicle data without resurrecting its owner`() {
+    fun `every restart retains the stopped VHAL owner for type 23 replay`() {
         val source = sessionManagerSource()
         val start = source.indexOf("private fun prepareNativeSessionStart(session: AasdkSession)")
         val end = source.indexOf("private fun startLocationForwarding", startIndex = start)
@@ -44,7 +44,7 @@ class VehicleEnergyReconnectContractTest {
         assertTrue("Native dependency preparer must exist", start >= 0)
         assertTrue("Native dependency preparer must have a boundary", end > start)
         val hook = source.substring(start, end)
-        val adopt = hook.indexOf("aasdkSession = session")
+        val adopt = hook.indexOf("adoptSessionOwnership(session)")
         val collectors = hook.indexOf("bindSessionCollectors(session)")
         assertTrue("Native restart must re-adopt its session", adopt >= 0)
         assertTrue("Native restart must retain collector rebinding", collectors > adopt)
@@ -60,6 +60,107 @@ class VehicleEnergyReconnectContractTest {
         assertFalse(
             "Reconnect must retain the cached VHAL snapshot for type-23 replay",
             reconnect.contains("_vehicleDataForwarder = null"),
+        )
+
+        val fullStop = source.substringAfter("fun stop() {")
+            .substringBefore("fun reconnect(")
+        assertTrue(
+            "Ignition/full stop must pause the VHAL owner",
+            fullStop.contains("_vehicleDataForwarder?.stop()"),
+        )
+        assertFalse(
+            "Ignition/full stop must retain the VHAL owner and cached EV snapshot for wake",
+            fullStop.contains("_vehicleDataForwarder = null"),
+        )
+        val revokeSession = fullStop.indexOf("revokeSessionOwnershipLocked()")
+        val stopForwarder = fullStop.indexOf("_vehicleDataForwarder?.stop()")
+        assertTrue(
+            "Explicit stop must revoke session ownership before the retained VHAL owner can be stopped",
+            revokeSession >= 0 && revokeSession < stopForwarder,
+        )
+
+        val collectorStart = source.indexOf("private fun bindSessionCollectors(session: AasdkSession)")
+        val collectorEnd = source.indexOf("private fun createVideoDecoder", collectorStart)
+        assertTrue(collectorStart >= 0 && collectorEnd > collectorStart)
+        val collectorsBlock = source.substring(collectorStart, collectorEnd)
+        assertTrue(
+            "Control messages must carry the exact session that produced them",
+            collectorsBlock.contains("handleControlMessage(session, message)"),
+        )
+
+        val handlerStart = source.indexOf(
+            "private fun handleControlMessage(sourceSession: AasdkSession, message: ControlMessage)",
+        )
+        val handlerEnd = source.indexOf("// ── EV energy-model tuning", handlerStart)
+        assertTrue(handlerStart >= 0 && handlerEnd > handlerStart)
+        val handler = source.substring(handlerStart, handlerEnd)
+        assertTrue(
+            "PhoneConnected effects must reject a stale session owner",
+            handler.contains("aasdkSession !== sourceSession"),
+        )
+        assertTrue(
+            "PhoneConnected must use the lock-owned streaming-service chokepoint",
+            handler.contains("startStreamingServicesLocked(sourceSession)"),
+        )
+
+        val connectionObserverStart = source.indexOf("// Observe session state")
+        val connectionObserverEnd = source.indexOf("bindSessionCollectors(session)", connectionObserverStart)
+        assertTrue(connectionObserverStart >= 0 && connectionObserverEnd > connectionObserverStart)
+        val connectionObserver = source.substring(connectionObserverStart, connectionObserverEnd)
+        assertTrue(
+            "Connection-state starts must verify exact session ownership",
+            connectionObserver.contains("aasdkSession !== session"),
+        )
+        assertTrue(
+            "Connection-state starts must use the same lock-owned chokepoint",
+            connectionObserver.contains("startStreamingServicesLocked(session)"),
+        )
+        assertTrue(
+            "VHAL has exactly one producer-start chokepoint",
+            Regex(Regex.escape("_vehicleDataForwarder?.start()")).findAll(source).count() == 1,
+        )
+        assertTrue(
+            "Every control-message effect must remain inside the session ownership lock",
+            handler.indexOf("synchronized(sessionStateLock)") in
+                0 until handler.indexOf("when (message)"),
+        )
+        assertTrue(
+            "Session ownership must use centralized adopt/revoke helpers",
+            source.contains("private fun adoptSessionOwnership(session: AasdkSession)") &&
+                source.contains("private fun revokeSessionOwnershipLocked()"),
+        )
+        assertTrue(
+            "No lifecycle path may assign the session outside centralized ownership helpers",
+            Regex("aasdkSession = ").findAll(source).count() == 2,
+        )
+    }
+
+    @Test
+    fun `VHAL stop invalidates an in-flight asynchronous start`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/input/VehicleDataForwarderImpl.kt",
+        ).readText()
+        val stopStart = source.indexOf("override fun stop()")
+        val stopEnd = source.indexOf("private fun connectToCar", stopStart)
+        assertTrue(stopStart >= 0 && stopEnd > stopStart)
+        val stop = source.substring(stopStart, stopEnd)
+        assertFalse(
+            "stop must not return merely because async start has not set isActive yet",
+            stop.contains("if (!isActive) return"),
+        )
+        assertTrue(stop.contains("desiredActive = false"))
+        assertTrue(stop.contains("lifecycleGeneration++"))
+
+        val startStart = source.indexOf("override fun start()")
+        assertTrue(startStart >= 0 && stopStart > startStart)
+        val start = source.substring(startStart, stopStart)
+        assertTrue(
+            "Every asynchronous start stage must be fenced by its lifecycle generation",
+            start.contains("isStartCurrent(generation)"),
+        )
+        assertTrue(
+            "A stale in-flight attempt must clean up rather than activate after stop",
+            start.contains("cleanupAfterStartAttempt(generation)"),
         )
     }
 


### PR DESCRIPTION
## Summary
- preserve the stopped VHAL owner and its last complete EV snapshot across ignition sleep
- restart all streaming producers through one exact-session, lock-owned chokepoint
- generation-fence asynchronous Car API startup so stop cannot be followed by stale activation
- reject stale control messages and native starts from a session while it is retiring
- fence late WPP, TCP, and USB transport callbacks against their retired owners

## Runtime evidence
The uploaded build 0.1.456 session connected and streamed normally, but at 16:28:21.661 Gearhead requested sensor type 23 and OAL immediately logged:

`sendCurrentEnergyModel[sensor-subscribe] rejected: no-forwarder`

The same day's earlier working session logged a started VHAL forwarder, a valid `65610Wh / 85530Wh` type-23 replay, and a queued native VEM. Ignition-off teardown had nulled the owner while the surviving process later restarted only native-session dependencies.

## Verification
- focused tests were observed RED before implementation and GREEN afterward
- independent concurrency/lifecycle review: PASS, no blocker or major finding
- `385` debug unit tests passed, zero failures/errors/skips
- ARM64 and x86_64 native builds passed
- debug APK assembly passed
- `git diff --check` passed

## Live validation still required
The next installed wake-session log must positively show:
- `Vehicle data forwarding started`
- `phone subscribed sensor type=23 — pushing current state`
- `sendCurrentEnergyModel[sensor-subscribe]: level=... cap=... range=...`
- `sendEnergyModel queued: level=...`

The absence of `no-forwarder` alone is not considered proof.