### PR TITLE
fix(input): align auto-negotiated touch coordinates

### DIFF
--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -1604,6 +1604,14 @@ void JniSession::buildServiceDiscoveryResponse(
         response.set_session_configuration(session_config);
     }
 
+    // InputSourceService exposes one touchscreen coordinate space for the
+    // display. In auto mode Gearhead consistently selects the first accepted
+    // video config, so advertise that same tier for touch. Keeping the saved
+    // manual size here while auto selected 4K caused the measured 0.1.461
+    // video=3840x2160 / touch=2560x1440 mismatch.
+    int touchWidth = sdrConfig_.videoWidth;
+    int touchHeight = sdrConfig_.videoHeight;
+
     // ---- Video channel (matches bridge exactly — NO audio_type) ----
     { auto* svc = response.add_channels();
       svc->set_id(2); // VIDEO — Java uses 2 (MEDIA_SINK), works with localhost proxy
@@ -1770,6 +1778,8 @@ void JniSession::buildServiceDiscoveryResponse(
                   tierCount = 3;
               }
           }
+          touchWidth = kDims[tiers[0]].w;
+          touchHeight = kDims[tiers[0]].h;
           LOGI("Auto SDR: codec=%s tiers=%d portrait=%d",
                useH265 ? "H.265" : "H.264 BP", tierCount, portrait ? 1 : 0);
           for (int i = 0; i < tierCount; ++i) {
@@ -1908,9 +1918,11 @@ void JniSession::buildServiceDiscoveryResponse(
           is->add_keycodes_supported(kc);
       }
       auto* ts = is->add_touchscreen();
-      ts->set_width(sdrConfig_.videoWidth);
-      ts->set_height(sdrConfig_.videoHeight);
+      ts->set_width(touchWidth);
+      ts->set_height(touchHeight);
       ts->set_type(aap_protobuf::service::inputsource::message::CAPACITIVE);
+      LOGI("Input touchscreen: %dx%d autoNeg=%d", touchWidth, touchHeight,
+           sdrConfig_.autoNegotiate ? 1 : 0);
     }
 
     // ---- Bluetooth channel ----

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -39,6 +39,7 @@ import com.openautolink.app.transport.aasdk.AasdkSdrConfig
 import com.openautolink.app.transport.usb.UsbConnectionManager
 import com.openautolink.app.video.DecoderState
 import com.openautolink.app.video.AutoDpiPolicy
+import com.openautolink.app.video.AutoVideoTouchPolicy
 import com.openautolink.app.video.MediaCodecDecoder
 import com.openautolink.app.video.VideoDecoder
 import com.openautolink.app.video.VideoStats
@@ -1466,6 +1467,19 @@ class SessionManager(
             0 to 0
         }
         OalLog.i(TAG, "Panel dims: ${panelW}x${panelH} (mode=$lastDisplayMode)")
+        val (protocolTouchW, protocolTouchH) = AutoVideoTouchPolicy.resolve(
+            autoNegotiate = videoAutoNegotiate,
+            codec = codec,
+            panelWidth = panelW,
+            panelHeight = panelH,
+            selectedWidth = resW,
+            selectedHeight = resH,
+        )
+        OalLog.i(
+            TAG,
+            "Protocol touchscreen: ${protocolTouchW}x${protocolTouchH} " +
+                "autoNeg=$videoAutoNegotiate selected=${resW}x${resH}",
+        )
 
         val session = AasdkSession(scope, ctx)
         session.transportMode = directTransport
@@ -1522,8 +1536,8 @@ class SessionManager(
             panelHeight = panelH,
             autoMargins = aaAutoMargins,
         )
-        _touchWidth.value = resW
-        _touchHeight.value = resH
+        _touchWidth.value = protocolTouchW
+        _touchHeight.value = protocolTouchH
         _effectiveDpi.value = effectiveDpi
 
         adoptSessionOwnership(session)

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.async
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
 data class ProjectionUiState(
@@ -155,6 +156,8 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     private val _phoneName = MutableStateFlow<String?>(null)
     private val _videoStats = MutableStateFlow(VideoStats())
     private val _audioStats = MutableStateFlow(AudioStats())
+    private var videoStatsJob: Job? = null
+    private var audioStatsJob: Job? = null
     private val _showStats = MutableStateFlow(false)
     private val _showPhoneChooser = MutableStateFlow(false)
     /**
@@ -321,7 +324,10 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         // Hop to the ViewModel scope: the decoder is created on whichever thread
         // starts the session, and surface attach must not run there.
         sessionManager.onDecoderCreated = {
-            viewModelScope.launch { attachPendingSurface() }
+            viewModelScope.launch {
+                attachPendingSurface()
+                bindCurrentStatsCollectors()
+            }
         }
 
         // Collect video and audio stats when streaming
@@ -333,23 +339,33 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     attachPendingSurface()
                 }
                 if (state == SessionState.STREAMING) {
-                    sessionManager.videoStats?.let { statsFlow ->
-                        launch {
-                            statsFlow.collect { stats ->
-                                _videoStats.value = stats
-                            }
-                        }
-                    }
-                    sessionManager.audioStats?.let { statsFlow ->
-                        launch {
-                            statsFlow.collect { stats ->
-                                _audioStats.value = stats
-                            }
-                        }
-                    }
+                    bindCurrentStatsCollectors()
                 }
             }
         }
+    }
+
+    /** Bind the overlay to the current decoder/player, never a retired one. */
+    private fun bindCurrentStatsCollectors() {
+        videoStatsJob?.cancel()
+        audioStatsJob?.cancel()
+        _videoStats.value = VideoStats()
+        _audioStats.value = AudioStats()
+        sessionManager.videoStats?.let { statsFlow ->
+            videoStatsJob = viewModelScope.launch {
+                statsFlow.collect { stats -> _videoStats.value = stats }
+            }
+        }
+        sessionManager.audioStats?.let { statsFlow ->
+            audioStatsJob = viewModelScope.launch {
+                statsFlow.collect { stats -> _audioStats.value = stats }
+            }
+        }
+        DiagnosticLog.i(
+            "video",
+            "Stats collectors rebound: video=${sessionManager.videoStats != null} " +
+                "audio=${sessionManager.audioStats != null}",
+        )
     }
 
     @Volatile private var hasConnected = false
@@ -2391,6 +2407,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             try { connectivityManager.unregisterNetworkCallback(it) } catch (_: Exception) {}
         }
         wifiAvailableCallback = null
+        sessionManager.onDecoderCreated = null
+        videoStatsJob?.cancel()
+        audioStatsJob?.cancel()
         // Stop file logging if active
         logcatCapture?.stop()
         fileLogWriter?.stop()

--- a/app/src/main/java/com/openautolink/app/video/AutoVideoTouchPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/video/AutoVideoTouchPolicy.kt
@@ -1,0 +1,24 @@
+package com.openautolink.app.video
+
+/** Keeps Kotlin touch scaling aligned with native auto-negotiation tier ordering. */
+object AutoVideoTouchPolicy {
+    fun resolve(
+        autoNegotiate: Boolean,
+        codec: String,
+        panelWidth: Int,
+        panelHeight: Int,
+        selectedWidth: Int,
+        selectedHeight: Int,
+    ): Pair<Int, Int> {
+        if (!autoNegotiate) return selectedWidth to selectedHeight
+        val portrait = panelWidth > 0 && panelHeight > 0 && panelWidth < panelHeight
+        val hevc = codec.equals("h265", ignoreCase = true) ||
+            codec.equals("hevc", ignoreCase = true)
+        return when {
+            hevc && portrait -> 2160 to 3840
+            hevc -> 3840 to 2160
+            portrait -> 1080 to 1920
+            else -> 1920 to 1080
+        }
+    }
+}

--- a/app/src/test/java/com/openautolink/app/session/AutoNegotiationGeometryWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/AutoNegotiationGeometryWiringContractTest.kt
@@ -45,6 +45,24 @@ class AutoNegotiationGeometryWiringContractTest {
     }
 
     @Test
+    fun `automatic touchscreen matches the first advertised video tier`() {
+        val nativeSession = projectFile("app/src/main/cpp/jni_session.cpp")
+
+        assertTrue(nativeSession.contains("int touchWidth = sdrConfig_.videoWidth"))
+        assertTrue(nativeSession.contains("touchWidth = kDims[tiers[0]].w"))
+        assertTrue(nativeSession.contains("touchHeight = kDims[tiers[0]].h"))
+        assertTrue(nativeSession.contains("ts->set_width(touchWidth)"))
+        assertTrue(nativeSession.contains("ts->set_height(touchHeight)"))
+        assertTrue(nativeSession.contains("Input touchscreen: %dx%d"))
+
+        val manager = projectFile("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+        assertTrue(manager.contains("AutoVideoTouchPolicy.resolve"))
+        assertTrue(manager.contains("_touchWidth.value = protocolTouchW"))
+        assertTrue(manager.contains("_touchHeight.value = protocolTouchH"))
+        assertTrue(manager.contains("Protocol touchscreen:"))
+    }
+
+    @Test
     fun `resolution baseline documents automatic per-tier density`() {
         val baseline = projectFile("docs/oal-resolution-negotiation-baseline.md")
 
@@ -52,6 +70,7 @@ class AutoNegotiationGeometryWiringContractTest {
         assertFalse(baseline.contains("One default density for all tiers"))
         assertTrue(baseline.contains("automatic per-tier density"))
         assertTrue(baseline.contains("4K tier uses density 263"))
+        assertTrue(baseline.contains("automatic touchscreen follows the first video tier"))
     }
 
     @Test

--- a/app/src/test/java/com/openautolink/app/session/ProjectionStatsBindingContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/ProjectionStatsBindingContractTest.kt
@@ -1,0 +1,34 @@
+package com.openautolink.app.session
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProjectionStatsBindingContractTest {
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun `decoder replacement cancels stale stats collectors and binds the current decoder`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
+        )
+
+        assertTrue(source.contains("private var videoStatsJob: Job? = null"))
+        assertTrue(source.contains("private fun bindCurrentStatsCollectors()"))
+        assertTrue(source.contains("videoStatsJob?.cancel()"))
+        assertTrue(source.contains("_videoStats.value = VideoStats()"))
+        assertTrue(source.contains("sessionManager.videoStats?.let"))
+        assertTrue(source.contains("bindCurrentStatsCollectors()"))
+        assertTrue(source.contains("sessionManager.onDecoderCreated ="))
+        assertTrue(source.contains("Stats collectors rebound:"))
+        assertTrue(source.contains("sessionManager.onDecoderCreated = null"))
+        assertTrue(source.contains("videoStatsJob?.cancel()"))
+        assertTrue(source.contains("audioStatsJob?.cancel()"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/video/AutoVideoTouchPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/video/AutoVideoTouchPolicyTest.kt
@@ -1,0 +1,45 @@
+package com.openautolink.app.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutoVideoTouchPolicyTest {
+    @Test
+    fun `manual mode preserves the selected resolution`() {
+        assertEquals(
+            2560 to 1440,
+            AutoVideoTouchPolicy.resolve(
+                autoNegotiate = false,
+                codec = "h265",
+                panelWidth = 2914,
+                panelHeight = 1134,
+                selectedWidth = 2560,
+                selectedHeight = 1440,
+            ),
+        )
+    }
+
+    @Test
+    fun `landscape auto mode follows first advertised tier per codec`() {
+        assertEquals(
+            3840 to 2160,
+            AutoVideoTouchPolicy.resolve(true, "h265", 2914, 1134, 2560, 1440),
+        )
+        assertEquals(
+            1920 to 1080,
+            AutoVideoTouchPolicy.resolve(true, "h264", 2914, 1134, 2560, 1440),
+        )
+    }
+
+    @Test
+    fun `portrait auto mode follows first advertised tier per codec`() {
+        assertEquals(
+            2160 to 3840,
+            AutoVideoTouchPolicy.resolve(true, "hevc", 1080, 1920, 1440, 2560),
+        )
+        assertEquals(
+            1080 to 1920,
+            AutoVideoTouchPolicy.resolve(true, "h264", 1080, 1920, 1440, 2560),
+        )
+    }
+}

--- a/docs/oal-resolution-negotiation-baseline.md
+++ b/docs/oal-resolution-negotiation-baseline.md
@@ -251,6 +251,13 @@ configuration index in auto mode. The phone communicates the selected index in
 The ordered list makes index 0 the highest advertised tier. Selection is still a
 phone decision; source order alone is not proof that every phone chooses index 0.
 
+`InputSourceService` exposes one touchscreen coordinate space rather than one per
+video configuration. The automatic touchscreen follows the first video tier,
+which matches Gearhead's selected index in every captured OAL auto-negotiation
+session. Manual mode continues to advertise the manually selected video size.
+OAL logs `Input touchscreen: WIDTHxHEIGHT autoNeg=...` so a future phone that
+selects a fallback index can be identified rather than silently mis-mapped.
+
 ---
 
 ## 2. Scoped 2914×1134 vehicle example


### PR DESCRIPTION
## Summary
- make the one auto-negotiated input touchscreen match the first advertised video tier in both native SDR and Kotlin touch scaling
- preserve the selected resolution exactly in manual mode
- cancel stale video/audio stats collectors, reset stale values, and rebind the overlay to the current decoder/player
- add runtime markers for both protocol touch dimensions and stats rebinding

## Causal evidence
The 0.1.461 uploaded logs provide a natural A/B across four sessions in one process:

| mode | video advertised/decoded | touchscreen state | observed touch |
|---|---|---|---|
| manual 4K | 3840x2160 | 3840x2160 | perfect |
| manual 1440p | 2560x1440 | 2560x1440 | perfect |
| auto H.265 | `vc[0]=4K`, `config_idx=0`, decoder 3840x2160 | 2560x1440 | misaligned |

This isolates the touch failure to auto service-discovery/input geometry. The same auto session proves it is 4K despite the overlay showing 1440p: `vc[0] res=5`, `VideoStart config_idx=0`, and decoder output `3840x2160`. The overlay was retaining the prior manual decoder's stats collector.

## Verification
- strict RED/GREEN tests for native/Kotlin touch-space agreement, manual preservation, H.264/H.265 landscape and portrait auto tiers, stats rebinding, cleanup, and docs
- full car-app suite: **403 passed**, zero failures/errors/skips
- ARM64 and x86_64 native builds passed
- debug APK assembled
- previous v0.1.461 car APK is a negative control for the new markers
- new APK contains `Protocol touchscreen:`, `Input touchscreen:`, `Stats collectors rebound:`, and `AutoVideoTouchPolicy` in the expected managed/native layers and both ABIs
- latest uploaded comparison log: 4/4 sessions connected, no checker findings
- independent re-review after correcting the initial one-sided fix: **APPROVE**, no blockers

## Runtime acceptance
This is build-verified, not vehicle-verified. The next auto H.265/4K test must positively show:

- `Protocol touchscreen: 3840x2160 autoNeg=true selected=2560x1440`
- `Input touchscreen: 3840x2160 autoNeg=1`
- `VideoStart config_idx=0`
- decoder output and stats overlay both report 3840x2160
- touch lands correctly across the full visible panel

A future phone selecting a fallback video index instead of index 0 remains detectable through the selected-index and touchscreen markers; current captured OAL auto sessions all select index 0.
