### PR TITLE
fix(wireless): learn companion from Bluetooth adapter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ its automatic MAC policy.
 
 **Multiple drivers?** On 17.4+ the car projects to whichever phone it is currently connected to over Bluetooth, so switching phones means switching the connection in the **car's own Bluetooth settings** — the APIs an app would need to do that are privileged and closed to us. The phone list on the projection screen still shows every phone it can see, and tapping one retries the connection to it.
 
-> **Multi-phone identity:** Give every phone a unique Bluetooth device name. In each phone's OAL companion, set **Phone identity → Friendly name** to exactly match that phone's Bluetooth name. The car uses this first match to bind the Bluetooth phone to the companion's stable `phone_id`, preventing one reachable companion from being selected for another phone's WPP handshake.
+> **Multi-phone identity:** Give every phone a unique Bluetooth device name. The companion reports that Bluetooth name automatically and keeps **Phone identity → Friendly name** as the display label only. The car uses the Bluetooth-name match once to bind the active Bluetooth phone to the companion's stable `phone_id`, preventing one reachable companion from being selected for another phone's WPP handshake.
 
 On Android Auto 17.3 and older, both phones can be on the car's WiFi at once and the floating phone icon switches between them directly. Settings → Connection → Known Phones → "Set Default" changes the preferred phone permanently.
 

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -1376,20 +1376,30 @@ object AaWirelessBtControl {
         expectedPhoneIdOverride: String? = null,
     ): Boolean {
         val expectedPhoneId = expectedPhoneIdOverride ?: phoneIdByBtAddress[phoneBtAddress]
-        val matches = CompanionIdentityPolicy.matches(
+        val matchBasis = CompanionIdentityPolicy.matchBasis(
             expectedPhoneId = expectedPhoneId,
             bluetoothDeviceName = phoneBtName,
             probe = probe,
         )
-        if (!matches) {
+        if (matchBasis == CompanionIdentityMatch.NONE) {
             OalLog.i(
                 TAG,
                 "Rejected companion at $phoneIp id=${probe.phoneId ?: "unknown"} " +
-                    "name=${probe.friendlyName ?: "unknown"} — Bluetooth owner is " +
-                    "$phoneBtAddress name=${phoneBtName ?: "unknown"} " +
+                    "name=${probe.friendlyName ?: "unknown"} " +
+                    "reportedBluetoothName=${probe.bluetoothName ?: "unknown"} — " +
+                    "Bluetooth owner is $phoneBtAddress name=${phoneBtName ?: "unknown"} " +
                     "expectedId=${expectedPhoneId ?: "unlearned"}",
             )
             return false
+        }
+        if (matchBasis == CompanionIdentityMatch.BLUETOOTH_NAME) {
+            OalLog.i(
+                TAG,
+                "Bluetooth-name matched companion at $phoneIp " +
+                    "reportedBluetoothName=${probe.bluetoothName ?: "unknown"} " +
+                    "to owner=$phoneBtAddress name=${phoneBtName ?: "unknown"}; " +
+                    "learning stableId=${probe.phoneId ?: "unknown"}",
+            )
         }
         probe.phoneId?.let { phoneIdByBtAddress[phoneBtAddress] = it }
         return true

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicy.kt
@@ -7,7 +7,16 @@ internal data class CompanionProbe(
     val phoneId: String?,
     val friendlyName: String?,
     val proxyPort: Int,
+    val bluetoothName: String? = null,
+    val bluetoothNameReported: Boolean = bluetoothName != null,
 )
+
+internal enum class CompanionIdentityMatch {
+    PHONE_ID,
+    BLUETOOTH_NAME,
+    FRIENDLY_NAME,
+    NONE,
+}
 
 /** Pure parsing and ownership policy for Bluetooth-phone → companion matching. */
 internal object CompanionIdentityPolicy {
@@ -22,10 +31,16 @@ internal object CompanionIdentityPolicy {
             ?.toIntOrNull()
             ?.takeIf { it in 1..65535 }
             ?: return null
+        val bluetoothNameField = parts.firstOrNull { it.startsWith("bt_name=") }
         return CompanionProbe(
             phoneId = parts.getOrNull(0)?.trim()?.takeIf { it.isNotEmpty() },
             friendlyName = parts.getOrNull(1)?.trim()?.takeIf { it.isNotEmpty() },
             proxyPort = port,
+            bluetoothName = bluetoothNameField
+                ?.removePrefix("bt_name=")
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() },
+            bluetoothNameReported = bluetoothNameField != null,
         )
     }
 
@@ -33,14 +48,40 @@ internal object CompanionIdentityPolicy {
         expectedPhoneId: String?,
         bluetoothDeviceName: String?,
         probe: CompanionProbe,
-    ): Boolean {
+    ): Boolean = matchBasis(expectedPhoneId, bluetoothDeviceName, probe) !=
+        CompanionIdentityMatch.NONE
+
+    fun matchBasis(
+        expectedPhoneId: String?,
+        bluetoothDeviceName: String?,
+        probe: CompanionProbe,
+    ): CompanionIdentityMatch {
         val expectedId = expectedPhoneId?.trim()?.takeIf { it.isNotEmpty() }
         if (expectedId != null) {
-            return expectedId == probe.phoneId
+            return if (expectedId == probe.phoneId) {
+                CompanionIdentityMatch.PHONE_ID
+            } else {
+                CompanionIdentityMatch.NONE
+            }
         }
-        val btName = normalizeName(bluetoothDeviceName) ?: return false
-        val companionName = normalizeName(probe.friendlyName) ?: return false
-        return btName == companionName
+        val btName = normalizeName(bluetoothDeviceName)
+            ?: return CompanionIdentityMatch.NONE
+        if (probe.bluetoothNameReported) {
+            val reportedBluetoothName = normalizeName(probe.bluetoothName)
+                ?: return CompanionIdentityMatch.NONE
+            return if (btName == reportedBluetoothName) {
+                CompanionIdentityMatch.BLUETOOTH_NAME
+            } else {
+                CompanionIdentityMatch.NONE
+            }
+        }
+        val companionName = normalizeName(probe.friendlyName)
+            ?: return CompanionIdentityMatch.NONE
+        return if (btName == companionName) {
+            CompanionIdentityMatch.FRIENDLY_NAME
+        } else {
+            CompanionIdentityMatch.NONE
+        }
     }
 
     private fun normalizeName(value: String?): String? = value

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/CompanionIdentityPolicyTest.kt
@@ -10,15 +10,108 @@ import org.junit.Test
 class CompanionIdentityPolicyTest {
 
     @Test
-    fun `probe parser preserves phone identity and proxy port`() {
+    fun `probe parser preserves phone identity bluetooth name and proxy port`() {
         val probe = CompanionIdentityPolicy.parseProbe(
-            "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=5280",
+            "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=5280\tbt_name=OnePlus 13",
         )
 
         requireNotNull(probe)
         assertEquals("19bbbce4-1234", probe.phoneId)
         assertEquals("Liz OnePlus 13", probe.friendlyName)
+        assertEquals("OnePlus 13", probe.bluetoothName)
         assertEquals(5280, probe.proxyPort)
+    }
+
+    @Test
+    fun `reported bluetooth name learns phone when friendly name differs`() {
+        val liz = CompanionProbe(
+            phoneId = "liz-id",
+            friendlyName = "Liz OnePlus 13",
+            proxyPort = 5280,
+            bluetoothName = "OnePlus 13",
+        )
+        val lance = CompanionProbe(
+            phoneId = "lance-id",
+            friendlyName = "Lance OnePlus 13",
+            proxyPort = 5280,
+            bluetoothName = "Lance OnePlus 13",
+        )
+
+        assertTrue(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "OnePlus 13",
+                probe = liz,
+            ),
+        )
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "OnePlus 13",
+                probe = lance,
+            ),
+        )
+    }
+
+    @Test
+    fun `match basis distinguishes bluetooth name from legacy friendly fallback`() {
+        val current = CompanionProbe(
+            phoneId = "liz-id",
+            friendlyName = "Liz OnePlus 13",
+            proxyPort = 5280,
+            bluetoothName = "OnePlus 13",
+        )
+        val legacy = CompanionProbe(
+            phoneId = "liz-id",
+            friendlyName = "OnePlus 13",
+            proxyPort = 5280,
+        )
+
+        assertEquals(
+            CompanionIdentityMatch.BLUETOOTH_NAME,
+            CompanionIdentityPolicy.matchBasis(null, "OnePlus 13", current),
+        )
+        assertEquals(
+            CompanionIdentityMatch.FRIENDLY_NAME,
+            CompanionIdentityPolicy.matchBasis(null, "OnePlus 13", legacy),
+        )
+        assertEquals(
+            CompanionIdentityMatch.NONE,
+            CompanionIdentityPolicy.matchBasis(null, "Different Phone", current),
+        )
+    }
+
+    @Test
+    fun `present empty bluetooth field never falls back to friendly name`() {
+        val probe = CompanionIdentityPolicy.parseProbe(
+            "OAL!liz-id\tOnePlus 13\twpp=5280\tbt_name=",
+        )
+
+        requireNotNull(probe)
+        assertTrue(probe.bluetoothNameReported)
+        assertNull(probe.bluetoothName)
+        assertEquals(
+            CompanionIdentityMatch.NONE,
+            CompanionIdentityPolicy.matchBasis(null, "OnePlus 13", probe),
+        )
+    }
+
+    @Test
+    fun `reported bluetooth name does not fall back to misleading friendly name`() {
+        val probe = CompanionProbe(
+            phoneId = "other-id",
+            friendlyName = "OnePlus 13",
+            proxyPort = 5280,
+            bluetoothName = "Someone Else's Phone",
+        )
+
+        assertFalse(
+            CompanionIdentityPolicy.matches(
+                expectedPhoneId = null,
+                bluetoothDeviceName = "OnePlus 13",
+                probe = probe,
+            ),
+        )
     }
 
     @Test
@@ -98,7 +191,9 @@ class CompanionIdentityPolicyTest {
         ).readText()
         assertTrue(server.contains("remoteDevice?.name"))
         assertTrue(server.contains("currentEndpoint(phoneBtAddress, phoneBtName)"))
-        assertTrue(control.contains("CompanionIdentityPolicy.matches("))
+        assertTrue(control.contains("CompanionIdentityPolicy.matchBasis("))
+        assertTrue(control.contains("Bluetooth-name matched companion at"))
+        assertTrue(control.contains("reportedBluetoothName=${'$'}{probe.bluetoothName ?: \"unknown\"}"))
         assertTrue(control.contains("private val phoneClaimLock = Any()"))
         assertTrue(control.contains("private var phoneClaimGeneration = 0L"))
         assertTrue(control.contains("claimGeneration = claimPhoneForHandshake("))
@@ -112,7 +207,7 @@ class CompanionIdentityPolicyTest {
             .count { it == "\"wpp\" -> startWpp()" })
         assertEquals(2, session.windowed("\"wpp\" -> startWpp(recovery = true)".length)
             .count { it == "\"wpp\" -> startWpp(recovery = true)" })
-        val matchIndex = control.indexOf("CompanionIdentityPolicy.matches(")
+        val matchIndex = control.indexOf("CompanionIdentityPolicy.matchBasis(")
         val cacheIndex = control.indexOf("lastAddressByPhone[phoneBtAddress] = ip", matchIndex)
         assertTrue(matchIndex >= 0)
         assertTrue(cacheIndex > matchIndex)

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionIdentityPayload.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionIdentityPayload.kt
@@ -1,0 +1,20 @@
+package com.openautolink.companion.service
+
+/** Builds the backward-compatible identity reply consumed by the car app. */
+internal object CompanionIdentityPayload {
+    fun encode(
+        phoneId: String,
+        friendlyName: String,
+        bluetoothName: String?,
+        proxyPort: Int,
+    ): String {
+        require(proxyPort in 1..65535) { "proxyPort must be live" }
+        val bluetoothField = "\tbt_name=${wireValue(bluetoothName.orEmpty())}"
+        return "OAL!${wireValue(phoneId)}\t${wireValue(friendlyName)}" +
+            "\twpp=$proxyPort$bluetoothField\n"
+    }
+
+    private fun wireValue(value: String): String = value
+        .replace(Regex("[\\t\\r\\n]+"), " ")
+        .trim()
+}

--- a/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt
@@ -414,9 +414,9 @@ class TcpAdvertiser(
     /**
      * Run a tiny dedicated server on [IDENTITY_PORT] that answers identity
      * probes. Each connection: peer sends `OAL?\n`, we reply with
-     * `OAL!{phone_id}\t{friendly_name}\n` and close. Single-purpose — never
-     * carries AA traffic. Used by the car-side subnet sweep + last-known-IP
-     * verification when mDNS is unavailable.
+     * `OAL!{phone_id}\t{friendly_name}\twpp={port}\tbt_name={adapter_name}\n`
+     * and close. Single-purpose — never carries AA traffic. Used by the car-side
+     * subnet sweep + last-known-IP verification when mDNS is unavailable.
      */
     private fun startIdentityServer(
         ticket: ListenerBindingTicket<Network>,
@@ -449,6 +449,12 @@ class TcpAdvertiser(
             }
         }
     }
+
+    private fun localBluetoothName(): String? = runCatching {
+        val manager = context.applicationContext
+            .getSystemService(Context.BLUETOOTH_SERVICE) as? android.bluetooth.BluetoothManager
+        manager?.adapter?.name?.trim()?.takeIf { it.isNotEmpty() }
+    }.getOrNull()
 
     private fun respondIdentityProbe(socket: Socket, remoteIp: String) {
         try {
@@ -522,12 +528,22 @@ class TcpAdvertiser(
                 proxy?.isAccepting == true -> proxy.localPort
                 else -> ensureProxyForWpp()
             }
-            val response = "OAL!$phoneId\t$friendlyName\twpp=$wppPort\n".toByteArray(Charsets.UTF_8)
+            val bluetoothName = localBluetoothName()
+            val response = CompanionIdentityPayload.encode(
+                phoneId = phoneId,
+                friendlyName = friendlyName,
+                bluetoothName = bluetoothName,
+                proxyPort = wppPort,
+            ).toByteArray(Charsets.UTF_8)
             socket.getOutputStream().apply {
                 write(response)
                 flush()
             }
-            CompanionLog.d(TAG, "Identity probe answered for $remoteIp")
+            CompanionLog.i(
+                TAG,
+                "Identity probe answered for $remoteIp phoneId=${phoneId.take(8)} " +
+                    "bluetoothName=${bluetoothName ?: "unavailable"}",
+            )
         } catch (e: Exception) {
             CompanionLog.d(TAG, "Identity probe failed for $remoteIp: ${e.message}")
         } finally {

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -402,9 +402,9 @@ fun MainScreen(
                 modifier = Modifier.padding(top = 4.dp),
             )
             Text(
-                text = "Multiple phones: give every phone a unique Bluetooth device name, " +
-                    "then set this Friendly name to exactly match that Bluetooth name. " +
-                    "The car uses the match only to learn this phone's stable ID.",
+                text = "Multiple phones: give every phone a unique Bluetooth device name. " +
+                    "That name is reported automatically when the car learns this phone's stable ID; " +
+                    "Friendly name is only the label shown in OAL.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),

--- a/companion/src/test/java/com/openautolink/companion/service/CompanionIdentityPayloadTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/service/CompanionIdentityPayloadTest.kt
@@ -1,0 +1,67 @@
+package com.openautolink.companion.service
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionIdentityPayloadTest {
+
+    @Test
+    fun `identity payload reports local bluetooth name separately from friendly name`() {
+        assertEquals(
+            "OAL!19bbbce4-1234\tLiz OnePlus 13\twpp=5280\tbt_name=OnePlus 13\n",
+            CompanionIdentityPayload.encode(
+                phoneId = "19bbbce4-1234",
+                friendlyName = "Liz OnePlus 13",
+                bluetoothName = "OnePlus 13",
+                proxyPort = 5280,
+            ),
+        )
+    }
+
+    @Test
+    fun `identity payload marks bluetooth name unavailable instead of looking legacy`() {
+        assertEquals(
+            "OAL!19bbbce4-1234\tOnePlus 13\twpp=5280\tbt_name=\n",
+            CompanionIdentityPayload.encode(
+                phoneId = "19bbbce4-1234",
+                friendlyName = "OnePlus 13",
+                bluetoothName = null,
+                proxyPort = 5280,
+            ),
+        )
+    }
+
+    @Test
+    fun `tcp identity probe publishes the local bluetooth adapter name`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/TcpAdvertiser.kt",
+        ).readText()
+
+        assertTrue(source.contains("android.bluetooth.BluetoothManager"))
+        assertTrue(source.contains("manager?.adapter?.name"))
+        assertTrue(source.contains("CompanionIdentityPayload.encode("))
+        assertTrue(source.contains("bluetoothName = bluetoothName"))
+        assertTrue(source.contains("bluetoothName=${'$'}{bluetoothName ?: \"unavailable\"}"))
+    }
+
+    @Test
+    fun `phone identity guidance no longer requires friendly name to equal bluetooth name`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt",
+        ).readText()
+
+        assertTrue(source.contains("unique Bluetooth device name"))
+        assertTrue(source.contains("reported automatically"))
+        assertFalse(source.contains("set this Friendly name to exactly match"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .first { it.isFile }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix WPP startup for a second phone when its OAL Friendly name differs from its actual Bluetooth device name.
- Have the companion always report the local Bluetooth adapter name field as backward-compatible `bt_name`; an unavailable name remains explicitly present and cannot masquerade as a legacy payload.
- Keep stable `phone_id` authoritative after learning, retain exact legacy Friendly-name matching only for older companions that truly lack `bt_name`, and reject present-but-empty names.
- Add explicit car/phone runtime markers and update multi-phone setup guidance.

## Root cause
In the 2026-08-21 capture, Liz's Bluetooth phone completed WPP handshakes and her companion repeatedly answered at the correct car-AP address, but the car rejected it with `expectedId=unlearned` because Bluetooth reported `OnePlus 13` while OAL Friendly name was `Liz OnePlus 13`. Lance's phone then matched exactly and streamed, providing the natural A/B.

## Verification
- Strict RED→GREEN tests for Liz's mismatch, cross-phone rejection, legacy fallback, wire payload, integration, and UI guidance.
- `:app:testDebugUnitTest`: 407 tests, 0 failures/errors/skips.
- `:companion:testDebugUnitTest`: 61 tests, 0 failures/errors/skips.
- Both debug APKs assembled with arm64-v8a and x86_64 native packaging.
- DEX containment confirmed for `bt_name=`, `Bluetooth-name matched companion at`, `reportedBluetoothName=`, and phone-side identity outcome markers.

## Runtime acceptance
On the next two-phone test, require:
1. Companion: `Identity probe answered ... bluetoothName=OnePlus 13`
2. Car: `Bluetooth-name matched companion at ... learning stableId=...`
3. Car dials that same companion address.
4. Positive stream outcome: native session + sustained `vflow`/rendering.

This is a code/build-verified attempt pending the next vehicle log; it is not yet road-verified.
