### PR TITLE
fix(wireless): rearm WPP owner on retained wake

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application>
+        <!-- ADB-only setting/reconnect controls are exported only in debug builds. -->
+        <receiver
+            android:name=".diagnostics.SettingsReceiver"
+            android:exported="true"
+            tools:replace="android:exported" />
+    </application>
+</manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -146,10 +146,10 @@
             android:name="com.android.automotive.application.DISTRACTION_OPTIMIZED"
             android:value="true" />
 
-        <!-- Debug: change settings via ADB broadcast without rebuild -->
+        <!-- ADB control receiver is private in release; debug manifest overrides exported=true. -->
         <receiver
             android:name=".diagnostics.SettingsReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.openautolink.app.SET_PREF" />
                 <action android:name="com.openautolink.app.RECONNECT" />

--- a/app/src/main/java/com/openautolink/app/MainActivity.kt
+++ b/app/src/main/java/com/openautolink/app/MainActivity.kt
@@ -127,7 +127,9 @@ class MainActivity : ComponentActivity() {
         // "JniTransport stopping".
         Thread({
             try {
-                com.openautolink.app.session.SessionManager.instanceOrNull()?.stop()
+                kotlinx.coroutines.runBlocking {
+                    com.openautolink.app.session.SessionManager.instanceOrNull()?.stop()
+                }
             } catch (e: Exception) {
                 Log.w("MainActivity", "SessionManager.stop() failed: ${e.message}")
             }

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -36,6 +36,7 @@ import com.openautolink.app.transport.ConnectionState
 import com.openautolink.app.transport.ControlMessage
 import com.openautolink.app.transport.aasdk.AasdkSession
 import com.openautolink.app.transport.aasdk.AasdkSdrConfig
+import com.openautolink.app.transport.bluetooth.AaWirelessBtControl
 import com.openautolink.app.transport.usb.UsbConnectionManager
 import com.openautolink.app.video.DecoderState
 import com.openautolink.app.video.AutoDpiPolicy
@@ -137,16 +138,17 @@ class SessionManager(
     private var wirelessSessionAdmission:
         com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token? = null
 
-    private fun installWirelessSessionAdmission(transportMode: String) {
+    private fun installWirelessSessionAdmission(
+        transportMode: String,
+    ): com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token =
         synchronized(wirelessAdmissionLock) {
             wirelessSessionAdmission?.let {
-                com.openautolink.app.transport.bluetooth.AaWirelessBtControl.clearSessionOwner(it)
+                AaWirelessBtControl.clearSessionOwner(it)
             }
-            wirelessSessionAdmission =
-                com.openautolink.app.transport.bluetooth.AaWirelessBtControl
-                    .installSessionOwner(transportMode)
+            AaWirelessBtControl.installSessionOwner(transportMode).also { token ->
+                wirelessSessionAdmission = token
+            }
         }
-    }
 
     private fun clearWirelessSessionAdmission() {
         synchronized(wirelessAdmissionLock) {
@@ -678,6 +680,9 @@ class SessionManager(
     /** Get the current default phone name. */
     fun getDefaultPhoneName(): String = _defaultPhoneName
 
+    /** True while an exact WPP session token owns the process-scoped advertiser. */
+    fun hasCurrentWppOwner(): Boolean = AaWirelessBtControl.hasCurrentWppOwner()
+
     /** Clear the default phone — next connection will pick any phone. */
     fun clearDefaultPhone() {
         _defaultPhoneName = ""
@@ -689,7 +694,7 @@ class SessionManager(
 
     /** Switch phone: disconnect, restart discovery in chooser mode. */
     fun switchPhone() {
-        stop()
+        scope.launch { stop() }
     }
 
     // Media session. Holds a reference to the process-wide singleton (created
@@ -727,6 +732,24 @@ class SessionManager(
 
     // Cluster manager
     private var _clusterManager: com.openautolink.app.cluster.ClusterManager? = null
+
+    private val startMutex = kotlinx.coroutines.sync.Mutex()
+    @Volatile private var lifecycleGeneration = 0L
+
+    /** Caller must already hold [startMutex]. */
+    private suspend fun rollbackLifecycleFailure(
+        phase: String,
+        error: Throwable,
+        cancelObserveJob: Boolean = true,
+    ) {
+        OalLog.e(TAG, "$phase lifecycle failed: ${error.message} — rolling back")
+        try {
+            stopWhileLifecycleLocked(cancelObserveJob = cancelObserveJob)
+        } catch (cleanupError: Exception) {
+            error.addSuppressed(cleanupError)
+            OalLog.e(TAG, "$phase rollback failed: ${cleanupError.message}")
+        }
+    }
 
     private var observeJob: Job? = null
     private var decoderWatchJob: Job? = null
@@ -978,7 +1001,7 @@ class SessionManager(
         session.sendNightMode(night)
     }
 
-    fun start(
+    suspend fun start(
         codecPreference: String = "h264",
         micSourcePreference: String = "car",
         scalingMode: String = "letterbox",
@@ -1011,13 +1034,34 @@ class SessionManager(
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
+        wppRearmSource: String? = null,
+        wppRearmFinalAdmission: (suspend () -> String?)? = null,
     ) {
+        val requestGeneration = lifecycleGeneration
+        startMutex.lock()
+        try {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+        if (requestGeneration != lifecycleGeneration) {
+            OalLog.i(TAG, "Start request rejected — lifecycle stop completed while waiting")
+            return@withContext
+        }
+        val initialWppRejection = if (wppRearmSource != null) {
+            wppRearmFinalAdmission?.invoke() ?: "admission-check-missing"
+        } else null
+        if (initialWppRejection != null) {
+            OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource " +
+                "reason=$initialWppRejection")
+            return@withContext
+        }
+        // Everything below mutates lifecycle-owned components. Any failure must
+        // roll the whole replacement back before releasing the lifecycle mutex.
+        try {
         // Cache for later reconnects that don't know the resolved IP (e.g.
         // Settings "Save & Reconnect" in Car Hotspot mode).
         if (!manualIpAddress.isNullOrBlank()) _lastManualIpAddress = manualIpAddress
         gpsForwardingEnabled = gpsForwarding
         micSource = micSourcePreference
-        observeJob?.cancel()
+        observeJob?.cancelAndJoin()
 
         // Create video decoder
         _videoDecoder?.release()
@@ -1190,7 +1234,8 @@ class SessionManager(
         _telemetryCollector?.audioPlayer = _audioPlayer
         _telemetryCollector?.start()
 
-        observeJob = scope.launch {
+        val startupOutcome = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val newObserveJob = scope.launch(start = kotlinx.coroutines.CoroutineStart.LAZY) {
             // Watch for decoder errors
             decoderWatchJob?.cancel()
             decoderWatchJob = launch { watchDecoderState() }
@@ -1214,22 +1259,64 @@ class SessionManager(
             callStateJob?.cancel()
             callStateJob = launch { watchCallState() }
 
-            // Start direct mode session
-            startSession(directTransport, hotspotSsid, hotspotPassword,
-                videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
-                aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
-                aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
-                videoFps,
-                driveSide, hideClock, hideSignal, hideBattery, scalingMode,
-                manualIpAddress,
-                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding, galVersion)
+            // Start direct mode session. Re-run WPP admission on this exact
+            // serialized coroutine immediately before the destructive owner
+            // transition; the caller may have suspended while reading settings
+            // or waiting for its render rectangle.
+            try {
+                // Register before final admission so the same rollback block
+                // owns both registration and unregistration.
+                registerScreenReceiver()
+                if (isDebuggableBuild()) registerDebugReceiver()
+                val finalWppRejection = if (wppRearmSource != null) {
+                wppRearmFinalAdmission?.invoke() ?: "admission-check-missing"
+            } else null
+            if (finalWppRejection != null) {
+                OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource " +
+                    "reason=$finalWppRejection")
+                stopWhileLifecycleLocked(cancelObserveJob = false)
+                startupOutcome.complete(Unit)
+                return@launch
+            }
+                startSession(directTransport, hotspotSsid, hotspotPassword,
+                    videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
+                    aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
+                    aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
+                    videoFps,
+                    driveSide, hideClock, hideSignal, hideBattery, scalingMode,
+                    manualIpAddress,
+                    safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+                    gpsForwarding, galVersion, wppRearmSource)
+                startupOutcome.complete(Unit)
+            } catch (e: Exception) {
+                wppRearmSource?.let { source ->
+                    OalLog.e(TAG, "WPP rearm outcome: source=$source " +
+                        "ownerInstalled=false error=${e.message}")
+                }
+                startupOutcome.completeExceptionally(e)
+            }
         }
+        newObserveJob.invokeOnCompletion { cause ->
+            if (!startupOutcome.isCompleted) {
+                startupOutcome.completeExceptionally(
+                    cause ?: IllegalStateException("session start ended before reporting outcome"),
+                )
+            }
+        }
+        observeJob = newObserveJob
+        newObserveJob.start()
 
-        // Listen for system sleep so we can gracefully tear down before the
-        // socket goes stale. Wake is handled in MainActivity.onResume().
-        registerScreenReceiver()
-        registerDebugReceiver()
+        kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+            startupOutcome.await()
+        }
+        } catch (e: Exception) {
+            rollbackLifecycleFailure("start", e)
+            throw e
+        }
+        }
+        } finally {
+            startMutex.unlock()
+        }
     }
 
     private fun startSession(
@@ -1248,10 +1335,18 @@ class SessionManager(
         safeAreaTop: Int = 0, safeAreaBottom: Int = 0, safeAreaLeft: Int = 0, safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
+        wppRearmSource: String? = null,
     ) {
         aasdkSession?.stop()
         _transportMode.value = directTransport
-        val ctx = context ?: return
+        val ctx = context
+        if (ctx == null) {
+            wppRearmSource?.let { source ->
+                OalLog.e(TAG, "WPP rearm outcome: source=$source " +
+                    "ownerInstalled=false error=context-missing")
+            }
+            return
+        }
 
         // Map resolution string to pixel dimensions. Strings are the AA
         // VideoCodecResolutionType enum values; portrait variants use the
@@ -1626,7 +1721,13 @@ class SessionManager(
         // Publish SDP only after this exact protocol owner has installed all
         // callbacks and bound its transport. This closes the cold-start and
         // USB→WPP preference races without delaying native negotiation itself.
-        installWirelessSessionAdmission(directTransport)
+        val ownerToken = installWirelessSessionAdmission(directTransport)
+        wppRearmSource?.let { source ->
+            val ownerInstalled = AaWirelessBtControl.isCurrentSessionOwner(ownerToken)
+            val message = "WPP rearm outcome: source=$source " +
+                "ownerInstalled=$ownerInstalled"
+            if (ownerInstalled) OalLog.i(TAG, message) else OalLog.e(TAG, message)
+        }
         com.openautolink.app.wake.PreWakeMonitor.reportSessionReady("admission-ready")
         OalLog.i(TAG, "aasdk JNI session started ($directTransport transport)")
     }
@@ -1728,7 +1829,10 @@ class SessionManager(
             OalLog.w(TAG, "ByeBye dispatch failed (${it.message}) — stopping immediately")
         }.isSuccess
 
-        if (!dispatched) { stop(); return }
+        if (!dispatched) {
+            scope.launch { stop() }
+            return
+        }
 
         scope.launch {
             // Give the ByeBye its bounded window to flush and be acknowledged.
@@ -1755,7 +1859,19 @@ class SessionManager(
         session.dialCompanion(ip)
     }
 
-    fun stop() {
+    suspend fun stop() {
+        startMutex.lock()
+        try {
+            kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+                lifecycleGeneration += 1L
+                stopWhileLifecycleLocked()
+            }
+        } finally {
+            startMutex.unlock()
+        }
+    }
+
+    private suspend fun stopWhileLifecycleLocked(cancelObserveJob: Boolean = true) {
         clearWirelessSessionAdmission()
         // Let another phone claim the session. Without this the first phone to
         // dial holds it until the app restarts, so a second phone in the car can
@@ -1764,15 +1880,15 @@ class SessionManager(
 
         unregisterScreenReceiver()
         unregisterDebugReceiver()
-        observeJob?.cancel()
+        if (cancelObserveJob) observeJob?.cancelAndJoin()
         observeJob = null
-        decoderWatchJob?.cancel()
+        decoderWatchJob?.cancelAndJoin()
         decoderWatchJob = null
-        keyframeWatchJob?.cancel()
+        keyframeWatchJob?.cancelAndJoin()
         keyframeWatchJob = null
-        videoStallWatchJob?.cancel()
+        videoStallWatchJob?.cancelAndJoin()
         videoStallWatchJob = null
-        callStateJob?.cancel()
+        callStateJob?.cancelAndJoin()
         callStateJob = null
         // Revoke ownership before cancelling collectors or stopping retained
         // producers. A PhoneConnected callback already executing cannot be
@@ -1840,7 +1956,7 @@ class SessionManager(
      *
      * Falls back to full [start] if component islands haven't been initialized yet.
      */
-    fun reconnect(
+    suspend fun reconnect(
         codecPreference: String = "h264",
         micSourcePreference: String = "car",
         scalingMode: String = "letterbox",
@@ -1930,6 +2046,16 @@ class SessionManager(
         }
         reconnectInProgress = true
         reconnectStartedAt = System.currentTimeMillis()
+        val requestGeneration = lifecycleGeneration
+        var lifecycleLockAcquired = false
+        try {
+            startMutex.lock()
+            lifecycleLockAcquired = true
+            kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
+            if (requestGeneration != lifecycleGeneration) {
+                OalLog.i(TAG, "Reconnect request rejected — lifecycle stop completed while waiting")
+                return@withContext
+            }
         gpsForwardingEnabled = gpsForwarding
         OalLog.i(TAG, "Reconnecting AA session with new settings (minimal restart)")
         micSource = micSourcePreference
@@ -1939,7 +2065,7 @@ class SessionManager(
         // 20+ "Keyframe re-request #2" lines came from this exact race).
         // Run on IO so we don't block the Main thread (causes ANR — we wait on
         // cancelAndJoin and then aasdkSession.stop() which JNI-joins the io_thread).
-        scope.launch(kotlinx.coroutines.Dispatchers.IO) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             try {
                 // Say goodbye before tearing down, whenever a session exists.
                 //
@@ -1977,15 +2103,19 @@ class SessionManager(
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
-            } finally {
-                // Always clear the guard so a future reconnect attempt can run.
-                reconnectInProgress = false
-                reconnectStartedAt = 0L
+                rollbackLifecycleFailure("reconnect", e)
             }
+        }
+        }
+        } finally {
+            // Always clear the guard so a future reconnect attempt can run.
+            reconnectInProgress = false
+            reconnectStartedAt = 0L
+            if (lifecycleLockAcquired) startMutex.unlock()
         }
     }
 
-    private fun doReconnectAfterCancel(
+    private suspend fun doReconnectAfterCancel(
         codecPreference: String, micSourcePreference: String, scalingMode: String,
         directTransport: String, hotspotSsid: String, hotspotPassword: String,
         videoAutoNegotiate: Boolean, aaResolution: String, aaDpi: Int,
@@ -2044,7 +2174,19 @@ class SessionManager(
         _voiceSessionActive.value = false
         _phoneSignalStrength.value = null
 
-        // 8. Start new AA session with new SDR config
+        // 8. Start the replacement protocol session synchronously while the
+        // lifecycle mutex is held. Only after its exact owner is installed do
+        // we publish the long-lived watcher job.
+        startSession(directTransport, hotspotSsid, hotspotPassword,
+            videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
+            aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
+            aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
+            videoFps,
+            driveSide, hideClock, hideSignal, hideBattery, scalingMode,
+            manualIpAddress,
+            safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
+            gpsForwarding, galVersion)
+
         observeJob = scope.launch {
             decoderWatchJob = launch { watchDecoderState() }
             keyframeWatchJob = launch { watchKeyframeNeeds() }
@@ -2057,16 +2199,6 @@ class SessionManager(
             // app restart. Nothing on the main thread should enter JNI.
             videoStallWatchJob = launch(kotlinx.coroutines.Dispatchers.IO) { watchVideoStall() }
             callStateJob = launch { watchCallState() }
-
-            startSession(directTransport, hotspotSsid, hotspotPassword,
-                videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
-                aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
-                aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
-                videoFps,
-                driveSide, hideClock, hideSignal, hideBattery, scalingMode,
-                manualIpAddress,
-                safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                gpsForwarding, galVersion)
         }
 
         // 9. Re-establish cluster binding — GM Templates Host may have killed
@@ -2398,13 +2530,17 @@ class SessionManager(
     //     --el duration_ms 60000 \
     //     com.openautolink.app
     //
-    // Exposed for integration tests. Action is namespaced under our package
-    // and the receiver is package-internal (RECEIVER_NOT_EXPORTED on T+); on
-    // older platforms it's still package-scoped at the dispatch layer because
-    // we pass the package in the broadcast intent.
+    // Debug-only integration controls. Release builds never register this
+    // receiver. Debug builds keep it exported so adb shell can drive the
+    // ignition and phone-injection scenarios.
     // ------------------------------------------------------------------
     private var debugSleepReceiver: android.content.BroadcastReceiver? = null
+    private fun isDebuggableBuild(): Boolean {
+        val flags = context?.applicationInfo?.flags ?: return false
+        return flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE != 0
+    }
     private fun registerDebugReceiver() {
+        if (!isDebuggableBuild()) return
         if (debugSleepReceiver != null) return
         val ctx = context ?: return
         val r = object : android.content.BroadcastReceiver() {

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -227,6 +227,11 @@ object AaWirelessBtControl {
     @Volatile
     var onStatus: ((String) -> Unit)? = null
 
+    fun isCurrentSessionOwner(token: WppSessionAdmission.Token): Boolean =
+        token.transportMode == "wpp" && sessionAdmission.isCurrent(token)
+
+    fun hasCurrentWppOwner(): Boolean = sessionAdmission.currentWppOwner() != null
+
     fun installSessionOwner(transportMode: String): WppSessionAdmission.Token {
         val token = synchronized(this) {
             sessionAdmission.installSession(transportMode)
@@ -973,6 +978,9 @@ object AaWirelessBtControl {
     var activePhoneCompanionIp: String? = null
         private set
 
+    private fun isDebuggableBuild(context: Context): Boolean =
+        context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE != 0
+
     fun init(context: Context) {
         appContext = context.applicationContext
         restoreKnownIps(context)
@@ -981,7 +989,8 @@ object AaWirelessBtControl {
             if (started) return
             started = true
         }
-        val receiver = object : BroadcastReceiver() {
+        if (isDebuggableBuild(context)) {
+            val receiver = object : BroadcastReceiver() {
             override fun onReceive(c: Context?, intent: Intent?) {
                 when (intent?.action) {
                     ACTION_START -> handleStart(context, intent)
@@ -1013,10 +1022,14 @@ object AaWirelessBtControl {
         // Exported so it can be driven from adb during bring-up. This is a debug
         // affordance; when the advertiser starts automatically it should stop being
         // externally triggerable.
-        androidx.core.content.ContextCompat.registerReceiver(
-            context, receiver, filter,
-            androidx.core.content.ContextCompat.RECEIVER_EXPORTED,
-        )
+            androidx.core.content.ContextCompat.registerReceiver(
+                context, receiver, filter,
+                androidx.core.content.ContextCompat.RECEIVER_EXPORTED,
+            )
+            OalLog.i(TAG, "Debug AA wireless controls registered")
+        } else {
+            OalLog.i(TAG, "Debug AA wireless controls disabled in release build")
+        }
 
         // Start advertising automatically whenever WPP is the selected transport.
         //

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -458,7 +458,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
     private val connectLock = Any()
 
     fun connect() {
-        connect(overrideIp = null)
+        connect(overrideIp = null, wppRearmSource = null)
     }
 
     /**
@@ -467,6 +467,20 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      * by-value here so a concurrent caller can't race on a shared field.
      */
     fun connect(overrideIp: String?) {
+        connect(overrideIp = overrideIp, wppRearmSource = null)
+    }
+
+    private fun connectForWppRearm(source: String) {
+        connect(overrideIp = null, wppRearmSource = source)
+    }
+
+    private fun connect(overrideIp: String?, wppRearmSource: String?) {
+        fun logWppRearmRejected(reason: String) {
+            wppRearmSource?.let { source ->
+                OalLog.i(TAG, "WPP rearm rejected: source=$source reason=$reason")
+            }
+        }
+
         // Open the chooser instead of auto-connecting when:
         //   - "Always ask" is on (Behavior 2), OR
         //   - No default phone is set yet (first-run or after Forget — the
@@ -494,6 +508,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     "Auto-connect suppressed — ignition state = ${com.openautolink.app.input.IgnitionMonitor.ignitionState.value} " +
                         "(off ${com.openautolink.app.input.IgnitionMonitor.msSinceIgnitionOff()}ms ago)",
                 )
+                logWppRearmRejected("ignition-off")
                 return
             }
             // Acquire the in-flight slot synchronously before suspending so
@@ -501,10 +516,12 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             synchronized(connectLock) {
                 if (hasConnected && sessionManager.sessionState.value != SessionState.IDLE) {
                     sessionManager.ensureClusterAlive()
+                    logWppRearmRejected("session-not-idle")
                     return
                 }
                 if (connectInFlight) {
                     OalLog.d(TAG, "connect() ignored — another connect coroutine is already in flight")
+                    logWppRearmRejected("connect-in-flight")
                     return
                 }
                 connectInFlight = true
@@ -521,6 +538,13 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     // needs the phone chooser, because there is no discovery step
                     // to disambiguate.
                     val transport = preferences.directTransport.first()
+                    if (wppRearmSource != null &&
+                        transport != AppPreferences.DIRECT_TRANSPORT_WPP
+                    ) {
+                        OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource " +
+                            "reason=transport-changed current=$transport")
+                        return@launch
+                    }
                     val usbMode = transport == AppPreferences.DIRECT_TRANSPORT_USB ||
                         transport == AppPreferences.DIRECT_TRANSPORT_WPP
                     if (!usbMode && mode == AppPreferences.CONNECTION_MODE_CAR_HOTSPOT) {
@@ -539,9 +563,13 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                             return@launch
                         }
                     }
-                    doConnect(overrideIp = null)
+                    doConnect(overrideIp = null, wppRearmSource = wppRearmSource)
                     settle = true
                 } catch (e: Exception) {
+                    wppRearmSource?.let { source ->
+                        OalLog.e(TAG, "WPP rearm outcome: source=$source " +
+                            "ownerInstalled=false error=${e.message}")
+                    }
                     OalLog.e(TAG, "connect() failed: ${e.message}")
                 } finally {
                     // Hold the in-flight slot briefly so sessionState has
@@ -589,13 +617,28 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      * chooser-open gate has been cleared. Reads all remaining settings and
      * hands off to SessionManager.start.
      */
-    private suspend fun doConnect(overrideIp: String?) {
+    private suspend fun doConnect(
+        overrideIp: String?,
+        wppRearmSource: String? = null,
+    ) {
             val codec = preferences.videoCodec.first()
             val micSrc = preferences.micSource.first()
             val scalingMode = preferences.videoScalingMode.first()
             val hotspotSsid = preferences.hotspotSsid.first()
             val hotspotPassword = preferences.hotspotPassword.first()
             val directTransport = preferences.directTransport.first()
+            wppRearmSource?.let {
+                val rejection = WppWakeReconnectPolicy.preStartRejection(
+                    wppSelectedNow = directTransport == AppPreferences.DIRECT_TRANSPORT_WPP,
+                    ignitionOff = com.openautolink.app.input.IgnitionMonitor.isOffOrLocked(),
+                    sessionIdle = sessionManager.sessionState.value == SessionState.IDLE,
+                    currentWppOwnerPresent = sessionManager.hasCurrentWppOwner(),
+                )
+                if (rejection != null) {
+                    OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource reason=$rejection")
+                    return
+                }
+            }
             val videoAutoNeg = preferences.videoAutoNegotiate.first()
             val aaRes = preferences.aaResolution.first()
             val aaDpi = preferences.aaDpi.first()
@@ -787,6 +830,27 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                         "manual DPI; scaling may be wrong until reconnect")
             }
 
+            // SessionManager invokes this once before destructive setup and again
+            // inside its serialized start coroutine immediately before creating
+            // the protocol owner. Keeping the check attached to the attempt closes
+            // the caller/callee suspension window without making SessionManager
+            // depend on UI-layer policy.
+            val wppRearmFinalAdmission: (suspend () -> String?)? =
+                wppRearmSource?.let {
+                    {
+                        val currentTransport = preferences.directTransport.first()
+                        WppWakeReconnectPolicy.preStartRejection(
+                            wppSelectedNow = currentTransport ==
+                                AppPreferences.DIRECT_TRANSPORT_WPP,
+                            ignitionOff = com.openautolink.app.input.IgnitionMonitor
+                                .isOffOrLocked(),
+                            sessionIdle = sessionManager.sessionState.value ==
+                                SessionState.IDLE,
+                            currentWppOwnerPresent = sessionManager.hasCurrentWppOwner(),
+                        )
+                    }
+                }
+
             sessionManager.start(
                 codecPreference = codec,
                 micSourcePreference = micSrc,
@@ -820,6 +884,8 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
                 galVersion = galVersion,
+                wppRearmSource = wppRearmSource,
+                wppRearmFinalAdmission = wppRearmFinalAdmission,
             )
     }
 
@@ -1111,28 +1177,43 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     )
                     _activePhoneId.value = null
                 }
-                // Force-kick auto-reconnect on wake. `phoneDiscovery.phones`
-                // edge-triggered collector only fires when isResolved flips
-                // false→true; after a short sleep the phone often stays
-                // resolved across the gap, so the edge never happens and we
-                // sit idle. The wake event is a level signal — use it to
-                // resync. Gate on the same conditions as the edge collector.
-                if (event.gapMs >= WAKE_AUTO_RECONNECT_MIN_GAP_MS &&
-                    wirelessDiscoveryEnabled &&
-                    !alwaysAskPhone.value &&
-                    defaultPhoneId.value.isNotBlank() &&
-                    !connectInFlight &&
-                    sessionManager.sessionState.value == SessionState.IDLE &&
-                    phoneDiscovery.phones.value.any { it.isResolved }) {
+                // Force-kick session ownership on wake. WPP is deliberately
+                // independent of the legacy phone picker and IP discovery: the
+                // Bluetooth dial-back cannot happen until this car first binds
+                // its listener and publishes SDP. Requiring a discovered default
+                // here produced a 78s owner-less wait in one wake and no owner at
+                // all in the next capture.
+                val wppSelected = preferences.directTransport.first() ==
+                    AppPreferences.DIRECT_TRANSPORT_WPP
+                val shouldKick = event.gapMs >= WAKE_AUTO_RECONNECT_MIN_GAP_MS &&
+                    WppWakeReconnectPolicy.shouldKickWake(
+                        wppSelected = wppSelected,
+                        wirelessDiscoveryEnabled = wirelessDiscoveryEnabled,
+                        alwaysAskPhone = alwaysAskPhone.value,
+                        defaultPhonePresent = defaultPhoneId.value.isNotBlank(),
+                        resolvedPhonePresent = phoneDiscovery.phones.value.any { it.isResolved },
+                        connectInFlight = connectInFlight,
+                        sessionIdle = sessionManager.sessionState.value == SessionState.IDLE,
+                        currentWppOwnerPresent = sessionManager.hasCurrentWppOwner(),
+                    )
+                if (shouldKick) {
                     val now = SystemClock.elapsedRealtime()
-                    if (now - lastAutoReconnectAttemptMs >= AUTO_RECONNECT_MIN_GAP_MS) {
+                    if (WppWakeReconnectPolicy.cooldownAllows(
+                            wppSelected = wppSelected,
+                            elapsedSinceAttemptMs = now - lastAutoReconnectAttemptMs,
+                            minimumGapMs = AUTO_RECONNECT_MIN_GAP_MS,
+                        )) {
                         lastAutoReconnectAttemptMs = now
-                        OalLog.i(
-                            TAG,
-                            "Wake event (gap=${event.gapMs}ms) — kicking auto-reconnect",
-                        )
-                        hasConnected = false
-                        connect()
+                        if (wppSelected) {
+                            connectForWppRearm(source = "wake")
+                        } else {
+                            OalLog.i(
+                                TAG,
+                                "Wake event (gap=${event.gapMs}ms) — kicking auto-reconnect",
+                            )
+                            hasConnected = false
+                            connect()
+                        }
                     }
                 }
             }
@@ -1148,17 +1229,31 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 .collect { state ->
                     val on = state == 4 || state == 5
                     if (!on) return@collect
-                    if (!wirelessDiscoveryEnabled) return@collect
-                    if (alwaysAskPhone.value) return@collect
-                    if (defaultPhoneId.value.isBlank()) return@collect
-                    if (connectInFlight) return@collect
-                    if (sessionManager.sessionState.value != SessionState.IDLE) return@collect
+                    val wppSelected = preferences.directTransport.first() ==
+                        AppPreferences.DIRECT_TRANSPORT_WPP
+                    if (!WppWakeReconnectPolicy.shouldKickIgnition(
+                            wppSelected = wppSelected,
+                            wirelessDiscoveryEnabled = wirelessDiscoveryEnabled,
+                            alwaysAskPhone = alwaysAskPhone.value,
+                            defaultPhonePresent = defaultPhoneId.value.isNotBlank(),
+                            connectInFlight = connectInFlight,
+                            sessionIdle = sessionManager.sessionState.value == SessionState.IDLE,
+                            currentWppOwnerPresent = sessionManager.hasCurrentWppOwner(),
+                        )) return@collect
                     val now = SystemClock.elapsedRealtime()
-                    if (now - lastAutoReconnectAttemptMs < AUTO_RECONNECT_MIN_GAP_MS) return@collect
+                    if (!WppWakeReconnectPolicy.cooldownAllows(
+                            wppSelected = wppSelected,
+                            elapsedSinceAttemptMs = now - lastAutoReconnectAttemptMs,
+                            minimumGapMs = AUTO_RECONNECT_MIN_GAP_MS,
+                        )) return@collect
                     lastAutoReconnectAttemptMs = now
-                    OalLog.i(TAG, "Ignition ON — kicking auto-reconnect")
-                    hasConnected = false
-                    connect()
+                    if (wppSelected) {
+                        connectForWppRearm(source = "ignition")
+                    } else {
+                        OalLog.i(TAG, "Ignition ON — kicking auto-reconnect")
+                        hasConnected = false
+                        connect()
+                    }
                 }
         }
         // Ignition OFF edge: tell the phone we're going away.
@@ -2418,7 +2513,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         // onCleared() runs on the main thread. Hand the native teardown to a
         // plain thread — viewModelScope is already cancelled by this point, so a
         // coroutine here would never run.
-        Thread({ sessionManager.stop() }, "oal-session-stop").start()
+        Thread({
+            kotlinx.coroutines.runBlocking { sessionManager.stop() }
+        }, "oal-session-stop").start()
         super.onCleared()
     }
 }

--- a/app/src/main/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicy.kt
@@ -1,0 +1,57 @@
+package com.openautolink.app.ui.projection
+
+/** Pure admission policy for rebuilding an idle projection session after wake. */
+internal object WppWakeReconnectPolicy {
+    fun cooldownAllows(
+        wppSelected: Boolean,
+        elapsedSinceAttemptMs: Long,
+        minimumGapMs: Long,
+    ): Boolean = wppSelected || elapsedSinceAttemptMs >= minimumGapMs
+
+    fun preStartRejection(
+        wppSelectedNow: Boolean,
+        ignitionOff: Boolean,
+        sessionIdle: Boolean,
+        currentWppOwnerPresent: Boolean = false,
+    ): String? = when {
+        !wppSelectedNow -> "transport-changed"
+        ignitionOff -> "ignition-off"
+        !sessionIdle -> "session-not-idle"
+        currentWppOwnerPresent -> "session-owner-active"
+        else -> null
+    }
+
+    fun shouldKickWake(
+        wppSelected: Boolean,
+        wirelessDiscoveryEnabled: Boolean,
+        alwaysAskPhone: Boolean,
+        defaultPhonePresent: Boolean,
+        resolvedPhonePresent: Boolean,
+        connectInFlight: Boolean,
+        sessionIdle: Boolean,
+        currentWppOwnerPresent: Boolean = false,
+    ): Boolean {
+        if (connectInFlight || !sessionIdle) return false
+        if (wppSelected) return !currentWppOwnerPresent
+        return wirelessDiscoveryEnabled &&
+            !alwaysAskPhone &&
+            defaultPhonePresent &&
+            resolvedPhonePresent
+    }
+
+    fun shouldKickIgnition(
+        wppSelected: Boolean,
+        wirelessDiscoveryEnabled: Boolean,
+        alwaysAskPhone: Boolean,
+        defaultPhonePresent: Boolean,
+        connectInFlight: Boolean,
+        sessionIdle: Boolean,
+        currentWppOwnerPresent: Boolean = false,
+    ): Boolean {
+        if (connectInFlight || !sessionIdle) return false
+        if (wppSelected) return !currentWppOwnerPresent
+        return wirelessDiscoveryEnabled &&
+            !alwaysAskPhone &&
+            defaultPhonePresent
+    }
+}

--- a/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/session/VehicleEnergyReconnectContractTest.kt
@@ -53,7 +53,7 @@ class VehicleEnergyReconnectContractTest {
             hook.contains("ensureVehicleDataForwarder()?.start()"),
         )
 
-        val reconnect = source.substringAfter("private fun doReconnectAfterCancel(")
+        val reconnect = source.substringAfter("private suspend fun doReconnectAfterCancel(")
             .substringBefore("fun onSystemWake()")
         assertTrue("Reconnect must pause VHAL while replacing the protocol session",
             reconnect.contains("_vehicleDataForwarder?.stop()"))

--- a/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
@@ -1,0 +1,349 @@
+package com.openautolink.app.ui.projection
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppWakeReconnectPolicyTest {
+
+    @Test
+    fun `idle WPP wake starts without default phone or discovery`() {
+        assertTrue(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = true,
+                defaultPhonePresent = false,
+                resolvedPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `WPP wake does not overlap a connect or live session`() {
+        assertFalse(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = false,
+                defaultPhonePresent = false,
+                resolvedPhonePresent = false,
+                connectInFlight = true,
+                sessionIdle = true,
+            ),
+        )
+        assertFalse(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = false,
+                defaultPhonePresent = false,
+                resolvedPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `active WPP owner suppresses delayed wake and ignition edges`() {
+        assertFalse(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = false,
+                defaultPhonePresent = false,
+                resolvedPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = true,
+                currentWppOwnerPresent = true,
+            ),
+        )
+        assertFalse(
+            WppWakeReconnectPolicy.shouldKickIgnition(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = false,
+                defaultPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = true,
+                currentWppOwnerPresent = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `legacy hotspot wake still requires configured resolved default`() {
+        assertFalse(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = false,
+                wirelessDiscoveryEnabled = true,
+                alwaysAskPhone = false,
+                defaultPhonePresent = true,
+                resolvedPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = true,
+            ),
+        )
+        assertTrue(
+            WppWakeReconnectPolicy.shouldKickWake(
+                wppSelected = false,
+                wirelessDiscoveryEnabled = true,
+                alwaysAskPhone = false,
+                defaultPhonePresent = true,
+                resolvedPhonePresent = true,
+                connectInFlight = false,
+                sessionIdle = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `idle WPP ignition starts without legacy phone selection state`() {
+        assertTrue(
+            WppWakeReconnectPolicy.shouldKickIgnition(
+                wppSelected = true,
+                wirelessDiscoveryEnabled = false,
+                alwaysAskPhone = true,
+                defaultPhonePresent = false,
+                connectInFlight = false,
+                sessionIdle = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `WPP owner rearm bypasses legacy discovery cooldown`() {
+        assertTrue(
+            WppWakeReconnectPolicy.cooldownAllows(
+                wppSelected = true,
+                elapsedSinceAttemptMs = 0L,
+                minimumGapMs = 10_000L,
+            ),
+        )
+        assertFalse(
+            WppWakeReconnectPolicy.cooldownAllows(
+                wppSelected = false,
+                elapsedSinceAttemptMs = 0L,
+                minimumGapMs = 10_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `stale WPP rearm is rejected immediately before session start`() {
+        assertTrue(
+            WppWakeReconnectPolicy.preStartRejection(
+                wppSelectedNow = false,
+                ignitionOff = false,
+                sessionIdle = true,
+            ) == "transport-changed",
+        )
+        assertTrue(
+            WppWakeReconnectPolicy.preStartRejection(
+                wppSelectedNow = true,
+                ignitionOff = true,
+                sessionIdle = true,
+            ) == "ignition-off",
+        )
+        assertTrue(
+            WppWakeReconnectPolicy.preStartRejection(
+                wppSelectedNow = true,
+                ignitionOff = false,
+                sessionIdle = false,
+            ) == "session-not-idle",
+        )
+        assertTrue(
+            WppWakeReconnectPolicy.preStartRejection(
+                wppSelectedNow = true,
+                ignitionOff = false,
+                sessionIdle = true,
+                currentWppOwnerPresent = true,
+            ) == "session-owner-active",
+        )
+        assertTrue(
+            WppWakeReconnectPolicy.preStartRejection(
+                wppSelectedNow = true,
+                ignitionOff = false,
+                sessionIdle = true,
+                currentWppOwnerPresent = false,
+            ) == null,
+        )
+    }
+
+    @Test
+    fun `release builds never register exported debug controls`() {
+        val manager = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+        val btControl = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+        val mainManifest = projectFile("app/src/main/AndroidManifest.xml").readText()
+        val debugManifest = projectFile("app/src/debug/AndroidManifest.xml").readText()
+
+        assertTrue(manager.contains("android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE"))
+        assertTrue(btControl.contains("private fun isDebuggableBuild(context: Context): Boolean"))
+        assertTrue(btControl.contains("if (isDebuggableBuild(context))"))
+        val debugGate = btControl.indexOf("if (isDebuggableBuild(context))")
+        val exportedRegistration = btControl.indexOf(
+            "androidx.core.content.ContextCompat.RECEIVER_EXPORTED",
+        )
+        assertTrue(debugGate >= 0)
+        assertTrue(exportedRegistration > debugGate)
+        val settingsReceiver = "android:name=\".diagnostics.SettingsReceiver\""
+        assertTrue(mainManifest.contains(settingsReceiver))
+        assertTrue(mainManifest.substringAfter(settingsReceiver).substringBefore("</receiver>")
+            .contains("android:exported=\"false\""))
+        assertTrue(debugManifest.contains(settingsReceiver))
+        assertTrue(debugManifest.substringAfter(settingsReceiver).substringBefore("/>")
+            .contains("android:exported=\"true\""))
+    }
+
+    @Test
+    fun `wake and ignition collectors read persisted transport and log WPP owner rearm`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
+        ).readText()
+        val manager = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+
+        assertTrue(source.contains("WppWakeReconnectPolicy.shouldKickWake("))
+        assertTrue(source.contains("WppWakeReconnectPolicy.shouldKickIgnition("))
+        assertTrue(source.windowed("preferences.directTransport.first()".length)
+            .count { it == "preferences.directTransport.first()" } >= 4)
+        assertTrue(source.contains("connectForWppRearm(source = \"wake\")"))
+        assertTrue(source.contains("connectForWppRearm(source = \"ignition\")"))
+        assertTrue(source.contains("wppRearmSource = wppRearmSource"))
+        assertTrue(source.contains("wppRearmFinalAdmission ="))
+        assertTrue(source.windowed("currentWppOwnerPresent = sessionManager.hasCurrentWppOwner()".length)
+            .count { it == "currentWppOwnerPresent = sessionManager.hasCurrentWppOwner()" } >= 4)
+        assertTrue(manager.contains("fun hasCurrentWppOwner(): Boolean = AaWirelessBtControl.hasCurrentWppOwner()"))
+        assertFalse(source.contains("AaWirelessBtControl.hasCurrentWppOwner()"))
+
+        val observeBlock = manager
+            .substringAfter("val newObserveJob = scope.launch")
+            .substringBefore("newObserveJob.invokeOnCompletion")
+        val finalAdmission = observeBlock.indexOf("wppRearmFinalAdmission?.invoke()")
+        val sessionStart = observeBlock.indexOf("startSession(", startIndex = finalAdmission)
+        val finalRejectionBranch = observeBlock.indexOf("if (finalWppRejection != null)")
+        val rollback = observeBlock.indexOf(
+            "stopWhileLifecycleLocked(cancelObserveJob = false)",
+            startIndex = finalRejectionBranch,
+        )
+        val rejectedComplete = observeBlock.indexOf(
+            "startupOutcome.complete(Unit)",
+            startIndex = finalRejectionBranch,
+        )
+        assertTrue(finalRejectionBranch >= 0)
+        assertTrue(rollback > finalRejectionBranch)
+        assertTrue(rejectedComplete > rollback)
+        val exceptionBranch = observeBlock.lastIndexOf("catch (e: Exception)")
+        val exceptionComplete = observeBlock.indexOf(
+            "startupOutcome.completeExceptionally(e)",
+            startIndex = exceptionBranch,
+        )
+        assertTrue(exceptionBranch >= 0)
+        assertTrue(exceptionComplete > exceptionBranch)
+        assertFalse(
+            observeBlock.substring(exceptionBranch, exceptionComplete)
+                .contains("stopWhileLifecycleLocked(cancelObserveJob = false)"),
+        )
+        val registerScreen = observeBlock.indexOf("registerScreenReceiver()")
+        val registerDebug = observeBlock.indexOf("registerDebugReceiver()")
+        assertTrue(registerScreen >= 0 && registerScreen < finalAdmission)
+        assertTrue(registerDebug > registerScreen && registerDebug < finalAdmission)
+        assertTrue(observeBlock.contains("if (isDebuggableBuild()) registerDebugReceiver()"))
+        assertTrue(manager.contains("if (!isDebuggableBuild()) return"))
+        assertTrue(manager.contains("android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE"))
+        assertTrue(finalAdmission >= 0)
+        assertTrue(sessionStart > finalAdmission)
+        assertTrue(observeBlock.contains("WPP rearm rejected: source="))
+        assertTrue(observeBlock.contains("reason=${'$'}finalWppRejection"))
+
+        assertTrue(manager.contains("private val startMutex = kotlinx.coroutines.sync.Mutex()"))
+        assertTrue(manager.contains("private suspend fun rollbackLifecycleFailure("))
+        val lifecycleStartBlock = manager
+            .substringAfter("suspend fun start(")
+            .substringBefore("private fun startSession(")
+        assertTrue(lifecycleStartBlock.contains("rollbackLifecycleFailure(\"start\", e)"))
+        assertTrue(lifecycleStartBlock.indexOf("try {") < lifecycleStartBlock.indexOf("observeJob?.cancelAndJoin()"))
+        assertTrue(manager.contains("observeJob?.cancelAndJoin()"))
+        assertTrue(manager.contains("val startupOutcome = kotlinx.coroutines.CompletableDeferred<Unit>()"))
+        assertTrue(manager.contains("val newObserveJob = scope.launch"))
+        assertTrue(manager.contains("observeJob = newObserveJob"))
+        assertTrue(manager.contains("newObserveJob.invokeOnCompletion"))
+        assertFalse(manager.contains("observeJob?.invokeOnCompletion"))
+        assertTrue(manager.contains("suspend fun stop()"))
+        assertTrue(manager.contains("private suspend fun stopWhileLifecycleLocked("))
+        assertTrue(manager.windowed("startMutex.lock()".length)
+            .count { it == "startMutex.lock()" } >= 2)
+        assertTrue(manager.windowed("startMutex.unlock()".length)
+            .count { it == "startMutex.unlock()" } >= 2)
+        assertTrue(manager.contains("stopWhileLifecycleLocked()"))
+        assertTrue(manager.contains("@Volatile private var lifecycleGeneration = 0L"))
+        assertTrue(manager.contains("val requestGeneration = lifecycleGeneration"))
+        assertTrue(manager.contains("requestGeneration != lifecycleGeneration"))
+        assertTrue(manager.contains("lifecycleGeneration += 1L"))
+        val reconnectBlock = manager
+            .substringAfter("suspend fun reconnect(")
+            .substringBefore("private suspend fun doReconnectAfterCancel(")
+        assertTrue(reconnectBlock.contains("var lifecycleLockAcquired = false"))
+        assertTrue(reconnectBlock.contains("lifecycleLockAcquired = true"))
+        assertTrue(reconnectBlock.contains("if (lifecycleLockAcquired) startMutex.unlock()"))
+        assertTrue(reconnectBlock.contains("startMutex.lock()"))
+        assertTrue(reconnectBlock.contains("kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO)"))
+        assertTrue(reconnectBlock.contains("rollbackLifecycleFailure(\"reconnect\", e)"))
+        assertFalse(reconnectBlock.contains("scope.launch(kotlinx.coroutines.Dispatchers.IO)"))
+        val reconnectWorker = manager
+            .substringAfter("private suspend fun doReconnectAfterCancel(")
+            .substringBefore("    /**")
+        val reconnectSessionStart = reconnectWorker.indexOf("startSession(")
+        val reconnectWatchers = reconnectWorker.indexOf("observeJob = scope.launch")
+        assertTrue(reconnectSessionStart >= 0)
+        assertTrue(reconnectWatchers > reconnectSessionStart)
+        assertTrue(manager.windowed("kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable)".length)
+            .count { it == "kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable)" } >= 3)
+        val stopBlock = manager
+            .substringAfter("suspend fun stop()")
+            .substringBefore("private suspend fun stopWhileLifecycleLocked(")
+        assertTrue(stopBlock.contains("kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable)"))
+        assertTrue(reconnectBlock.contains("kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable)"))
+        assertTrue(manager.contains("decoderWatchJob?.cancelAndJoin()"))
+        assertTrue(manager.contains("keyframeWatchJob?.cancelAndJoin()"))
+        assertTrue(manager.contains("videoStallWatchJob?.cancelAndJoin()"))
+        assertTrue(manager.contains("callStateJob?.cancelAndJoin()"))
+        assertTrue(manager.windowed("observeJob?.cancelAndJoin()".length)
+            .count { it == "observeJob?.cancelAndJoin()" } >= 2)
+        assertTrue(manager.contains("startupOutcome.await()"))
+
+        val startBlock = manager
+            .substringAfter("private fun startSession(")
+            .substringBefore("private fun prepareNativeSessionStart")
+        val ownerInstall = startBlock.indexOf("val ownerToken = installWirelessSessionAdmission(directTransport)")
+        val ownerQuery = startBlock.indexOf("AaWirelessBtControl.isCurrentSessionOwner(ownerToken)", startIndex = ownerInstall)
+        val outcomeLog = startBlock.indexOf("WPP rearm outcome: source=", startIndex = ownerQuery)
+        assertTrue(ownerInstall >= 0)
+        assertTrue(ownerQuery > ownerInstall)
+        assertTrue(outcomeLog > ownerQuery)
+        assertFalse(startBlock.contains("hasCurrentWppOwner()"))
+        val control = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        ).readText()
+        assertTrue(control.contains("fun isCurrentSessionOwner(token: WppSessionAdmission.Token)"))
+        assertTrue(source.contains("WPP rearm rejected: source=${'$'}wppRearmSource reason=${'$'}rejection"))
+        assertFalse(source.contains("WPP wake — binding session owner immediately"))
+        assertFalse(source.contains("WPP ignition — binding session owner immediately"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .first { it.isFile }
+    }
+}


### PR DESCRIPTION
## Summary
- Reinstall the WPP session owner immediately on retained-process Activity wake or ignition ON while projection is idle.
- Do not wait for a default phone or IP discovery before binding the WPP listener and publishing SDP.
- Keep legacy hotspot discovery/default-phone requirements unchanged.
- Bypass the legacy discovery cooldown for authoritative WPP wake/ignition triggers while preserving existing connect-in-flight, live-session, and active-owner guards.
- Reject a delayed second wake/ignition edge at trigger selection, early pre-start, and serialized final admission if an exact WPP owner is already waiting for phone dial-back.
- Revalidate persisted transport, ignition, session state, and owner state at the final start boundary; every admitted trigger ends with an explicit rejection, exception outcome, or synchronized owner-installed outcome.
- Serialize and fully roll back initial setup and replacement reconnect failures before releasing the lifecycle mutex, preventing partially replaced decoder/audio/sensor/session state.

## Root cause
Car 0.1.464 at 19:24:33 repeatedly logged `Advertiser deferred — no current WPP session owner`. Activity resumed and the surface was ready, but no WPP owner, listener, SDP advertisement, phone dial-back, or native session followed.

The retained ViewModel's WPP transport-selection flow uses `distinctUntilChanged`, so it does not re-emit merely because the car wakes. The wake and ignition recovery collectors then incorrectly required the legacy default-phone/discovery state. WPP is circular under that gate: a phone cannot dial the AA Wireless UUID until the car first creates the session owner and publishes SDP.

Natural A/B in the same process: the prior wake also began owner-less, but eventually created the owner only after phone discovery surfaced 78.446 seconds after Activity resume; projection then connected in seconds.

## Verification
- Strict RED→GREEN tests for idle WPP wake, ignition, no-default/no-discovery, live/in-flight rejection, delayed-edge active-owner rejection, legacy hotspot preservation, and WPP cooldown bypass.
- `:app:testDebugUnitTest`: 416 tests, 0 failures/errors/skips.
- Exported adb-only WPP controls are gated by `ApplicationInfo.FLAG_DEBUGGABLE`; release builds retain automatic WPP startup but never register those debug receivers.
- The manifest `SettingsReceiver` is non-exported in release and exported only through the debug-variant manifest override.
- `:app:assembleDebug`: successful with arm64-v8a and x86_64 native packaging.
- Final APK DEX contains the admitted/rejected WPP rearm paths and `WPP rearm outcome: source=... ownerInstalled=...`.

## Runtime acceptance
After an ignition cycle with a retained process, require this positive sequence in the next car log:
1. `WPP TCP server listening`
2. `Session admission installed:`
3. `WPP rearm outcome: source=ignition ownerInstalled=true` or `source=wake ownerInstalled=true`
4. `Listening on Android Auto Wireless UUID`
5. Phone dial-back, native session start, and sustained `vflow`

This is a code/build-verified attempt pending vehicle runtime proof.
