### PR TITLE
fix(wireless): keep rearm admission in session owner

### DIFF
--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -21,6 +21,7 @@ import com.openautolink.app.diagnostics.RemoteDiagnosticsImpl
 import com.openautolink.app.diagnostics.TelemetryCollector
 import com.openautolink.app.input.GnssForwarder
 import com.openautolink.app.input.GnssForwarderImpl
+import com.openautolink.app.input.IgnitionMonitor
 import com.openautolink.app.input.ImuForwarder
 import com.openautolink.app.input.VehicleDataForwarder
 import com.openautolink.app.input.VehicleDataForwarderImpl
@@ -683,6 +684,37 @@ class SessionManager(
     /** True while an exact WPP session token owns the process-scoped advertiser. */
     fun hasCurrentWppOwner(): Boolean = AaWirelessBtControl.hasCurrentWppOwner()
 
+    /**
+     * Re-check wake admission inside the lifecycle owner instead of transporting
+     * a suspend callback across coroutine/default-argument state machines. The
+     * 0.1.465 carried source=ignition into this owner while the compiled
+     * callback argument was null, so no WPP owner was created.
+     */
+    private suspend fun currentWppRearmRejection(
+        wppRearmSource: String?,
+        stage: String,
+    ): String? {
+        if (wppRearmSource == null) return null
+        val ctx = context
+        val rejection = if (ctx == null) {
+            "context-missing"
+        } else {
+            val currentTransport = AppPreferences.getInstance(ctx).directTransport.first()
+            when {
+                currentTransport != AppPreferences.DIRECT_TRANSPORT_WPP -> "transport-changed"
+                IgnitionMonitor.isOffOrLocked() -> "ignition-off"
+                sessionState.value != SessionState.IDLE -> "session-not-idle"
+                AaWirelessBtControl.hasCurrentWppOwner() -> "session-owner-active"
+                else -> null
+            }
+        }
+        OalLog.i(
+            TAG,
+            "WPP rearm admission checked locally: source=$wppRearmSource stage=$stage result=${rejection ?: "accepted"}",
+        )
+        return rejection
+    }
+
     /** Clear the default phone — next connection will pick any phone. */
     fun clearDefaultPhone() {
         _defaultPhoneName = ""
@@ -1035,7 +1067,6 @@ class SessionManager(
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
         wppRearmSource: String? = null,
-        wppRearmFinalAdmission: (suspend () -> String?)? = null,
     ) {
         val requestGeneration = lifecycleGeneration
         startMutex.lock()
@@ -1045,9 +1076,7 @@ class SessionManager(
             OalLog.i(TAG, "Start request rejected — lifecycle stop completed while waiting")
             return@withContext
         }
-        val initialWppRejection = if (wppRearmSource != null) {
-            wppRearmFinalAdmission?.invoke() ?: "admission-check-missing"
-        } else null
+        val initialWppRejection = currentWppRearmRejection(wppRearmSource, stage = "initial")
         if (initialWppRejection != null) {
             OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource " +
                 "reason=$initialWppRejection")
@@ -1268,9 +1297,7 @@ class SessionManager(
                 // owns both registration and unregistration.
                 registerScreenReceiver()
                 if (isDebuggableBuild()) registerDebugReceiver()
-                val finalWppRejection = if (wppRearmSource != null) {
-                wppRearmFinalAdmission?.invoke() ?: "admission-check-missing"
-            } else null
+                val finalWppRejection = currentWppRearmRejection(wppRearmSource, stage = "final")
             if (finalWppRejection != null) {
                 OalLog.i(TAG, "WPP rearm rejected: source=$wppRearmSource " +
                     "reason=$finalWppRejection")

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -830,27 +830,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                         "manual DPI; scaling may be wrong until reconnect")
             }
 
-            // SessionManager invokes this once before destructive setup and again
-            // inside its serialized start coroutine immediately before creating
-            // the protocol owner. Keeping the check attached to the attempt closes
-            // the caller/callee suspension window without making SessionManager
-            // depend on UI-layer policy.
-            val wppRearmFinalAdmission: (suspend () -> String?)? =
-                wppRearmSource?.let {
-                    {
-                        val currentTransport = preferences.directTransport.first()
-                        WppWakeReconnectPolicy.preStartRejection(
-                            wppSelectedNow = currentTransport ==
-                                AppPreferences.DIRECT_TRANSPORT_WPP,
-                            ignitionOff = com.openautolink.app.input.IgnitionMonitor
-                                .isOffOrLocked(),
-                            sessionIdle = sessionManager.sessionState.value ==
-                                SessionState.IDLE,
-                            currentWppOwnerPresent = sessionManager.hasCurrentWppOwner(),
-                        )
-                    }
-                }
-
             sessionManager.start(
                 codecPreference = codec,
                 micSourcePreference = micSrc,
@@ -885,7 +864,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 gpsForwarding = gpsForwarding,
                 galVersion = galVersion,
                 wppRearmSource = wppRearmSource,
-                wppRearmFinalAdmission = wppRearmFinalAdmission,
             )
     }
 

--- a/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
@@ -219,16 +219,26 @@ class WppWakeReconnectPolicyTest {
         assertTrue(source.contains("connectForWppRearm(source = \"wake\")"))
         assertTrue(source.contains("connectForWppRearm(source = \"ignition\")"))
         assertTrue(source.contains("wppRearmSource = wppRearmSource"))
-        assertTrue(source.contains("wppRearmFinalAdmission ="))
+        assertFalse(source.contains("wppRearmFinalAdmission"))
+        assertFalse(manager.contains("wppRearmFinalAdmission"))
+        assertFalse(manager.contains("admission-check-missing"))
+        assertTrue(manager.contains("private suspend fun currentWppRearmRejection("))
+        assertTrue(manager.contains("currentWppRearmRejection(wppRearmSource, stage = \"initial\")"))
+        assertTrue(manager.contains("currentWppRearmRejection(wppRearmSource, stage = \"final\")"))
+        assertTrue(manager.contains("WPP rearm admission checked locally: source=${'$'}wppRearmSource stage=${'$'}stage result=${'$'}{rejection ?: \"accepted\"}"))
+        assertTrue(manager.contains("AppPreferences.getInstance(ctx).directTransport.first()"))
+        assertTrue(manager.contains("IgnitionMonitor.isOffOrLocked()"))
         assertTrue(source.windowed("currentWppOwnerPresent = sessionManager.hasCurrentWppOwner()".length)
-            .count { it == "currentWppOwnerPresent = sessionManager.hasCurrentWppOwner()" } >= 4)
+            .count { it == "currentWppOwnerPresent = sessionManager.hasCurrentWppOwner()" } >= 2)
         assertTrue(manager.contains("fun hasCurrentWppOwner(): Boolean = AaWirelessBtControl.hasCurrentWppOwner()"))
         assertFalse(source.contains("AaWirelessBtControl.hasCurrentWppOwner()"))
 
         val observeBlock = manager
             .substringAfter("val newObserveJob = scope.launch")
             .substringBefore("newObserveJob.invokeOnCompletion")
-        val finalAdmission = observeBlock.indexOf("wppRearmFinalAdmission?.invoke()")
+        val finalAdmission = observeBlock.indexOf(
+            "currentWppRearmRejection(wppRearmSource, stage = \"final\")",
+        )
         val sessionStart = observeBlock.indexOf("startSession(", startIndex = finalAdmission)
         val finalRejectionBranch = observeBlock.indexOf("if (finalWppRejection != null)")
         val rollback = observeBlock.indexOf(


### PR DESCRIPTION
## Summary
- Move WPP wake admission checks into `SessionManager`, the lifecycle owner that consumes them.
- Remove the suspend-function callback passed from `ProjectionViewModel`; the 0.1.465 release carried `source=ignition` but received that callback as null at runtime and rejected itself with `admission-check-missing`.
- Re-check live transport, ignition, session, and exact-owner state at both initial and final serialized admission boundaries.
- Add explicit initial/final local-admission outcome markers.

## Field evidence
On car 0.1.465 after an 18-minute store stop:
- 10:23:42.414: ignition returned with no current WPP owner.
- 10:23:42.469: the ignition rearm entered the connection pipeline.
- 10:23:42.537: `WPP rearm rejected: source=ignition reason=admission-check-missing`.
- No owner, listener, SDP advertisement, phone dial-back, or AA session followed.
- The companion was already listening and repeatedly answered identity probes.
- Save & Reconnect later installed owner generation 2 at 10:25:36.205; phone dial-back followed at 10:25:37.549 and native AA started at 10:25:42.707.

Paired car/phone events show car-minus-phone clock offset 31.424s and 31.434s (median 31.429s, spread 10ms).

## Verification
- Regression test failed before production changes because callback transport and `admission-check-missing` still existed.
- Focused test passed after the change.
- Full `:app:testDebugUnitTest`: 416 tests, 0 failures/errors/skips.
- `:app:assembleDebug`: successful; arm64-v8a and x86_64 packaged.
- Final APK includes `WPP rearm admission checked locally`, `stage=initial`, `stage=final`, and `session-owner-active`.
- Final APK does not include `admission-check-missing`.

## Runtime acceptance
The next retained-process ignition wake must show:
1. `WPP rearm admission checked locally: source=ignition stage=initial result=accepted`
2. the same marker with `stage=final result=accepted`
3. `Session admission installed:` and WPP listener/SDP publication
4. phone dial-back, native session start, and sustained `vflow`

This is a code/build-verified attempt pending vehicle runtime proof.
