### PR TITLE
fix(companion): restore transport after process death

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/diagnostics/ProcessExitSummary.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/ProcessExitSummary.kt
@@ -1,0 +1,48 @@
+package com.openautolink.companion.diagnostics
+
+/** Formats ApplicationExitInfo fields without depending on Android framework classes. */
+internal object ProcessExitSummary {
+    const val MAX_DESCRIPTION_CHARS = 160
+
+    fun format(
+        reason: Int,
+        status: Int,
+        importance: Int,
+        pssKb: Long,
+        rssKb: Long,
+        timestampMs: Long,
+        nowMs: Long,
+        description: String?,
+    ): String {
+        val ageMs = (nowMs - timestampMs).coerceAtLeast(0L)
+        val safeDescription = description
+            ?.replace(Regex("\\s+"), " ")
+            ?.trim()
+            ?.take(MAX_DESCRIPTION_CHARS)
+            ?.ifBlank { null }
+            ?: "none"
+        return "reason=${reasonName(reason)}($reason) status=$status importance=$importance " +
+            "ageMs=$ageMs pssKb=$pssKb rssKb=$rssKb description=$safeDescription"
+    }
+
+    private fun reasonName(reason: Int): String = when (reason) {
+        0 -> "UNKNOWN"
+        1 -> "EXIT_SELF"
+        2 -> "SIGNALED"
+        3 -> "LOW_MEMORY"
+        4 -> "CRASH"
+        5 -> "CRASH_NATIVE"
+        6 -> "ANR"
+        7 -> "INITIALIZATION_FAILURE"
+        8 -> "PERMISSION_CHANGE"
+        9 -> "EXCESSIVE_RESOURCE_USAGE"
+        10 -> "USER_REQUESTED"
+        11 -> "USER_STOPPED"
+        12 -> "DEPENDENCY_DIED"
+        13 -> "OTHER"
+        14 -> "FREEZER"
+        15 -> "PACKAGE_STATE_CHANGE"
+        16 -> "PACKAGE_UPDATED"
+        else -> "UNKNOWN_$reason"
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionRestartPolicy.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionRestartPolicy.kt
@@ -1,0 +1,9 @@
+package com.openautolink.companion.service
+
+/** Distinguishes Android's null-intent START_STICKY redelivery from explicit commands. */
+internal object CompanionRestartPolicy {
+    fun shouldRestoreTransport(
+        intentWasNull: Boolean,
+        transportDesired: Boolean,
+    ): Boolean = intentWasNull && transportDesired
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -1,5 +1,6 @@
 package com.openautolink.companion.service
 
+import android.app.ActivityManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -17,6 +18,7 @@ import com.openautolink.companion.diagnostics.CompanionFileLogger
 import com.openautolink.companion.diagnostics.CompanionLog
 import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.diagnostics.PhoneWppStage
+import com.openautolink.companion.diagnostics.ProcessExitSummary
 import com.openautolink.companion.diagnostics.WppAssociationOwner
 import com.openautolink.companion.diagnostics.WppIntegrationTrigger
 import com.openautolink.companion.diagnostics.WppNetworkObserver
@@ -74,6 +76,9 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         // a cold reboot resumes it once one of those triggers first starts the
         // service (there is no standalone BOOT_COMPLETED launcher).
         maybeStartPersistentLogging()
+        // Do this after persistent logging starts: CompanionFileLogger clears the
+        // logcat ring when it begins, so logging first would erase the evidence.
+        logPreviousProcessExit()
     }
 
     /** Start file logging if the persisted "always log" pref is enabled. */
@@ -90,6 +95,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         when (intent?.action) {
             ACTION_STOP -> {
                 CompanionLog.i(TAG, "Stop requested")
+                setTransportDesired(false)
                 _isRunning.value = false
                 _isConnected.value = false
                 _statusText.value = "Stopped"
@@ -98,6 +104,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
             ACTION_START -> {
                 joinWppAttempt(WppIntegrationTrigger.START, intent)
+                setTransportDesired(true)
                 // If already connected (AA bridge active), ignore duplicate starts
                 // (e.g. BT auto-start firing a few hundred ms after the car already
                 // TCP-connected and we fired the AA trigger). Restarting here would
@@ -121,6 +128,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
             ACTION_PREWARM -> {
                 joinWppAttempt(WppIntegrationTrigger.PREWARM, intent)
+                setTransportDesired(true)
                 // Pre-warm path: car-presence signal (BT, scripted, etc.) tells
                 // us a car connection is imminent. Start the AA pipeline now so
                 // by the time the car's TCP arrives ~3–10s later, AA is warm
@@ -145,10 +153,17 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             }
 
             else -> {
-                // System restart
-                if (_isRunning.value) {
-                    CompanionLog.i(TAG, "Service restarted by system, resuming")
+                if (CompanionRestartPolicy.shouldRestoreTransport(intent == null, transportDesired())) {
+                    // START_STICKY recreates the process with a null intent. All
+                    // in-memory state is new, so _isRunning cannot tell us whether
+                    // the killed instance owned a listener. Rebuild it explicitly.
+                    CompanionLog.i(TAG, "System sticky restart — restoring TCP transport")
+                    _isRunning.value = true
+                    _isConnected.value = false
+                    _statusText.value = "Advertising..."
                     startTcp()
+                } else {
+                    CompanionLog.w(TAG, "Ignoring unknown service action: ${intent?.action}")
                 }
                 // Resume always-log mode after an OS-initiated restart, even if
                 // the service wasn't "running" before the kill — onCreate also
@@ -158,6 +173,49 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         }
         return START_STICKY
     }
+
+    private fun logPreviousProcessExit() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            CompanionLog.i(TAG, "Previous companion process exit unavailable: API ${Build.VERSION.SDK_INT}")
+            return
+        }
+        try {
+            val activityManager = getSystemService(ActivityManager::class.java)
+            val previous = activityManager.getHistoricalProcessExitReasons(packageName, 0, 1)
+                .firstOrNull()
+            if (previous == null) {
+                CompanionLog.i(TAG, "Previous companion process exit: none recorded")
+                return
+            }
+            val summary = ProcessExitSummary.format(
+                reason = previous.reason,
+                status = previous.status,
+                importance = previous.importance,
+                pssKb = previous.pss,
+                rssKb = previous.rss,
+                timestampMs = previous.timestamp,
+                nowMs = System.currentTimeMillis(),
+                description = previous.description,
+            )
+            CompanionLog.w(TAG, "Previous companion process exit: $summary")
+        } catch (e: Exception) {
+            CompanionLog.w(
+                TAG,
+                "Previous companion process exit unavailable: ${e.javaClass.simpleName}",
+            )
+        }
+    }
+
+    private fun setTransportDesired(desired: Boolean) {
+        getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+            .edit()
+            .putBoolean(PREF_TRANSPORT_DESIRED, desired)
+            .apply()
+    }
+
+    private fun transportDesired(): Boolean =
+        getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+            .getBoolean(PREF_TRANSPORT_DESIRED, false)
 
     private fun startTcp() {
         PhoneWppDiagnostics.record(PhoneWppStage.TCP_START_INTENT)
@@ -460,6 +518,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         private const val TAG = "OAL_Service"
         private const val CHANNEL_ID = "oal_companion_channel"
         private const val NOTIFICATION_ID = 1
+        private const val PREF_TRANSPORT_DESIRED = "transport_desired"
         /** Idle timeout for file logging when no AA connection is ever made. */
         private const val LOG_IDLE_TIMEOUT_MS = 10L * 60L * 1000L
 

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/ProcessExitSummaryTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/ProcessExitSummaryTest.kt
@@ -1,0 +1,94 @@
+package com.openautolink.companion.diagnostics
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProcessExitSummaryTest {
+
+    @Test
+    fun `formats native crash with bounded single-line description`() {
+        val summary = ProcessExitSummary.format(
+            reason = 5,
+            status = 6,
+            importance = 100,
+            pssKb = 42_000L,
+            rssKb = 84_000L,
+            timestampMs = 10_000L,
+            nowMs = 11_250L,
+            description = "native crash\ninside bridge",
+        )
+
+        assertEquals(
+            "reason=CRASH_NATIVE(5) status=6 importance=100 ageMs=1250 " +
+                "pssKb=42000 rssKb=84000 description=native crash inside bridge",
+            summary,
+        )
+    }
+
+    @Test
+    fun `unknown reason and future timestamp remain truthful`() {
+        val summary = ProcessExitSummary.format(
+            reason = 99,
+            status = 0,
+            importance = 400,
+            pssKb = 0L,
+            rssKb = 0L,
+            timestampMs = 20_000L,
+            nowMs = 10_000L,
+            description = null,
+        )
+
+        assertEquals(
+            "reason=UNKNOWN_99(99) status=0 importance=400 ageMs=0 " +
+                "pssKb=0 rssKb=0 description=none",
+            summary,
+        )
+    }
+
+    @Test
+    fun `description is capped to keep uploaded log records bounded`() {
+        val summary = ProcessExitSummary.format(
+            reason = 6,
+            status = 0,
+            importance = 100,
+            pssKb = 1L,
+            rssKb = 2L,
+            timestampMs = 0L,
+            nowMs = 1L,
+            description = "x".repeat(500),
+        )
+
+        val description = summary.substringAfter("description=")
+        assertEquals(ProcessExitSummary.MAX_DESCRIPTION_CHARS, description.length)
+        assertTrue(summary.contains("reason=ANR(6)"))
+    }
+
+    @Test
+    fun `service logs previous exit after file logger starts`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        val onCreate = source.substringAfter("override fun onCreate()")
+            .substringBefore("private fun maybeStartPersistentLogging()")
+
+        val persistentLogging = onCreate.indexOf("maybeStartPersistentLogging()")
+        val exitLogging = onCreate.indexOf("logPreviousProcessExit()")
+
+        assertTrue(persistentLogging >= 0)
+        assertTrue(exitLogging > persistentLogging)
+        assertTrue(source.contains("if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R)"))
+        assertTrue(source.contains("getHistoricalProcessExitReasons(packageName, 0, 1)"))
+        assertTrue(source.contains("Previous companion process exit:"))
+        assertTrue(source.contains("Previous companion process exit unavailable:"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+}

--- a/companion/src/test/java/com/openautolink/companion/service/CompanionRestartPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/service/CompanionRestartPolicyTest.kt
@@ -1,0 +1,91 @@
+package com.openautolink.companion.service
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionRestartPolicyTest {
+
+    @Test
+    fun `null sticky redelivery restores transport when prior owner desired it`() {
+        assertTrue(
+            CompanionRestartPolicy.shouldRestoreTransport(
+                intentWasNull = true,
+                transportDesired = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `upload-only sticky service does not manufacture transport ownership`() {
+        assertFalse(
+            CompanionRestartPolicy.shouldRestoreTransport(
+                intentWasNull = true,
+                transportDesired = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `explicit intent without an action does not masquerade as sticky redelivery`() {
+        assertFalse(
+            CompanionRestartPolicy.shouldRestoreTransport(
+                intentWasNull = false,
+                transportDesired = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `service applies sticky restart policy before resuming persistent logging`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        val fallbackBranch = source.substringAfter("else -> {")
+            .substringBefore("return START_STICKY")
+
+        val policyCall =
+            "CompanionRestartPolicy.shouldRestoreTransport(intent == null, transportDesired())"
+        val policyCheck = fallbackBranch.indexOf(policyCall)
+        val stickyBranch = fallbackBranch.substringAfter("if ($policyCall) {")
+            .substringBefore("} else {")
+        val unknownActionBranch = fallbackBranch.substringAfter("} else {")
+
+        val runningRestore = stickyBranch.indexOf("_isRunning.value = true")
+        val transportRestore = stickyBranch.indexOf("startTcp()")
+        val persistentLogging = fallbackBranch.indexOf("maybeStartPersistentLogging()")
+
+        assertTrue(policyCheck >= 0)
+        assertTrue(runningRestore >= 0)
+        assertTrue(transportRestore > runningRestore)
+        assertTrue(persistentLogging > fallbackBranch.indexOf("startTcp()"))
+        assertFalse(unknownActionBranch.substringBefore("}").contains("startTcp()"))
+        assertTrue(stickyBranch.contains("System sticky restart — restoring TCP transport"))
+    }
+
+    @Test
+    fun `explicit lifecycle commands persist transport ownership intent`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        val stopBranch = source.substringAfter("ACTION_STOP -> {").substringBefore("ACTION_START -> {")
+        val startBranch = source.substringAfter("ACTION_START -> {").substringBefore("ACTION_PREWARM -> {")
+        val prewarmBranch = source.substringAfter("ACTION_PREWARM -> {").substringBefore("ACTION_UPLOAD_LOGS -> {")
+
+        val clearDesired = stopBranch.indexOf("setTransportDesired(false)")
+        val stopService = stopBranch.indexOf("stopSelf()")
+        assertTrue(clearDesired >= 0)
+        assertTrue(stopService > clearDesired)
+        assertTrue(startBranch.contains("setTransportDesired(true)"))
+        assertTrue(prewarmBranch.contains("setTransportDesired(true)"))
+    }
+
+    private fun projectFile(relativePath: String): File {
+        val workingDir = File(checkNotNull(System.getProperty("user.dir")))
+        return generateSequence(workingDir) { it.parentFile }
+            .map { root -> File(root, relativePath) }
+            .firstOrNull(File::isFile)
+            ?: error("Could not locate $relativePath from $workingDir")
+    }
+}


### PR DESCRIPTION
## Summary

- restore the companion TCP advertiser when Android recreates the `START_STICKY` service with a null intent and the previous owner persisted transport as desired
- distinguish genuine null-intent redelivery from an explicit no-action Intent and from upload-only service use
- reset the fresh process's running/connected/status state before rebuilding transport
- record the most recent `ApplicationExitInfo` reason, status, importance, memory, age, and bounded description after persistent file logging starts
- keep unknown explicit service actions inert

## Runtime incident addressed

On 2026-08-22, Liz's companion process disappeared during a healthy stream. Android recreated the foreground service about 1.08 seconds later, but fresh-process `_isRunning=false` made the existing sticky-restart branch skip `startTcp()`. The car then had no companion listener until a later manual restart.

This change repairs that recovery path. It does **not** claim to prevent the original process death; the new exit record is intended to classify the next occurrence as crash, native crash, ANR, low-memory kill, user stop, dependency death, or another Android exit reason.

## TDD and verification

- RED: focused tests failed on missing `CompanionRestartPolicy` and `ProcessExitSummary`
- RED: API compatibility test failed before the Android 11 guard was added
- GREEN: focused tests passed
- full companion unit suite: 70 tests, 0 failures/errors/skips
- `:companion:assembleDebug`: passed
- `:companion:compileReleaseKotlin --rerun-tasks`: passed
- `git diff --check`: passed
- added-line security scan: no hardcoded secret, injection, eval/exec, or unsafe deserialization finding
- lint: two pre-existing `MissingPermission` errors remain in unchanged `TcpAdvertiser.kt` and `WifiJobService.kt`; no changed-file lint error

## Runtime acceptance

After an actual companion process recreation, require:

```text
Previous companion process exit: reason=...
System sticky restart — restoring TCP transport
Starting TCP server on port 5277
```

Then require a car socket, Android Auto proxy attach, bridge establishment, native car session, and sustained `vflow`. The first three lines prove this recovery path ran; only the full downstream sequence proves user-visible recovery.
