### PR TITLE
fix(input): apply remaps live after save

### DIFF
--- a/app/src/main/java/com/openautolink/app/input/KeyRemapParser.kt
+++ b/app/src/main/java/com/openautolink/app/input/KeyRemapParser.kt
@@ -1,0 +1,18 @@
+package com.openautolink.app.input
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Parses the persisted Android-keycode → Android Auto-keycode map. */
+internal object KeyRemapParser {
+    fun parse(serialized: String): Map<Int, Int> {
+        if (serialized.isBlank()) return emptyMap()
+        return runCatching {
+            Json.parseToJsonElement(serialized).jsonObject.map { (hardwareKey, aaKey) ->
+                hardwareKey.toInt() to aaKey.jsonPrimitive.int
+            }.toMap()
+        }.getOrDefault(emptyMap())
+    }
+}

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -19,6 +19,7 @@ import com.openautolink.app.audio.AudioStats
 import com.openautolink.app.data.AppPreferences
 import com.openautolink.app.data.KnownPhone
 import com.openautolink.app.data.KnownPhonesStore
+import com.openautolink.app.input.KeyRemapParser
 import com.openautolink.app.input.SteeringWheelController
 import com.openautolink.app.input.TouchForwarder
 import com.openautolink.app.input.TouchForwarderImpl
@@ -316,6 +317,22 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
 
     init {
         registerTransportNetworkCallback()
+
+        // Key remaps belong to this process-scoped input controller, not to an
+        // individual AA protocol session. Keep it bound to DataStore so an
+        // assignment replaces the live map immediately; Save & Reconnect only
+        // restarts the AA protocol session and does not recreate this ViewModel.
+        viewModelScope.launch {
+            preferences.keyRemap.distinctUntilChanged()
+                .collect { serialized ->
+                    val map = KeyRemapParser.parse(serialized)
+                    steeringWheelController.customKeyMap = map
+                    OalLog.i(
+                        "input",
+                        "Applied custom key map update: count=${map.size} mappings=$map",
+                    )
+                }
+        }
 
         // Attach the surface as soon as a decoder exists, in addition to the
         // state-change path below. Either one alone can miss: the state observer
@@ -664,25 +681,6 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             val saBottom = preferences.safeAreaBottom.first()
             val saLeft = preferences.safeAreaLeft.first()
             val saRight = preferences.safeAreaRight.first()
-
-            // Load key remap from preferences
-            val keyRemapJson = preferences.keyRemap.first()
-            val map: Map<Int, Int> = if (keyRemapJson.isBlank()) {
-                emptyMap()
-            } else {
-                try {
-                    val parsed = mutableMapOf<Int, Int>()
-                    val json = org.json.JSONObject(keyRemapJson)
-                    for (key in json.keys()) {
-                        parsed[key.toInt()] = json.getInt(key)
-                    }
-                    parsed
-                } catch (_: Exception) {
-                    emptyMap()
-                }
-            }
-            steeringWheelController.customKeyMap = map
-            OalLog.i("input", "Loaded custom key map: count=${map.size}")
 
             // Load volume offsets
             val volMedia = preferences.volumeOffsetMedia.first()

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -2145,7 +2145,7 @@ private fun InputTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
         Text(
             text = "Map physical buttons (steering wheel, remote) to Android Auto actions. " +
                     "Tap an action, then press the physical button you want to assign. " +
-                    "Requires Save & Reconnect.",
+                    "Key assignments apply immediately and persist across reconnects.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.padding(bottom = 12.dp)

--- a/app/src/test/java/com/openautolink/app/input/KeyRemapParserTest.kt
+++ b/app/src/test/java/com/openautolink/app/input/KeyRemapParserTest.kt
@@ -1,0 +1,26 @@
+package com.openautolink.app.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyRemapParserTest {
+
+    @Test
+    fun `new serialized mapping replaces the previous hardware actions`() {
+        val previous = KeyRemapParser.parse("{\"137\":88,\"138\":87}")
+        val updated = KeyRemapParser.parse("{\"137\":87,\"138\":88}")
+
+        assertEquals(mapOf(137 to 88, 138 to 87), previous)
+        assertEquals(mapOf(137 to 87, 138 to 88), updated)
+    }
+
+    @Test
+    fun `blank mapping clears all custom actions`() {
+        assertEquals(emptyMap<Int, Int>(), KeyRemapParser.parse(""))
+    }
+
+    @Test
+    fun `invalid mapping fails closed to built in defaults`() {
+        assertEquals(emptyMap<Int, Int>(), KeyRemapParser.parse("not-json"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/ui/settings/KeyRemapDialogContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/settings/KeyRemapDialogContractTest.kt
@@ -41,15 +41,33 @@ class KeyRemapDialogContractTest {
     }
 
     @Test
-    fun `empty saved map actively clears the live steering controller`() {
+    fun `saved key remap changes update the live controller without rebuilding the view model`() {
         val source = projectFile(
             "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
         ).readText()
-        val load = source.substringAfter("// Load key remap from preferences")
-            .substringBefore("// Load volume offsets")
+        val initBlock = source.substringAfter("init {")
+            .substringBefore("/** Bind the overlay")
+        val connectBlock = source.substringAfter("private fun doConnect(")
+            .substringBefore("fun reconnect()")
 
-        assertTrue(load.contains("steeringWheelController.customKeyMap = map"))
-        assertFalse(load.contains("if (keyRemapJson.isNotBlank())"))
+        assertTrue(initBlock.contains("preferences.keyRemap.distinctUntilChanged()"))
+        assertTrue(initBlock.contains(".collect { serialized ->"))
+        assertTrue(initBlock.contains("KeyRemapParser.parse(serialized)"))
+        assertTrue(initBlock.contains("steeringWheelController.customKeyMap = map"))
+        assertTrue(initBlock.contains("Applied custom key map update:"))
+        assertFalse(connectBlock.contains("preferences.keyRemap.first()"))
+    }
+
+    @Test
+    fun `key remap help states that assignments apply immediately`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+        ).readText()
+        val inputTab = source.substringAfter("private fun InputTab")
+            .substringBefore("private fun AudioTab")
+
+        assertTrue(inputTab.contains("Key assignments apply immediately"))
+        assertFalse(inputTab.contains("Requires Save & Reconnect"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- bind the process-scoped steering-wheel controller continuously to the persisted key-remap DataStore flow
- suppress duplicate applications from unrelated preference writes
- replace the one-shot connect-time parser with a fail-closed reusable parser
- tell users assignments apply immediately and persist across reconnects

## Root cause
Car 0.1.466 logs prove persistence was correct but runtime state was stale:

```text
08:25:09.072 persisted {F8/138→Previous/88, F7/137→Next/87}
08:25:12.737 Save & Reconnect
08:25:45.465 F7/137 dispatched old Previous/88
08:25:49.277 F8/138 dispatched old Next/87
```

`ProjectionViewModel.connect()` loaded the map once into its private `SteeringWheelController`. Settings invokes `SessionManager.reconnect()` directly, so the ViewModel/controller survives and retained the previous map.

## Verification
- TDD RED: missing parser
- TDD RED: no process-scoped live collector
- TDD RED: stale Save & Reconnect UI copy
- TDD RED: collector lacked duplicate suppression
- focused remap tests: green
- full car unit suite: **420 tests, 0 failures/errors**
- `git diff --check`: clean
- static security scan: clean
- independent review cycle 1 found missing `distinctUntilChanged`; fixed under RED/GREEN
- independent final review: PASS, no security or logic errors

Repository-wide lint still reports 8 pre-existing errors, all outside this diff.

## Runtime status
This is a shipped-code candidate, not yet vehicle-verified. Positive verification after install is:

```text
Key remap persisted: mappings={"138":88,"137":87}
Applied custom key map update: mappings={137=87, 138=88}
Custom remap: KEYCODE_F7 (137) → AA 87
Custom remap: KEYCODE_F8 (138) → AA 88
```

Refs #19; keep the issue open until the car confirms those outcomes and button behavior.
