### PR TITLE
fix(cluster): rebind navigation by generation

### DIFF
--- a/app/src/main/java/com/openautolink/app/cluster/ClusterBindingRegistry.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterBindingRegistry.kt
@@ -1,0 +1,165 @@
+package com.openautolink.app.cluster
+
+internal const val CLUSTER_BINDING_GENERATION_EXTRA =
+    "com.openautolink.app.cluster.BINDING_GENERATION"
+
+/** Serializes manager transitions with AndroidX cluster session initialization. */
+internal object ClusterBindingLifecycle {
+    val lock = Any()
+}
+
+/**
+ * Generation-owned lifecycle registry for the cluster host binding.
+ *
+ * AndroidX may unbind [androidx.car.app.activity.CarAppActivity] without delivering the
+ * cluster Session's lifecycle destroy callback. Manager generations therefore own liveness;
+ * a session callback can only affect the generation under which it registered.
+ */
+internal class ClusterBindingRegistry {
+
+    class ManagerLease internal constructor(val generation: Long)
+
+    class SessionLease internal constructor(
+        val generation: Long,
+        val sessionId: Long,
+    )
+
+    private var nextGeneration = 0L
+    private var nextSessionId = 0L
+    private var activeGeneration: Long? = null
+    private val liveSessionIds = linkedSetOf<Long>()
+    private var primarySessionId: Long? = null
+
+    @Synchronized
+    fun openManager(): ManagerLease {
+        val generation = ++nextGeneration
+        activeGeneration = generation
+        liveSessionIds.clear()
+        primarySessionId = null
+        return ManagerLease(generation)
+    }
+
+    @Synchronized
+    fun closeManager(lease: ManagerLease): Boolean {
+        if (activeGeneration != lease.generation) return false
+        activeGeneration = null
+        liveSessionIds.clear()
+        primarySessionId = null
+        return true
+    }
+
+    @Synchronized
+    fun registerSession(expectedGeneration: Long? = null): SessionLease? {
+        val generation = activeGeneration ?: return null
+        if (expectedGeneration != null && expectedGeneration != generation) return null
+        val sessionId = ++nextSessionId
+        liveSessionIds += sessionId
+        return SessionLease(generation, sessionId)
+    }
+
+    @Synchronized
+    fun markPrimary(lease: SessionLease): Boolean {
+        if (activeGeneration != lease.generation || lease.sessionId !in liveSessionIds) {
+            return false
+        }
+        primarySessionId = lease.sessionId
+        return true
+    }
+
+    @Synchronized
+    fun unregisterSession(lease: SessionLease) {
+        if (activeGeneration != lease.generation) return
+        liveSessionIds -= lease.sessionId
+        if (primarySessionId == lease.sessionId) primarySessionId = null
+    }
+
+    @Synchronized
+    fun isManagerCurrent(lease: ManagerLease): Boolean =
+        activeGeneration == lease.generation
+
+    @Synchronized
+    fun hasLiveSession(lease: ManagerLease): Boolean =
+        activeGeneration == lease.generation && primarySessionId in liveSessionIds
+
+    @Synchronized
+    fun isSessionCurrent(lease: SessionLease): Boolean =
+        activeGeneration == lease.generation && lease.sessionId in liveSessionIds
+}
+
+/** Identity-safe primary-owner slot scoped by a cluster binding generation. */
+internal class GenerationOwnedSlot<T : Any> {
+    class Claim<T : Any>(
+        val accepted: Boolean,
+        val displaced: T?,
+    )
+
+    private var generation: Long? = null
+    private var owner: T? = null
+
+    @Synchronized
+    fun claim(candidateGeneration: Long, candidate: T): Claim<T> {
+        val currentGeneration = generation
+        if (currentGeneration == null || candidateGeneration > currentGeneration) {
+            val displaced = owner
+            generation = candidateGeneration
+            owner = candidate
+            return Claim(accepted = true, displaced = displaced)
+        }
+        if (candidateGeneration == currentGeneration && owner === candidate) {
+            return Claim(accepted = true, displaced = null)
+        }
+        return Claim(accepted = false, displaced = null)
+    }
+
+    @Synchronized
+    fun release(candidateGeneration: Long, candidate: T): Boolean {
+        if (generation != candidateGeneration || owner !== candidate) return false
+        generation = null
+        owner = null
+        return true
+    }
+
+    @Synchronized
+    fun invalidate(candidateGeneration: Long): T? {
+        if (generation != candidateGeneration) return null
+        val displaced = owner
+        generation = null
+        owner = null
+        return displaced
+    }
+
+    @Synchronized
+    fun isOwner(candidateGeneration: Long, candidate: T): Boolean =
+        generation == candidateGeneration && owner === candidate
+
+    @Synchronized
+    fun currentOwner(): T? = owner
+}
+
+/** Process-wide facade used by ClusterManager and AndroidX cluster Sessions. */
+internal object ClusterBindingState {
+    private val registry = ClusterBindingRegistry()
+
+    fun openManager(): ClusterBindingRegistry.ManagerLease = registry.openManager()
+
+    fun closeManager(lease: ClusterBindingRegistry.ManagerLease): Boolean =
+        registry.closeManager(lease)
+
+    fun registerSession(expectedGeneration: Long? = null): ClusterBindingRegistry.SessionLease? =
+        registry.registerSession(expectedGeneration)
+
+    fun markPrimary(lease: ClusterBindingRegistry.SessionLease): Boolean =
+        registry.markPrimary(lease)
+
+    fun unregisterSession(lease: ClusterBindingRegistry.SessionLease) =
+        registry.unregisterSession(lease)
+
+    fun isManagerCurrent(lease: ClusterBindingRegistry.ManagerLease): Boolean =
+        registry.isManagerCurrent(lease)
+
+    fun hasLiveSession(lease: ClusterBindingRegistry.ManagerLease): Boolean =
+        registry.hasLiveSession(lease)
+
+    fun isSessionCurrent(lease: ClusterBindingRegistry.SessionLease): Boolean =
+        registry.isSessionCurrent(lease)
+}

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
@@ -58,8 +58,7 @@ class ClusterMainSession : Session() {
 
         private const val ARRIVAL_TIMEOUT_MS = 10_000L
 
-        @Volatile
-        private var primarySession: ClusterMainSession? = null
+        private val primarySessions = GenerationOwnedSlot<ClusterMainSession>()
 
         /**
          * Proactively end any active cluster navigation. Called from
@@ -69,7 +68,7 @@ class ClusterMainSession : Session() {
          * because our process going away doesn't synchronously notify it.
          */
         fun endActiveNavigation() {
-            val session = primarySession ?: return
+            val session = primarySessions.currentOwner() ?: return
             try {
                 session.navigationManager?.navigationEnded()
                 session.isNavigating = false
@@ -79,23 +78,76 @@ class ClusterMainSession : Session() {
                 Log.w(TAG, "endActiveNavigation() failed: ${e.message}")
             }
         }
+
+        /** Retire only the primary owned by [generation]. A late callback from
+         * that session cannot clear a replacement generation's owner. */
+        fun invalidateBindingGeneration(generation: Long, reason: String) {
+            primarySessions.invalidate(generation)?.retirePrimary(reason, endNavigation = true)
+        }
     }
 
     private var navigationManager: NavigationManager? = null
     private var scope: CoroutineScope? = null
     private var isNavigating = false
-    private var isPrimary = false
     private var hasSeenActiveNav = false
     private var arrivalTimeoutJob: Job? = null
+    private var bindingLease: ClusterBindingRegistry.SessionLease? = null
+    private var tripOutcomeLogged = false
 
-    override fun onCreateScreen(intent: Intent): Screen {
-        ClusterBindingState.sessionAlive = true
+    override fun onCreateScreen(intent: Intent): Screen =
+        synchronized(ClusterBindingLifecycle.lock) { createScreen(intent) }
 
-        isPrimary = primarySession == null
-        if (isPrimary) {
-            primarySession = this
-            Log.i(TAG, "Primary session created — owns NavigationManager")
-            DiagnosticLog.i("cluster", "ClusterMainSession created (primary)")
+    private fun createScreen(intent: Intent): Screen {
+        val expectedGeneration = if (intent.hasExtra(CLUSTER_BINDING_GENERATION_EXTRA)) {
+            intent.getLongExtra(CLUSTER_BINDING_GENERATION_EXTRA, Long.MIN_VALUE)
+        } else {
+            null
+        }
+        val lease = ClusterBindingState.registerSession(expectedGeneration)
+        if (lease == null) {
+            Log.w(TAG, "Session rejected for stale or missing cluster manager generation")
+            DiagnosticLog.w(
+                "cluster",
+                "Cluster session rejected: expectedGeneration=$expectedGeneration",
+            )
+            return RelayScreen(carContext)
+        }
+        bindingLease = lease
+
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) {
+                val ownedLease = bindingLease
+                if (ownedLease != null) {
+                    if (primarySessions.release(ownedLease.generation, this@ClusterMainSession)) {
+                        retirePrimary("session destroy", endNavigation = true)
+                        DiagnosticLog.i(
+                            "cluster",
+                            "ClusterMainSession destroyed generation=${ownedLease.generation}",
+                        )
+                    }
+                    ClusterBindingState.unregisterSession(ownedLease)
+                }
+                bindingLease = null
+            }
+        })
+
+        val claim = primarySessions.claim(lease.generation, this)
+        val primaryAccepted = claim.accepted && ClusterBindingState.markPrimary(lease)
+        claim.displaced?.retirePrimary(
+            "superseded by generation ${lease.generation}",
+            endNavigation = true,
+        )
+        if (claim.accepted && !primaryAccepted) {
+            primarySessions.release(lease.generation, this)
+            Log.w(TAG, "Primary claim lost because generation ${lease.generation} retired")
+            return RelayScreen(carContext)
+        }
+        if (primaryAccepted) {
+            Log.i(TAG, "Primary session created — owns NavigationManager (generation=${lease.generation})")
+            DiagnosticLog.i(
+                "cluster",
+                "ClusterMainSession created (primary) generation=${lease.generation}",
+            )
         } else {
             Log.i(TAG, "Secondary session created — passive")
             return RelayScreen(carContext)
@@ -110,6 +162,7 @@ class ClusterMainSession : Session() {
 
         navigationManager?.setNavigationManagerCallback(object : NavigationManagerCallback {
             override fun onStopNavigation() {
+                if (!isCurrentPrimary()) return
                 Log.i(TAG, "onStopNavigation callback from Templates Host")
                 // Do NOT set isNavigating = false — GM's Templates Host may call this
                 // spuriously. We only end navigation on explicit nav_state_clear or
@@ -145,30 +198,30 @@ class ClusterMainSession : Session() {
             collectNavigationState()
         }
 
-        lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onDestroy(owner: LifecycleOwner) {
-                if (isPrimary) {
-                    primarySession = null
-                    Log.i(TAG, "Primary session destroyed")
-                    DiagnosticLog.i("cluster", "ClusterMainSession destroyed")
-                    arrivalTimeoutJob?.cancel()
-                    if (isNavigating) {
-                        try {
-                            navigationManager?.navigationEnded()
-                        } catch (e: Exception) {
-                            Log.e(TAG, "navigationEnded() failed on destroy: ${e.message}")
-                        }
-                        isNavigating = false
-                    }
-                    scope?.cancel()
-                    scope = null
-                    navigationManager = null
-                }
-                ClusterBindingState.sessionAlive = false
-            }
-        })
-
         return RelayScreen(carContext)
+    }
+
+    private fun retirePrimary(reason: String, endNavigation: Boolean) {
+        if (endNavigation && isNavigating) {
+            try {
+                navigationManager?.navigationEnded()
+            } catch (e: Exception) {
+                Log.e(TAG, "navigationEnded() failed during $reason: ${e.message}")
+            }
+        }
+        isNavigating = false
+        arrivalTimeoutJob?.cancel()
+        arrivalTimeoutJob = null
+        scope?.cancel()
+        scope = null
+        navigationManager = null
+        Log.i(TAG, "Primary session retired: $reason")
+    }
+
+    private fun isCurrentPrimary(): Boolean {
+        val lease = bindingLease ?: return false
+        return ClusterBindingState.isSessionCurrent(lease) &&
+            primarySessions.isOwner(lease.generation, this)
     }
 
     private suspend fun collectNavigationState() {
@@ -187,6 +240,7 @@ class ClusterMainSession : Session() {
     }
 
     private fun processStateUpdate(maneuver: ManeuverState?) {
+        if (!isCurrentPrimary()) return
         val navManager = navigationManager ?: return
 
         if (maneuver != null) {
@@ -206,10 +260,21 @@ class ClusterMainSession : Session() {
             try {
                 val trip = buildTrip(maneuver)
                 navManager.updateTrip(trip)
+                if (!tripOutcomeLogged) {
+                    tripOutcomeLogged = true
+                    DiagnosticLog.i(
+                        "cluster",
+                        "Trip update outcome=sent generation=${bindingLease?.generation} " +
+                            "maneuver=${maneuver.type} road=${maneuver.roadName}",
+                    )
+                }
                 DiagnosticLog.d("cluster", "Trip: ${maneuver.type} dist=${maneuver.distanceMeters}m road=${maneuver.roadName} lanes=${maneuver.lanes?.size ?: 0}")
             } catch (e: Exception) {
                 Log.e(TAG, "updateTrip() failed: ${e.message}")
-                DiagnosticLog.e("cluster", "updateTrip() failed: ${e.message}")
+                DiagnosticLog.e(
+                    "cluster",
+                    "Trip update outcome=failed generation=${bindingLease?.generation} error=${e.message}",
+                )
             }
 
             // Arrival timeout for terminal maneuver types

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt
@@ -17,8 +17,8 @@ import com.openautolink.app.diagnostics.DiagnosticLog
  * launching CarAppActivity to trigger Templates Host binding, and recovering from
  * GM killing the cluster session.
  *
- * GM AAOS may kill third-party CarAppService sessions. This manager detects when the
- * session dies (via [ClusterBindingState.sessionAlive]) and re-launches the binding chain.
+ * GM AAOS may kill third-party CarAppService sessions. This manager uses a generation-owned
+ * binding lease to detect stale sessions and re-launch the binding chain.
  */
 class ClusterManager(private val context: Context) {
 
@@ -32,6 +32,8 @@ class ClusterManager(private val context: Context) {
         private const val PERMISSIONS_RETRY_DELAY_MS = 3000L
         private const val HEALTH_CHECK_DELAY_MS = 5000L
         private const val MAX_HEALTH_RETRIES = 3
+        private fun openBindingManager(): ClusterBindingRegistry.ManagerLease =
+            synchronized(ClusterBindingLifecycle.lock) { ClusterBindingState.openManager() }
 
         /** Runtime permissions that must be granted before launching CarAppActivity,
          *  to avoid covering the system permissions dialog. */
@@ -45,13 +47,25 @@ class ClusterManager(private val context: Context) {
     private var enabled = false
     private var healthRetryCount = 0
     private var relaunching = false
+    private var bindingLease = openBindingManager()
 
     /**
      * Enable or disable the cluster CarAppService component.
      * Must be called early in Activity.onCreate() before Templates Host discovers it.
      */
     fun setClusterEnabled(enabled: Boolean) {
-        this.enabled = enabled
+        synchronized(ClusterBindingLifecycle.lock) {
+            if (!ClusterBindingState.isManagerCurrent(bindingLease)) {
+                Log.i(TAG, "Ignoring component state from retired generation ${bindingLease.generation}")
+                return@synchronized
+            }
+            this.enabled = enabled
+            applyClusterComponentState(enabled)
+        }
+    }
+
+    /** Caller owns [ClusterBindingLifecycle.lock]. */
+    private fun applyClusterComponentState(enabled: Boolean) {
         val newState = if (enabled) {
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED
         } else {
@@ -75,71 +89,86 @@ class ClusterManager(private val context: Context) {
      * Launch CarAppActivity to trigger Templates Host binding for the cluster.
      * Uses a separate task (taskAffinity) so it doesn't disturb the main activity.
      *
-     * Guarded by [ClusterBindingState.sessionAlive] — if a session is already alive,
-     * waits for teardown before retrying.
+     * Guarded by this manager's generation-owned binding lease. Sessions from an
+     * older manager can never block a fresh launch.
      *
      * Brings the main activity back to front after binding completes (1s delay).
      */
     fun launchClusterBinding() {
-        if (!enabled) {
-            Log.d(TAG, "Cluster not enabled — skipping launch")
-            return
-        }
-
-        // Don't launch CarAppActivity while runtime permissions are pending —
-        // it starts a new task that covers the system permission dialog
-        val pendingPermissions = REQUIRED_PERMISSIONS.any {
-            ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
-        }
-        if (pendingPermissions) {
-            Log.i(TAG, "Runtime permissions pending — deferring cluster launch")
-            handler.postDelayed({ launchClusterBinding() }, PERMISSIONS_RETRY_DELAY_MS)
-            return
-        }
-
-        if (ClusterBindingState.sessionAlive) {
-            Log.i(TAG, "Session still alive — will retry after teardown")
-            handler.postDelayed({
-                if (!ClusterBindingState.sessionAlive) {
-                    Log.i(TAG, "Old session torn down — retrying launch")
-                    launchClusterBinding()
-                }
-            }, RETRY_DELAY_MS)
-            return
-        }
-
-        try {
-            val intent = Intent().apply {
-                setClassName(context, CAR_APP_ACTIVITY_CLASS)
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
+        synchronized(ClusterBindingLifecycle.lock) {
+            if (!enabled) {
+                Log.d(TAG, "Cluster not enabled — skipping launch")
+                return@synchronized
             }
-            context.startActivity(intent)
-            Log.i(TAG, "Launched CarAppActivity for Templates Host binding")
-            DiagnosticLog.i("cluster", "Launched CarAppActivity for Templates Host binding")
+            val launchLease = bindingLease
+            if (!ClusterBindingState.isManagerCurrent(launchLease)) {
+                Log.i(TAG, "Cluster binding generation ${launchLease.generation} is retired — skipping launch")
+                return@synchronized
+            }
 
-            // Schedule health check — if session doesn't come alive, retry
-            scheduleHealthCheck()
+            // Don't launch CarAppActivity while runtime permissions are pending —
+            // it starts a new task that covers the system permission dialog
+            val pendingPermissions = REQUIRED_PERMISSIONS.any {
+                ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+            }
+            if (pendingPermissions) {
+                Log.i(TAG, "Runtime permissions pending — deferring cluster launch")
+                handler.postDelayed({ launchClusterBinding() }, PERMISSIONS_RETRY_DELAY_MS)
+                return@synchronized
+            }
 
-            // Bring main activity back — binding is IPC-based, doesn't need foreground
-            handler.postDelayed({
-                try {
-                    val mainActivity = Class.forName("${context.packageName}.MainActivity")
-                    val bringBack = Intent(context, mainActivity).apply {
-                        flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
-                                Intent.FLAG_ACTIVITY_NEW_TASK or
-                                Intent.FLAG_ACTIVITY_NO_ANIMATION
+            if (ClusterBindingState.hasLiveSession(launchLease)) {
+                Log.i(TAG, "Current-generation session still alive — will retry after teardown")
+                handler.postDelayed({
+                    if (ClusterBindingState.isManagerCurrent(launchLease) &&
+                        !ClusterBindingState.hasLiveSession(launchLease)
+                    ) {
+                        Log.i(TAG, "Old session torn down — retrying launch")
+                        launchClusterBinding()
                     }
-                    context.startActivity(bringBack)
-                    Log.i(TAG, "Brought main activity back to foreground")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to bring main activity back: ${e.message}")
+                }, RETRY_DELAY_MS)
+                return@synchronized
+            }
+
+            try {
+                val intent = Intent().apply {
+                    setClassName(context, CAR_APP_ACTIVITY_CLASS)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_NO_ANIMATION
+                    putExtra(CLUSTER_BINDING_GENERATION_EXTRA, launchLease.generation)
                 }
-            }, BRING_BACK_DELAY_MS)
-        } catch (e: Exception) {
-            // Cluster service blocked or not available — graceful degradation
-            Log.w(TAG, "Failed to launch CarAppActivity: ${e.message}")
-            DiagnosticLog.w("cluster", "Failed to launch CarAppActivity: ${e.message}")
-            Log.i(TAG, "Cluster navigation will not be available — media metadata still flows via MediaSession")
+                context.startActivity(intent)
+                Log.i(TAG, "Launched CarAppActivity for Templates Host binding")
+                DiagnosticLog.i("cluster", "Launched CarAppActivity for Templates Host binding")
+
+                // Schedule health check — if session doesn't come alive, retry
+                scheduleHealthCheck(launchLease)
+
+                // Bring main activity back — binding is IPC-based, doesn't need foreground
+                handler.postDelayed({
+                    synchronized(ClusterBindingLifecycle.lock) {
+                        if (!enabled || !ClusterBindingState.isManagerCurrent(launchLease)) {
+                            return@synchronized
+                        }
+                        try {
+                            val mainActivity = Class.forName("${context.packageName}.MainActivity")
+                            val bringBack = Intent(context, mainActivity).apply {
+                                flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
+                                        Intent.FLAG_ACTIVITY_NEW_TASK or
+                                        Intent.FLAG_ACTIVITY_NO_ANIMATION
+                            }
+                            context.startActivity(bringBack)
+                            Log.i(TAG, "Brought main activity back to foreground")
+                        } catch (e: Exception) {
+                            Log.w(TAG, "Failed to bring main activity back: ${e.message}")
+                        }
+                    }
+                }, BRING_BACK_DELAY_MS)
+            } catch (e: Exception) {
+                // Cluster service blocked or not available — graceful degradation
+                Log.w(TAG, "Failed to launch CarAppActivity: ${e.message}")
+                DiagnosticLog.w("cluster", "Failed to launch CarAppActivity: ${e.message}")
+                Log.i(TAG, "Cluster navigation will not be available — media metadata still flows via MediaSession")
+            }
         }
     }
 
@@ -148,26 +177,29 @@ class ClusterManager(private val context: Context) {
      * If the cluster session hasn't come alive after HEALTH_CHECK_DELAY_MS,
      * tear down the stale task and retry the full binding chain.
      */
-    private fun scheduleHealthCheck() {
+    private fun scheduleHealthCheck(launchLease: ClusterBindingRegistry.ManagerLease) {
         handler.postDelayed({
-            if (!enabled) return@postDelayed
-            if (ClusterBindingState.sessionAlive) {
-                Log.i(TAG, "Health check: cluster session alive")
-                healthRetryCount = 0
-                relaunching = false
-                return@postDelayed
+            synchronized(ClusterBindingLifecycle.lock) {
+                if (!enabled) return@synchronized
+                if (!ClusterBindingState.isManagerCurrent(launchLease)) return@synchronized
+                if (ClusterBindingState.hasLiveSession(launchLease)) {
+                    Log.i(TAG, "Health check: cluster session alive")
+                    healthRetryCount = 0
+                    relaunching = false
+                    return@synchronized
+                }
+                healthRetryCount++
+                if (healthRetryCount > MAX_HEALTH_RETRIES) {
+                    Log.w(TAG, "Health check: max retries ($MAX_HEALTH_RETRIES) exceeded — giving up")
+                    DiagnosticLog.w("cluster", "Cluster binding failed after $MAX_HEALTH_RETRIES retries")
+                    healthRetryCount = 0
+                    relaunching = false
+                    return@synchronized
+                }
+                Log.w(TAG, "Health check: session not alive — retry $healthRetryCount/$MAX_HEALTH_RETRIES")
+                DiagnosticLog.w("cluster", "Cluster session not alive — retrying ($healthRetryCount/$MAX_HEALTH_RETRIES)")
+                restartClusterBinding()
             }
-            healthRetryCount++
-            if (healthRetryCount > MAX_HEALTH_RETRIES) {
-                Log.w(TAG, "Health check: max retries ($MAX_HEALTH_RETRIES) exceeded \u2014 giving up")
-                DiagnosticLog.w("cluster", "Cluster binding failed after $MAX_HEALTH_RETRIES retries")
-                healthRetryCount = 0
-                relaunching = false
-                return@postDelayed
-            }
-            Log.w(TAG, "Health check: session not alive — retry $healthRetryCount/$MAX_HEALTH_RETRIES")
-            DiagnosticLog.w("cluster", "Cluster session not alive — retrying ($healthRetryCount/$MAX_HEALTH_RETRIES)")
-            restartClusterBinding()
         }, HEALTH_CHECK_DELAY_MS)
     }
 
@@ -176,28 +208,31 @@ class ClusterManager(private val context: Context) {
      * Called when the cluster session is detected as dead, or when nav state needs reset.
      */
     fun restartClusterBinding() {
-        Log.w(TAG, "Restarting cluster binding chain")
-        DiagnosticLog.w("cluster", "Restarting cluster binding chain")
-        ClusterNavigationState.clear()
-
-        // Find and finish the CarAppActivity task
-        try {
-            val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-            for (appTask in am.appTasks) {
-                if (appTask.taskInfo.baseActivity?.className == CAR_APP_ACTIVITY_CLASS) {
-                    Log.i(TAG, "Finishing CarAppActivity task")
-                    DiagnosticLog.w("cluster", "GM killed cluster session — finishing task and rebinding")
-                    appTask.finishAndRemoveTask()
-                    break
-                }
+        synchronized(ClusterBindingLifecycle.lock) {
+            val retiredLease = bindingLease
+            if (!ClusterBindingState.closeManager(retiredLease)) {
+                DiagnosticLog.i(
+                    "cluster",
+                    "Cluster binding restart ignored: retired generation=${retiredLease.generation}",
+                )
+                return@synchronized
             }
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to finish CarAppActivity task: ${e.message}")
-        }
+            Log.w(TAG, "Restarting cluster binding chain")
+            DiagnosticLog.w("cluster", "Restarting cluster binding chain")
+            ClusterNavigationState.clear()
+            ClusterMainSession.invalidateBindingGeneration(retiredLease.generation, "binding restart")
+            finishClusterTask(retiredLease, "restart")
+            val replacementLease = ClusterBindingState.openManager()
+            bindingLease = replacementLease
+            DiagnosticLog.i(
+                "cluster",
+                "Cluster binding generation replaced: old=${retiredLease.generation} new=${replacementLease.generation}",
+            )
 
-        handler.postDelayed({
-            launchClusterBinding()
-        }, RELAUNCH_DELAY_MS)
+            handler.postDelayed({
+                if (ClusterBindingState.isManagerCurrent(replacementLease)) launchClusterBinding()
+            }, RELAUNCH_DELAY_MS)
+        }
     }
 
     /**
@@ -205,23 +240,68 @@ class ClusterManager(private val context: Context) {
      * Called after bridge reconnect (Hello received) and when returning from Settings.
      */
     fun ensureAlive() {
-        if (!enabled) return
-        if (ClusterBindingState.sessionAlive) return
-        if (relaunching) return
+        synchronized(ClusterBindingLifecycle.lock) {
+            if (!enabled) return@synchronized
+            if (ClusterBindingState.hasLiveSession(bindingLease)) return@synchronized
+            if (relaunching) return@synchronized
 
-        Log.w(TAG, "Cluster session not alive \u2014 relaunching binding")
-        DiagnosticLog.w("cluster", "Cluster session not alive \u2014 relaunching binding")
-        relaunching = true
-        restartClusterBinding()
+            Log.w(TAG, "Cluster session not alive — relaunching binding")
+            DiagnosticLog.w("cluster", "Cluster session not alive — relaunching binding")
+            relaunching = true
+            restartClusterBinding()
+        }
     }
 
     /**
      * Stop monitoring and release handler callbacks.
      */
     fun release() {
-        setClusterEnabled(false)
-        handler.removeCallbacksAndMessages(null)
-        healthRetryCount = 0
-        relaunching = false
+        synchronized(ClusterBindingLifecycle.lock) {
+            enabled = false
+            handler.removeCallbacksAndMessages(null)
+            healthRetryCount = 0
+            relaunching = false
+            val retiredLease = bindingLease
+            if (!ClusterBindingState.closeManager(retiredLease)) {
+                DiagnosticLog.i(
+                    "cluster",
+                    "Cluster manager release ignored: retired generation=${retiredLease.generation}",
+                )
+                return@synchronized
+            }
+            ClusterMainSession.invalidateBindingGeneration(retiredLease.generation, "manager release")
+            applyClusterComponentState(false)
+            finishClusterTask(retiredLease, "release")
+        }
+    }
+
+    private fun finishClusterTask(
+        lease: ClusterBindingRegistry.ManagerLease,
+        reason: String,
+    ) {
+        try {
+            val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+            val task = am.appTasks.firstOrNull {
+                it.taskInfo.baseActivity?.className == CAR_APP_ACTIVITY_CLASS
+            }
+            if (task == null) {
+                DiagnosticLog.i(
+                    "cluster",
+                    "Cluster task teardown outcome=not-found reason=$reason generation=${lease.generation}",
+                )
+                return
+            }
+            task.finishAndRemoveTask()
+            DiagnosticLog.i(
+                "cluster",
+                "Cluster task teardown outcome=finished reason=$reason generation=${lease.generation}",
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to finish CarAppActivity task: ${e.message}")
+            DiagnosticLog.w(
+                "cluster",
+                "Cluster task teardown outcome=failed reason=$reason generation=${lease.generation} error=${e.message}",
+            )
+        }
     }
 }

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationState.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationState.kt
@@ -40,14 +40,3 @@ object ClusterNavigationState {
         vehicleEnergyForecast.value = null
     }
 }
-
-/**
- * Tracks whether a live ClusterMainSession exists.
- *
- * Used by the activity to know whether it needs to re-launch CarAppActivity
- * to re-establish the Templates Host binding chain after teardown.
- */
-object ClusterBindingState {
-    @Volatile
-    var sessionAlive = false
-}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterBindingRegistryTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterBindingRegistryTest.kt
@@ -1,0 +1,180 @@
+package com.openautolink.app.cluster
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClusterBindingRegistryTest {
+
+    @Test
+    fun closingManagerInvalidatesSessionEvenWhenHostNeverDestroysIt() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val session = registry.registerSession()
+
+        assertNotNull(session)
+        registry.markPrimary(session!!)
+        assertTrue(registry.hasLiveSession(manager))
+
+        assertTrue(registry.closeManager(manager))
+
+        assertFalse(registry.hasLiveSession(manager))
+        assertFalse(registry.isSessionCurrent(session))
+        assertNull(registry.registerSession())
+    }
+
+    @Test
+    fun staleSessionDestroyCannotClearReplacementGeneration() {
+        val registry = ClusterBindingRegistry()
+        val oldManager = registry.openManager()
+        val oldSession = registry.registerSession()!!
+        val newManager = registry.openManager()
+        val newSession = registry.registerSession()!!
+        registry.markPrimary(newSession)
+
+        registry.unregisterSession(oldSession)
+        assertFalse(registry.closeManager(oldManager))
+
+        assertTrue(registry.isManagerCurrent(newManager))
+        assertTrue(registry.isSessionCurrent(newSession))
+        assertTrue(registry.hasLiveSession(newManager))
+    }
+
+    @Test
+    fun destroyingOneOfMultipleCurrentSessionsLeavesGenerationAlive() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val primary = registry.registerSession()!!
+        val secondary = registry.registerSession()!!
+        registry.markPrimary(primary)
+
+        registry.unregisterSession(secondary)
+
+        assertTrue(registry.isSessionCurrent(primary))
+        assertTrue(registry.hasLiveSession(manager))
+
+        registry.unregisterSession(primary)
+
+        assertFalse(registry.hasLiveSession(manager))
+    }
+
+    @Test
+    fun passiveSecondaryCannotKeepBindingAliveAfterPrimaryDies() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val primary = registry.registerSession()!!
+        val secondary = registry.registerSession()!!
+        registry.markPrimary(primary)
+
+        registry.unregisterSession(primary)
+
+        assertTrue(registry.isSessionCurrent(secondary))
+        assertFalse(registry.hasLiveSession(manager))
+    }
+
+    @Test
+    fun lifecycleLockSerializesSessionInitializationAgainstRetirement() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val initializationEntered = CountDownLatch(1)
+        val allowInitializationToFinish = CountDownLatch(1)
+        val retirementFinished = CountDownLatch(1)
+        val retired = AtomicBoolean(false)
+
+        val initialization = thread {
+            synchronized(ClusterBindingLifecycle.lock) {
+                val session = registry.registerSession(manager.generation)!!
+                registry.markPrimary(session)
+                initializationEntered.countDown()
+                assertTrue(allowInitializationToFinish.await(2, TimeUnit.SECONDS))
+            }
+        }
+        assertTrue(initializationEntered.await(2, TimeUnit.SECONDS))
+
+        val retirement = thread {
+            synchronized(ClusterBindingLifecycle.lock) {
+                retired.set(registry.closeManager(manager))
+            }
+            retirementFinished.countDown()
+        }
+
+        assertFalse(retirementFinished.await(100, TimeUnit.MILLISECONDS))
+        assertFalse(retired.get())
+        allowInitializationToFinish.countDown()
+        initialization.join(2_000)
+        retirement.join(2_000)
+
+        assertTrue(retirementFinished.await(0, TimeUnit.MILLISECONDS))
+        assertTrue(retired.get())
+    }
+
+    @Test
+    fun openingReplacementGenerationImmediatelyRejectsOldLiveness() {
+        val registry = ClusterBindingRegistry()
+        val oldManager = registry.openManager()
+        val oldSession = registry.registerSession()!!
+
+        val replacement = registry.openManager()
+
+        assertFalse(registry.isManagerCurrent(oldManager))
+        assertFalse(registry.isSessionCurrent(oldSession))
+        assertFalse(registry.hasLiveSession(replacement))
+    }
+
+    @Test
+    fun staleActivityGenerationCannotRegisterIntoReplacementManager() {
+        val registry = ClusterBindingRegistry()
+        val oldManager = registry.openManager()
+        val replacement = registry.openManager()
+
+        assertNull(registry.registerSession(oldManager.generation))
+        assertNotNull(registry.registerSession(replacement.generation))
+    }
+
+    @Test
+    fun newerGenerationDisplacesStalePrimaryOwner() {
+        val slot = GenerationOwnedSlot<Any>()
+        val oldPrimary = Any()
+        val newPrimary = Any()
+
+        assertTrue(slot.claim(1, oldPrimary).accepted)
+        val replacement = slot.claim(2, newPrimary)
+
+        assertTrue(replacement.accepted)
+        assertTrue(replacement.displaced === oldPrimary)
+        assertTrue(slot.isOwner(2, newPrimary))
+        assertFalse(slot.isOwner(1, oldPrimary))
+    }
+
+    @Test
+    fun lateOldPrimaryReleaseCannotClearNewOwner() {
+        val slot = GenerationOwnedSlot<Any>()
+        val oldPrimary = Any()
+        val newPrimary = Any()
+        slot.claim(1, oldPrimary)
+        slot.claim(2, newPrimary)
+
+        assertFalse(slot.release(1, oldPrimary))
+        assertTrue(slot.isOwner(2, newPrimary))
+    }
+
+    @Test
+    fun secondSessionInSameGenerationRemainsPassive() {
+        val slot = GenerationOwnedSlot<Any>()
+        val primary = Any()
+        val secondary = Any()
+        slot.claim(4, primary)
+
+        val claim = slot.claim(4, secondary)
+
+        assertFalse(claim.accepted)
+        assertNull(claim.displaced)
+        assertTrue(slot.isOwner(4, primary))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterManagerWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterManagerWiringContractTest.kt
@@ -1,0 +1,36 @@
+package com.openautolink.app.cluster
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClusterManagerWiringContractTest {
+
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate project root from $start")
+        return File(root, relative).readText()
+    }
+
+    @Test
+    fun delayedForegroundRestoreIsOwnedByLaunchingGeneration() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt"
+        )
+        val start = source.indexOf("// Bring main activity back")
+        val end = source.indexOf("}, BRING_BACK_DELAY_MS)", start)
+        assertTrue("bring-back callback missing", start >= 0 && end > start)
+
+        val callback = source.substring(start, end)
+        assertTrue(
+            "bring-back callback must share the lifecycle lock",
+            callback.contains("synchronized(ClusterBindingLifecycle.lock)"),
+        )
+        assertTrue(
+            "bring-back callback must reject a retired launch generation",
+            callback.contains("ClusterBindingState.isManagerCurrent(launchLease)"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- replace the process-global cluster `sessionAlive` Boolean with generation-owned manager and session leases
- serialize manager retirement, AndroidX session initialization, task/component side effects, and delayed foreground callbacks through one lifecycle lock
- treat only the current primary cluster session as live, so a passive secondary cannot block rebinding
- add INFO-level binding-generation and `Trip update outcome=sent|failed` evidence for the next vehicle capture

## Runtime evidence behind this change
On car app 0.1.466, `CarAppActivity` unbound without `ClusterMainSession.onDestroy()`. The process-global liveness Boolean stayed true across later ignition starts, so OAL skipped a fresh Templates Host binding. Maps still delivered valid ACTIVE navigation state while media artwork/info continued through the independent process-wide MediaSession.

## Host verification
Performed on `lance-host` in isolated host worktree `/mnt/Temp/Hermes_Work/openautolink-cluster-binding-host`:
- `:app:testDebugUnitTest`: **431 tests, 0 failures/errors/skips**
- `:app:assembleDebug`: **BUILD SUCCESSFUL**, arm64-v8a and x86_64 native tasks included
- host APK SHA-256: `9700058c4098cc3c1f81ba18aa3a372fd6aee7f5ade4427c4e6b7f99a61ce39f`
- built DEX contains the new generation/release/restart/trip-outcome markers
- independent lifecycle/concurrency review: PASS after fixing stale-manager, initialization-retirement, and delayed-callback races

## Scope / honest status
This is a code-complete **attempt pending vehicle verification**. It does not claim the cluster is fixed until the next car log shows a fresh activity launch, primary cluster session creation, `Trip update outcome=sent`, and visible turn guidance.

No AAB was signed or uploaded and no release was created by this PR work.
