### PR TITLE
feat(logs): secure invited-user uploads

### DIFF
--- a/app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/LogUploader.kt
@@ -6,6 +6,7 @@ import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.HttpURLConnection
+import java.net.URI
 import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -17,6 +18,18 @@ import java.util.zip.ZipOutputStream
 sealed class UploadResult {
     data class Success(val storedBytes: Int, val fileCount: Int) : UploadResult()
     data class Failure(val reason: String) : UploadResult()
+}
+
+/** Maintainer credentials must never be sent over cleartext or non-HTTP schemes. */
+object UploadEndpointPolicy {
+    fun isAllowed(raw: String): Boolean = try {
+        val uri = URI(raw.trim())
+        uri.scheme.equals("https", ignoreCase = true) &&
+            !uri.host.isNullOrBlank() &&
+            uri.userInfo == null
+    } catch (_: Exception) {
+        false
+    }
 }
 
 /**
@@ -102,6 +115,9 @@ class LogUploader(private val context: Context) {
         if (url.isBlank() || token.isBlank()) {
             return UploadResult.Failure("upload not configured")
         }
+        if (!UploadEndpointPolicy.isAllowed(url)) {
+            return UploadResult.Failure("HTTPS upload URL required")
+        }
         val files = recentFiles()
         if (files.isEmpty()) return UploadResult.Failure("no log files to upload")
 
@@ -117,6 +133,7 @@ class LogUploader(private val context: Context) {
         return try {
             val conn = (URL(url).openConnection() as HttpURLConnection).apply {
                 requestMethod = "POST"
+                instanceFollowRedirects = false
                 doOutput = true
                 connectTimeout = CONNECT_TIMEOUT_MS
                 readTimeout = READ_TIMEOUT_MS

--- a/app/src/test/java/com/openautolink/app/diagnostics/UploadEndpointPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/diagnostics/UploadEndpointPolicyTest.kt
@@ -1,0 +1,20 @@
+package com.openautolink.app.diagnostics
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UploadEndpointPolicyTest {
+    @Test fun acceptsHttpsEndpoint() {
+        assertTrue(UploadEndpointPolicy.isAllowed("https://logs.example.com/upload"))
+    }
+
+    @Test fun rejectsCleartextHttpEndpoint() {
+        assertFalse(UploadEndpointPolicy.isAllowed("http://logs.example.com/upload"))
+    }
+
+    @Test fun rejectsNonHttpAndMalformedEndpoints() {
+        assertFalse(UploadEndpointPolicy.isAllowed("ftp://logs.example.com/upload"))
+        assertFalse(UploadEndpointPolicy.isAllowed("not a url"))
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/MainActivity.kt
+++ b/companion/src/main/java/com/openautolink/companion/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import com.openautolink.companion.diagnostics.UploadCredentialStore
 import com.openautolink.companion.service.CompanionService
 import com.openautolink.companion.ui.MainScreen
 import com.openautolink.companion.ui.theme.OalCompanionTheme
@@ -39,6 +40,8 @@ class MainActivity : ComponentActivity() {
         handleIntent(intent)
 
         val prefs = getSharedPreferences(CompanionPrefs.NAME, MODE_PRIVATE)
+        // Move any legacy token out of the backed-up settings file before use.
+        UploadCredentialStore.read(this, prefs)
         val autoStartMode = prefs.getInt(CompanionPrefs.AUTO_START_MODE, 0)
         if (autoStartMode == CompanionPrefs.AUTO_START_APP_OPEN && !CompanionService.isRunning.value) {
             startCompanionService()

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/LogUploader.kt
@@ -8,6 +8,7 @@ import java.io.BufferedOutputStream
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.net.HttpURLConnection
+import java.net.URI
 import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -19,6 +20,18 @@ import java.util.zip.ZipOutputStream
 sealed class UploadResult {
     data class Success(val bytes: Int, val fileCount: Int) : UploadResult()
     data class Failure(val reason: String) : UploadResult()
+}
+
+/** Invitation credentials must never be sent over cleartext or non-HTTP schemes. */
+object UploadEndpointPolicy {
+    fun isAllowed(raw: String): Boolean = try {
+        val uri = URI(raw.trim())
+        uri.scheme.equals("https", ignoreCase = true) &&
+            !uri.host.isNullOrBlank() &&
+            uri.userInfo == null
+    } catch (_: Exception) {
+        false
+    }
 }
 
 /**
@@ -92,6 +105,9 @@ class LogUploader(private val context: Context) {
         if (url.isBlank() || token.isBlank()) {
             return UploadResult.Failure("not configured")
         }
+        if (!UploadEndpointPolicy.isAllowed(url)) {
+            return UploadResult.Failure("HTTPS upload URL required")
+        }
         val files = recentFiles()
         if (files.isEmpty()) return UploadResult.Failure("no log files")
 
@@ -113,6 +129,7 @@ class LogUploader(private val context: Context) {
             } ?: return UploadResult.Failure("no default network")
             val conn = (defaultNetwork.openConnection(endpoint) as HttpURLConnection).apply {
                 requestMethod = "POST"
+                instanceFollowRedirects = false
                 doOutput = true
                 connectTimeout = CONNECT_TIMEOUT_MS
                 readTimeout = READ_TIMEOUT_MS

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/UploadCredentialStore.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/UploadCredentialStore.kt
@@ -1,0 +1,61 @@
+package com.openautolink.companion.diagnostics
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.SharedPreferences
+import com.openautolink.companion.CompanionPrefs
+
+/** Migration decision kept pure so credential movement is unit-testable. */
+enum class TokenMigration {
+    COPY_AND_REMOVE_LEGACY,
+    REMOVE_LEGACY_ONLY,
+    NONE;
+
+    companion object {
+        fun plan(secretToken: String, legacyToken: String): TokenMigration = when {
+            secretToken.isBlank() && legacyToken.isNotBlank() -> COPY_AND_REMOVE_LEGACY
+            legacyToken.isNotBlank() -> REMOVE_LEGACY_ONLY
+            else -> NONE
+        }
+    }
+}
+
+/** Stores the upload invitation token outside the backed-up settings file. */
+object UploadCredentialStore {
+    const val FILE_NAME = "OalUploadCredentials"
+    private const val TOKEN_KEY = "upload_token"
+
+    @SuppressLint("ApplySharedPref") // Security migration must be durable before legacy removal.
+    @Synchronized
+    private fun migrate(mainPrefs: SharedPreferences, secretPrefs: SharedPreferences) {
+        val secret = secretPrefs.getString(TOKEN_KEY, "").orEmpty()
+        val legacy = mainPrefs.getString(CompanionPrefs.LOG_UPLOAD_TOKEN, "").orEmpty()
+        when (TokenMigration.plan(secret, legacy)) {
+            TokenMigration.COPY_AND_REMOVE_LEGACY -> {
+                val copied = secretPrefs.edit().putString(TOKEN_KEY, legacy).commit()
+                if (copied) {
+                    mainPrefs.edit().remove(CompanionPrefs.LOG_UPLOAD_TOKEN).commit()
+                }
+            }
+            TokenMigration.REMOVE_LEGACY_ONLY ->
+                mainPrefs.edit().remove(CompanionPrefs.LOG_UPLOAD_TOKEN).commit()
+            TokenMigration.NONE -> Unit
+        }
+    }
+
+    fun read(context: Context, mainPrefs: SharedPreferences): String {
+        val secretPrefs = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+        migrate(mainPrefs, secretPrefs)
+        return secretPrefs.getString(TOKEN_KEY, "").orEmpty()
+    }
+
+    @SuppressLint("ApplySharedPref") // UI must not claim a token that was not durably stored.
+    fun write(context: Context, mainPrefs: SharedPreferences, token: String): Boolean {
+        val secretPrefs = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+        val written = secretPrefs.edit().putString(TOKEN_KEY, token.trim()).commit()
+        if (written) {
+            mainPrefs.edit().remove(CompanionPrefs.LOG_UPLOAD_TOKEN).commit()
+        }
+        return written
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -19,6 +19,7 @@ import com.openautolink.companion.diagnostics.CompanionLog
 import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.diagnostics.PhoneWppStage
 import com.openautolink.companion.diagnostics.ProcessExitSummary
+import com.openautolink.companion.diagnostics.UploadCredentialStore
 import com.openautolink.companion.diagnostics.WppAssociationOwner
 import com.openautolink.companion.diagnostics.WppIntegrationTrigger
 import com.openautolink.companion.diagnostics.WppNetworkObserver
@@ -492,7 +493,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             return
         }
         val url = prefs.getString(CompanionPrefs.LOG_UPLOAD_URL, "") ?: ""
-        val token = prefs.getString(CompanionPrefs.LOG_UPLOAD_TOKEN, "") ?: ""
+        val token = UploadCredentialStore.read(this, prefs)
         val label = prefs.getString(CompanionPrefs.LOG_UPLOAD_DEVICE_LABEL, "") ?: ""
         if (url.isBlank() || token.isBlank()) {
             CompanionLog.w(TAG, "Upload requested but URL/token not configured")

--- a/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
+++ b/companion/src/main/java/com/openautolink/companion/ui/MainScreen.kt
@@ -76,6 +76,7 @@ import androidx.core.content.ContextCompat
 import com.openautolink.companion.R
 import com.openautolink.companion.CompanionPrefs
 import com.openautolink.companion.autostart.WifiJobService
+import com.openautolink.companion.diagnostics.UploadCredentialStore
 import com.openautolink.companion.service.CompanionService
 import com.openautolink.companion.ui.theme.OalGreen
 import com.openautolink.companion.ui.theme.OalOrange
@@ -1585,7 +1586,7 @@ private fun FileLoggingSection() {
         mutableStateOf(prefs.getBoolean(CompanionPrefs.LOG_UPLOAD_ENABLED, CompanionPrefs.DEFAULT_LOG_UPLOAD_ENABLED))
     }
     var uploadUrl by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_URL, "") ?: "") }
-    var uploadToken by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_TOKEN, "") ?: "") }
+    var uploadToken by remember { mutableStateOf(UploadCredentialStore.read(context, prefs)) }
     var deviceLabel by remember { mutableStateOf(prefs.getString(CompanionPrefs.LOG_UPLOAD_DEVICE_LABEL, "") ?: "") }
     val uploadState by CompanionService.uploadState.collectAsState()
 
@@ -1639,10 +1640,11 @@ private fun FileLoggingSection() {
                 OutlinedTextField(
                     value = uploadToken,
                     onValueChange = {
-                        uploadToken = it
-                        prefs.edit().putString(CompanionPrefs.LOG_UPLOAD_TOKEN, it.trim()).apply()
+                        if (UploadCredentialStore.write(context, prefs, it)) {
+                            uploadToken = it
+                        }
                     },
-                    label = { Text("Upload token") },
+                    label = { Text("Invitation token") },
                     singleLine = true,
                     visualTransformation = PasswordVisualTransformation(),
                     modifier = Modifier.fillMaxWidth(),

--- a/companion/src/main/res/xml/backup_rules.xml
+++ b/companion/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-    <include domain="sharedpref" path="OalCompanionPrefs.xml" />
+    <!-- Fail closed during legacy-token migration: no SharedPreferences backup. -->
+    <exclude domain="sharedpref" path="." />
 </full-backup-content>

--- a/companion/src/main/res/xml/data_extraction_rules.xml
+++ b/companion/src/main/res/xml/data_extraction_rules.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <include domain="sharedpref" path="OalCompanionPrefs.xml" />
+        <!-- OalCompanionPrefs historically contained the upload token. -->
+        <exclude domain="sharedpref" path="." />
     </cloud-backup>
     <device-transfer>
-        <include domain="sharedpref" path="OalCompanionPrefs.xml" />
+        <exclude domain="sharedpref" path="." />
     </device-transfer>
 </data-extraction-rules>

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/UploadCredentialBackupContractTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/UploadCredentialBackupContractTest.kt
@@ -1,0 +1,40 @@
+package com.openautolink.companion.diagnostics
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UploadCredentialBackupContractTest {
+    private fun projectFile(path: String): File {
+        val candidates = listOf(File(path), File("companion/$path"), File("../companion/$path"))
+        return candidates.first { it.exists() }
+    }
+
+    @Test fun allSharedPreferencesAreExcludedWhileLegacyTokenMayExist() {
+        val source = projectFile("src/main/java/com/openautolink/companion/diagnostics/UploadCredentialStore.kt").readText()
+        assertTrue(source.contains("OalUploadCredentials"))
+        for (name in listOf("backup_rules.xml", "data_extraction_rules.xml")) {
+            val file = projectFile("src/main/res/xml/$name")
+            val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+            val excludes = document.getElementsByTagName("exclude")
+            assertTrue("$name must contain an exclusion", excludes.length > 0)
+            val sharedPrefRootExcludes = (0 until excludes.length).count { index ->
+                val node = excludes.item(index)
+                node.attributes.getNamedItem("domain")?.nodeValue == "sharedpref" &&
+                    node.attributes.getNamedItem("path")?.nodeValue == "."
+            }
+            assertTrue("$name must exclude the complete legacy preference domain", sharedPrefRootExcludes > 0)
+            assertEquals("$name must not allowlist backed-up preferences", 0, document.getElementsByTagName("include").length)
+        }
+    }
+
+    @Test fun migrationRemovesLegacyTokenWithDurableCommits() {
+        val source = projectFile("src/main/java/com/openautolink/companion/diagnostics/UploadCredentialStore.kt").readText()
+        assertTrue(source.contains("putString(TOKEN_KEY, legacy).commit()"))
+        assertTrue(source.contains("remove(CompanionPrefs.LOG_UPLOAD_TOKEN).commit()"))
+        assertFalse(source.contains("remove(CompanionPrefs.LOG_UPLOAD_TOKEN).apply()"))
+    }
+}

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/UploadSecurityPolicyTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/UploadSecurityPolicyTest.kt
@@ -1,0 +1,20 @@
+package com.openautolink.companion.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UploadSecurityPolicyTest {
+    @Test fun acceptsOnlyHttpsEndpoints() {
+        assertTrue(UploadEndpointPolicy.isAllowed("https://logs.example.com/upload"))
+        assertFalse(UploadEndpointPolicy.isAllowed("http://logs.example.com/upload"))
+        assertFalse(UploadEndpointPolicy.isAllowed("file:///tmp/logs"))
+    }
+
+    @Test fun migrationCopiesLegacyTokenOnlyWhenSecretStoreIsEmpty() {
+        assertEquals(TokenMigration.COPY_AND_REMOVE_LEGACY, TokenMigration.plan("", "legacy-token"))
+        assertEquals(TokenMigration.REMOVE_LEGACY_ONLY, TokenMigration.plan("new-token", "legacy-token"))
+        assertEquals(TokenMigration.NONE, TokenMigration.plan("", ""))
+    }
+}


### PR DESCRIPTION
## Summary
- require HTTPS and disable redirect-following before either Android app sends an invitation token
- migrate the companion token out of backed-up preferences and fail closed by excluding all SharedPreferences while a legacy token may exist
- preserve the existing off-by-default upload UX while renaming the credential field to Invitation token

## Receiver and pipeline deployment
The live self-hosted receiver was separately upgraded to per-owner hash-only credentials, immutable owner namespaces, bounded ZIP validation, quotas/rate limits, atomic private storage, a write-isolated container, owner-aware ingest/dedup/retention, and a hard private-owner boundary before LLM/GitHub triage.

## Verification
- car unit suite: 434 tests, 0 failures/errors/skips
- companion unit suite: 74 tests, 0 failures/errors/skips
- focused upload security tests: 7, all passed
- companion lint: no findings in changed upload/backup files; two pre-existing MissingPermission errors remain in unchanged TcpAdvertiser/WifiJobService
- receiver/API/user management: 22 tests passed
- pipeline/privacy/retention/checker: 11 tests passed
- live public smoke: add=200, duplicate=true, revoke=401; owner path isolation verified
- live container: healthy, non-root, read-only rootfs, all caps dropped; only incoming is writable; bin/state/reports are not visible
- independent fail-closed re-review: PASS, no remaining blockers

Existing companion installations keep their token through a durable one-time migration. Historical Lance logs were preserved under `lance-household`; a pre-migration archive was created and hashed.
