### PR TITLE
fix(audio): bound playback latency and honor media Stop

### DIFF
--- a/app/src/main/cpp/jni_channel_handlers.cpp
+++ b/app/src/main/cpp/jni_channel_handlers.cpp
@@ -174,6 +174,9 @@ void JniAudioSinkHandler::onMediaChannelStartIndication(
     char channelName[32];
     snprintf(channelName, sizeof(channelName), "audio[%d]", static_cast<int>(type_));
     session_.reportGalStartEnvelope(channelName, indication);
+    const int sampleRate = (type_ == AudioType::Media) ? 48000 : 16000;
+    const int channels = (type_ == AudioType::Media) ? 2 : 1;
+    session_.dispatchAudioStart(purposeFromType(), sampleRate, channels);
     channel_->receive(shared_from_this());
 }
 
@@ -183,6 +186,7 @@ void JniAudioSinkHandler::onMediaChannelStopIndication(
     activeSessionId_.store(0);
     LOGI("Audio stop (type=%d)", static_cast<int>(type_));
     logProtoRaw("AudioStop", indication);
+    session_.dispatchAudioStop(purposeFromType());
     channel_->receive(shared_from_this());
 }
 

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -211,6 +211,8 @@ void JniSession::start(JNIEnv* env, jobject transportPipe, jobject callback, job
     cbMethods_.onVideoFrame = env->GetMethodID(cbClass, "onVideoFrame", "([BJIII)V");
     cbMethods_.onVideoCodecConfigured = env->GetMethodID(cbClass, "onVideoCodecConfigured", "(I)V");
     cbMethods_.onAudioFrame = env->GetMethodID(cbClass, "onAudioFrame", "([BIII)V");
+    cbMethods_.onAudioStart = env->GetMethodID(cbClass, "onAudioStart", "(III)V");
+    cbMethods_.onAudioStop = env->GetMethodID(cbClass, "onAudioStop", "(I)V");
     cbMethods_.onMicRequest = env->GetMethodID(cbClass, "onMicRequest", "(Z)V");
     cbMethods_.onNavigationStatus = env->GetMethodID(cbClass, "onNavigationStatus", "(I)V");
     cbMethods_.onNavigationTurn = env->GetMethodID(cbClass, "onNavigationTurn",
@@ -2391,6 +2393,32 @@ void JniSession::sendRpmSensor(int rpmE3)
 // ============================================================================
 // Dispatch methods Ã¢â‚¬â€ called by handler classes to fire JNI callbacks
 // ============================================================================
+
+void JniSession::dispatchAudioStart(int purpose, int sampleRate, int channels)
+{
+    if (!cbMethods_.onAudioStart || !callbackRef_) return;
+    bool attached;
+    JNIEnv* env = getEnv(attached);
+    if (env) {
+        env->CallVoidMethod(callbackRef_, cbMethods_.onAudioStart,
+                            static_cast<jint>(purpose),
+                            static_cast<jint>(sampleRate),
+                            static_cast<jint>(channels));
+    }
+    releaseEnv(attached);
+}
+
+void JniSession::dispatchAudioStop(int purpose)
+{
+    if (!cbMethods_.onAudioStop || !callbackRef_) return;
+    bool attached;
+    JNIEnv* env = getEnv(attached);
+    if (env) {
+        env->CallVoidMethod(callbackRef_, cbMethods_.onAudioStop,
+                            static_cast<jint>(purpose));
+    }
+    releaseEnv(attached);
+}
 
 void JniSession::dispatchAudioFrame(const uint8_t* data, size_t size,
                                      int purpose, int sampleRate, int channels)

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -207,6 +207,8 @@ public:
         const aap_protobuf::service::media::video::message::VideoFocusRequestNotification& request) override;
 
     // ---- Dispatch methods (called by handler classes → JNI) ----
+    void dispatchAudioStart(int purpose, int sampleRate, int channels);
+    void dispatchAudioStop(int purpose);
     void dispatchAudioFrame(const uint8_t* data, size_t size, int purpose, int sampleRate, int channels);
     void dispatchMicRequest(bool open);
     void dispatchNavStatus(int status);
@@ -443,6 +445,8 @@ private:
         jmethodID onVideoFrame = nullptr;
         jmethodID onVideoCodecConfigured = nullptr;
         jmethodID onAudioFrame = nullptr;
+        jmethodID onAudioStart = nullptr;
+        jmethodID onAudioStop = nullptr;
         jmethodID onMicRequest = nullptr;
         jmethodID onNavigationStatus = nullptr;
         jmethodID onNavigationTurn = nullptr;

--- a/app/src/main/java/com/openautolink/app/audio/AacDecoder.kt
+++ b/app/src/main/java/com/openautolink/app/audio/AacDecoder.kt
@@ -66,8 +66,23 @@ class AacDecoder(
     fun stop() {
         running = false
         inputQueue.clear()
-        decodeThread?.interrupt()
+        val thread = decodeThread
         decodeThread = null
+        thread?.interrupt()
+
+        // MediaCodec is owned by the decoder thread until that thread exits.
+        // Join through transient caller interruption so stop() never releases a
+        // codec that the old generation can still touch.
+        var restoreInterrupt = false
+        while (thread?.isAlive == true) {
+            try {
+                thread.join()
+            } catch (_: InterruptedException) {
+                restoreInterrupt = true
+            }
+        }
+        if (restoreInterrupt) Thread.currentThread().interrupt()
+
         try {
             codec?.stop()
             codec?.release()

--- a/app/src/main/java/com/openautolink/app/audio/AudioPlayerImpl.kt
+++ b/app/src/main/java/com/openautolink/app/audio/AudioPlayerImpl.kt
@@ -60,6 +60,7 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
 
     private val slots = mutableMapOf<AudioPurpose, AudioPurposeSlot>()
     private val slotFormats = mutableMapOf<AudioPurpose, AudioFormat>()
+    private val slotLifecycleLock = Any()
     private val focusManager = AudioFocusManager(audioManager)
     val coordinator = AudioPurposeCoordinator()
     private var idleCheckTimer: Timer? = null
@@ -78,46 +79,50 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
     private var initialized = false
 
     override fun initialize() {
-        if (initialized) return
+        synchronized(slotLifecycleLock) {
+            if (initialized) return@synchronized
 
-        // Pre-allocate all 5 AudioTrack slots with default formats
-        for (purpose in AudioPurpose.entries) {
-            val fmt = DEFAULT_FORMATS[purpose] ?: AudioFormat(48000, 2)
-            val slot = AudioPurposeSlot(purpose, fmt.sampleRate, fmt.channels)
-            slot.initialize()
-            slots[purpose] = slot
-            slotFormats[purpose] = fmt
+            // Pre-allocate all 5 AudioTrack slots with default formats
+            for (purpose in AudioPurpose.entries) {
+                val fmt = DEFAULT_FORMATS[purpose] ?: AudioFormat(48000, 2)
+                val slot = AudioPurposeSlot(purpose, fmt.sampleRate, fmt.channels)
+                slot.initialize()
+                slots[purpose] = slot
+                slotFormats[purpose] = fmt
+            }
+
+            // Request session-level audio focus once
+            focusManager.requestSessionFocus(
+                onLost = { pauseAllActive() },
+                onRegained = { resumeAllPaused() }
+            )
+
+            initialized = true
+            Log.i(TAG, "Audio player initialized with ${slots.size} purpose slots")
+            DiagnosticLog.i("audio", "AudioPlayer initialized with ${slots.size} purpose slots")
+            startIdleChecker()
+            updateStats()
         }
-
-        // Request session-level audio focus once
-        focusManager.requestSessionFocus(
-            onLost = { pauseAllActive() },
-            onRegained = { resumeAllPaused() }
-        )
-
-        initialized = true
-        Log.i(TAG, "Audio player initialized with ${slots.size} purpose slots")
-        DiagnosticLog.i("audio", "AudioPlayer initialized with ${slots.size} purpose slots")
-        startIdleChecker()
-        updateStats()
     }
 
     override fun release() {
-        if (!initialized) return
+        synchronized(slotLifecycleLock) {
+            if (!initialized) return@synchronized
 
-        stopIdleChecker()
-        for ((_, slot) in slots) {
-            slot.release()
+            stopIdleChecker()
+            for ((_, slot) in slots) {
+                slot.release()
+            }
+            slots.clear()
+            slotFormats.clear()
+            explicitStopTimes.clear()
+            focusManager.releaseFocus()
+            coordinator.reset()
+            initialized = false
+
+            Log.i(TAG, "Audio player released")
+            _stats.value = AudioStats()
         }
-        slots.clear()
-        slotFormats.clear()
-        explicitStopTimes.clear()
-        focusManager.releaseFocus()
-        coordinator.reset()
-        initialized = false
-
-        Log.i(TAG, "Audio player released")
-        _stats.value = AudioStats()
     }
 
     private var audioFrameCount = 0L
@@ -127,101 +132,118 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
     override fun onAudioFrame(frame: AudioFrame) {
         if (!frame.isPlayback) return
 
-        val slot = slots[frame.purpose]
-        if (slot == null) {
-            Log.w(TAG, "No slot for purpose ${frame.purpose}")
-            DiagnosticLog.w("audio", "No slot for purpose ${frame.purpose}")
-            return
-        }
+        synchronized(slotLifecycleLock) {
+            val slot = resolvePlaybackSlot(frame) ?: return@synchronized
 
-        // Auto-start: if audio frames arrive before audio_start control message
-        // (happens when phone was already streaming before app connected),
-        // start the slot with the frame's sample rate and channel count.
-        // BUT: suppress auto-start briefly after an explicit stop to prevent
-        // straggler frames from reactivating a purpose that was just stopped.
-        if (!slot.isActive) {
-            val suppressUntil = explicitStopTimes[frame.purpose] ?: 0L
-            if (System.currentTimeMillis() - suppressUntil < AUTO_START_SUPPRESS_MS) {
-                return // straggler frame after explicit stop — discard
+            audioFrameCount++
+            audioBytesReceived += frame.data.size
+            val now = System.currentTimeMillis()
+            if (now - lastAudioLogTime >= 2000) {
+                val ringBuf = slot.ringBufferAvailable
+                val ringCap = slot.ringBufferCapacity
+                val fillPct = if (ringCap > 0) (ringBuf * 100 / ringCap) else 0
+                Log.i(TAG, "audio: frames=$audioFrameCount bytes=$audioBytesReceived " +
+                        "thisFrame=${frame.data.size}B ring=$ringBuf/$ringCap (${fillPct}%) " +
+                        "written=${slot.framesWritten.get()} pending=${slot.pendingAudioBytes} " +
+                        "staleDropped=${slot.staleAudioBytesDropped} underruns=${slot.underrunCount.get()}")
+                // Detailed per-slot diagnostics for remote viewing
+                val slotSnapshot = slots.toMap()
+                for ((p, s) in slotSnapshot) {
+                    if (!s.isActive && s.totalWriteCalls == 0L) continue
+                    DiagnosticLog.d("audio", "slot=$p active=${s.isActive} " +
+                            "writes=${s.totalWriteCalls} written=${s.framesWritten.get()} " +
+                            "maxWriteMs=${s.maxWriteMs} slowWrites=${s.slowWriteCount} " +
+                            "maxGapMs=${s.maxGapMs} hwUnderruns=${s.hwUnderrunCount}")
+                }
+                lastAudioLogTime = now
             }
-            Log.i(TAG, "Auto-starting ${frame.purpose} from audio frame: ${frame.sampleRate}Hz ${frame.channels}ch")
-            startPurpose(frame.purpose, frame.sampleRate, frame.channels)
-        }
 
-        audioFrameCount++
-        audioBytesReceived += frame.data.size
-        val now = System.currentTimeMillis()
-        if (now - lastAudioLogTime >= 2000) {
-            val ringBuf = slot.ringBufferAvailable
-            val ringCap = slot.ringBufferCapacity
-            val fillPct = if (ringCap > 0) (ringBuf * 100 / ringCap) else 0
-            Log.i(TAG, "audio: frames=$audioFrameCount bytes=$audioBytesReceived " +
-                    "thisFrame=${frame.data.size}B ring=$ringBuf/$ringCap (${fillPct}%) " +
-                    "written=${slot.framesWritten.get()} underruns=${slot.underrunCount.get()}")
-            // Detailed per-slot diagnostics for remote viewing
-            for ((p, s) in slots) {
-                if (!s.isActive && s.totalWriteCalls == 0L) continue
-                DiagnosticLog.d("audio", "slot=$p active=${s.isActive} " +
-                        "writes=${s.totalWriteCalls} written=${s.framesWritten.get()} " +
-                        "maxWriteMs=${s.maxWriteMs} slowWrites=${s.slowWriteCount} " +
-                        "maxGapMs=${s.maxGapMs} hwUnderruns=${s.hwUnderrunCount}")
+            if (frame.isAac) {
+                slot.feedAac(frame.data)
+            } else {
+                slot.feedPcm(frame.data)
             }
-            lastAudioLogTime = now
-        }
-
-        if (frame.isAac) {
-            slot.feedAac(frame.data)
-        } else {
-            slot.feedPcm(frame.data)
         }
     }
 
-    override fun startPurpose(purpose: AudioPurpose, sampleRate: Int, channels: Int) {
-        val existingSlot = slots[purpose]
-        val requestedFmt = AudioFormat(sampleRate, channels)
-        explicitStopTimes.remove(purpose)  // clear suppression on explicit start
-
-        // Check if format changed from what the slot was created with — recreate if so
-        if (existingSlot != null) {
-            val currentFmt = slotFormats[purpose]
-            if (currentFmt != requestedFmt && !existingSlot.isActive) {
-                Log.i(TAG, "Recreating $purpose slot: ${sampleRate}Hz ${channels}ch")
-                existingSlot.release()
-                val newSlot = AudioPurposeSlot(purpose, sampleRate, channels)
-                newSlot.initialize()
-                slots[purpose] = newSlot
-                slotFormats[purpose] = requestedFmt
+    private fun resolvePlaybackSlot(frame: AudioFrame): AudioPurposeSlot? =
+        synchronized(slotLifecycleLock) {
+            var slot = slots[frame.purpose]
+            if (slot == null) {
+                Log.w(TAG, "No slot for purpose ${frame.purpose}")
+                DiagnosticLog.w("audio", "No slot for purpose ${frame.purpose}")
+                return@synchronized null
             }
+
+            // Auto-start can race the lifecycle flow. Keep the post-Stop
+            // suppression check and the start/replacement in this same owner
+            // critical section so a stale frame cannot undo a newer Stop.
+            if (!slot.isActive) {
+                val suppressUntil = explicitStopTimes[frame.purpose] ?: 0L
+                if (System.currentTimeMillis() - suppressUntil < AUTO_START_SUPPRESS_MS) {
+                    return@synchronized null
+                }
+                Log.i(
+                    TAG,
+                    "Auto-starting ${frame.purpose} from audio frame: " +
+                        "${frame.sampleRate}Hz ${frame.channels}ch",
+                )
+                startPurpose(frame.purpose, frame.sampleRate, frame.channels)
+                slot = slots[frame.purpose] ?: return@synchronized null
+            }
+            slot
         }
 
-        val slot = slots[purpose] ?: return
-        slot.start()
+    override fun startPurpose(purpose: AudioPurpose, sampleRate: Int, channels: Int) {
+        synchronized(slotLifecycleLock) {
+            val existingSlot = slots[purpose]
+            val requestedFmt = AudioFormat(sampleRate, channels)
+            explicitStopTimes.remove(purpose)  // clear suppression on explicit start
 
-        // Notify coordinator and apply volume ducking
-        val actions = coordinator.onPurposeStarted(purpose)
-        applyVolumeActions(actions)
+            // Check if format changed from what the slot was created with — recreate if so
+            if (existingSlot != null) {
+                val currentFmt = slotFormats[purpose]
+                if (currentFmt != requestedFmt && !existingSlot.isActive) {
+                    Log.i(TAG, "Recreating $purpose slot: ${sampleRate}Hz ${channels}ch")
+                    existingSlot.release()
+                    val newSlot = AudioPurposeSlot(purpose, sampleRate, channels)
+                    newSlot.initialize()
+                    slots[purpose] = newSlot
+                    slotFormats[purpose] = requestedFmt
+                }
+            }
 
-        Log.i(TAG, "Started $purpose: ${sampleRate}Hz ${channels}ch (call=${coordinator.callState.value})")
-        DiagnosticLog.i("audio", "AudioTrack started: purpose=$purpose, rate=${sampleRate}, ch=$channels")
-        updateStats()
+            val slot = slots[purpose] ?: return@synchronized
+            slot.start()
+
+            // Notify coordinator and apply volume ducking
+            val actions = coordinator.onPurposeStarted(purpose)
+            applyVolumeActions(actions)
+
+            Log.i(TAG, "Started $purpose: ${sampleRate}Hz ${channels}ch (call=${coordinator.callState.value})")
+            DiagnosticLog.i("audio", "AudioTrack started: purpose=$purpose, rate=${sampleRate}, ch=$channels")
+            updateStats()
+        }
     }
 
     override fun stopPurpose(purpose: AudioPurpose) {
-        val slot = slots[purpose] ?: return
-        slot.stop()
-        explicitStopTimes[purpose] = System.currentTimeMillis()
+        synchronized(slotLifecycleLock) {
+            val slot = slots[purpose] ?: return@synchronized
+            slot.stop()
+            explicitStopTimes[purpose] = System.currentTimeMillis()
 
-        // Notify coordinator and restore volumes
-        val actions = coordinator.onPurposeStopped(purpose)
-        applyVolumeActions(actions)
+            // Notify coordinator and restore volumes
+            val actions = coordinator.onPurposeStopped(purpose)
+            applyVolumeActions(actions)
 
-        Log.i(TAG, "Stopped $purpose (call=${coordinator.callState.value})")
-        DiagnosticLog.i("audio", "AudioTrack stopped: purpose=$purpose")
-        updateStats()
+            Log.i(TAG, "Stopped $purpose (call=${coordinator.callState.value})")
+            DiagnosticLog.i("audio", "AudioTrack stopped: purpose=$purpose")
+            updateStats()
+        }
     }
 
     override fun setVolume(purpose: AudioPurpose, volume: Float) {
-        slots[purpose]?.setVolume(volume)
+        synchronized(slotLifecycleLock) { slots[purpose] }?.setVolume(volume)
     }
 
     /**
@@ -230,7 +252,7 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
      */
     private fun applyVolumeActions(actions: List<VolumeAction>) {
         for (action in actions) {
-            val slot = slots[action.purpose] ?: continue
+            val slot = synchronized(slotLifecycleLock) { slots[action.purpose] } ?: continue
             slot.setVolume(action.volume)
             if (action.volume < AudioPurposeCoordinator.NORMAL_VOLUME) {
                 Log.d(TAG, "Ducked ${action.purpose} to ${action.volume}")
@@ -239,17 +261,19 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
     }
 
     /**
-     * Pause all active slots on external audio focus loss.
-     * Does NOT clear ring buffers — overflow drops oldest naturally.
+     * Pause all active slots on external audio focus loss and retire any
+     * pending PCM so old speech/music cannot resume after focus returns.
      */
     private fun pauseAllActive() {
-        for ((purpose, slot) in slots) {
-            if (slot.isActive) {
-                slot.pause()
-                Log.d(TAG, "Paused $purpose (focus loss)")
+        synchronized(slotLifecycleLock) {
+            for ((purpose, slot) in slots) {
+                if (slot.isActive) {
+                    slot.pause()
+                    Log.d(TAG, "Paused $purpose (focus loss)")
+                }
             }
+            updateStats()
         }
-        updateStats()
     }
 
     /**
@@ -257,61 +281,61 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
      * Slots that were explicitly stopped (not paused) won't resume.
      */
     private fun resumeAllPaused() {
-        for ((purpose, slot) in slots) {
-            if (!slot.isActive && slot.isPausedByFocus) {
-                slot.resume()
-                if (slot.isActive) {
-                    Log.d(TAG, "Resumed $purpose (focus regain)")
+        synchronized(slotLifecycleLock) {
+            for ((purpose, slot) in slots) {
+                if (!slot.isActive && slot.isPausedByFocus) {
+                    slot.resume()
+                    if (slot.isActive) {
+                        Log.d(TAG, "Resumed $purpose (focus regain)")
+                    }
                 }
             }
+            // Re-apply coordinator volumes after resuming
+            val actions = AudioPurpose.entries
+                .filter { slots[it]?.isActive == true }
+                .flatMap { purpose -> coordinator.onPurposeStarted(purpose) }
+            applyVolumeActions(actions)
+            updateStats()
         }
-        // Re-apply coordinator volumes after resuming
-        val actions = AudioPurpose.entries
-            .filter { slots[it]?.isActive == true }
-            .let { activePurposes ->
-                activePurposes.map { purpose ->
-                    coordinator.onPurposeStarted(purpose)
-                }.flatten()
-            }
-        applyVolumeActions(actions)
-        updateStats()
     }
 
     private fun updateStats() {
-        val active = slots.filter { it.value.isActive }.keys
-        val underruns = slots.mapValues { it.value.underrunCount.get() }
-            .filter { it.value > 0 }
+        synchronized(slotLifecycleLock) {
+            val active = slots.filter { it.value.isActive }.keys
+            val underruns = slots.mapValues { it.value.underrunCount.get() }
+                .filter { it.value > 0 }
 
-        // Log new underruns since last stats update
-        val prevUnderruns = _stats.value.underruns
-        for ((purpose, count) in underruns) {
-            val prev = prevUnderruns[purpose] ?: 0L
-            if (count > prev) {
-                DiagnosticLog.w("audio", "Underrun on $purpose: $count total (+${count - prev})")
+            // Log new underruns since last stats update
+            val prevUnderruns = _stats.value.underruns
+            for ((purpose, count) in underruns) {
+                val prev = prevUnderruns[purpose] ?: 0L
+                if (count > prev) {
+                    DiagnosticLog.w("audio", "Underrun on $purpose: $count total (+${count - prev})")
+                }
             }
+
+            val written = slots.mapValues { it.value.framesWritten.get() }
+                .filter { it.value > 0 }
+
+            val maxWrite = slots.filter { it.value.totalWriteCalls > 0 }
+                .mapValues { it.value.maxWriteMs }
+            val slowW = slots.filter { it.value.slowWriteCount > 0 }
+                .mapValues { it.value.slowWriteCount }
+            val maxGap = slots.filter { it.value.totalWriteCalls > 0 }
+                .mapValues { it.value.maxGapMs }
+            val hwUr = slots.filter { it.value.hwUnderrunCount > 0 }
+                .mapValues { it.value.hwUnderrunCount }
+
+            _stats.value = AudioStats(
+                activePurposes = active,
+                underruns = underruns,
+                framesWritten = written,
+                maxWriteMs = maxWrite,
+                slowWrites = slowW,
+                maxGapMs = maxGap,
+                hwUnderruns = hwUr,
+            )
         }
-
-        val written = slots.mapValues { it.value.framesWritten.get() }
-            .filter { it.value > 0 }
-
-        val maxWrite = slots.filter { it.value.totalWriteCalls > 0 }
-            .mapValues { it.value.maxWriteMs }
-        val slowW = slots.filter { it.value.slowWriteCount > 0 }
-            .mapValues { it.value.slowWriteCount }
-        val maxGap = slots.filter { it.value.totalWriteCalls > 0 }
-            .mapValues { it.value.maxGapMs }
-        val hwUr = slots.filter { it.value.hwUnderrunCount > 0 }
-            .mapValues { it.value.hwUnderrunCount }
-
-        _stats.value = AudioStats(
-            activePurposes = active,
-            underruns = underruns,
-            framesWritten = written,
-            maxWriteMs = maxWrite,
-            slowWrites = slowW,
-            maxGapMs = maxGap,
-            hwUnderruns = hwUr,
-        )
     }
 
     private fun startIdleChecker() {
@@ -330,21 +354,23 @@ class AudioPlayerImpl(private val audioManager: AudioManager) : AudioPlayer {
     }
 
     private fun checkIdlePurposes() {
-        var changed = false
-        for ((purpose, slot) in slots) {
-            if (!slot.isActive) continue
-            val idle = slot.idleMs()
-            val timeout = if (purpose == AudioPurpose.MEDIA) IDLE_TIMEOUT_MEDIA_MS else IDLE_TIMEOUT_OTHER_MS
-            if (idle >= timeout) {
-                slot.stop()
-                coordinator.onPurposeStopped(purpose)
-                Log.i(TAG, "Auto-stopped idle $purpose (idle ${idle}ms)")
-                DiagnosticLog.i("audio", "Auto-stopped idle $purpose (${idle}ms)")
-                changed = true
+        synchronized(slotLifecycleLock) {
+            var changed = false
+            for ((purpose, slot) in slots) {
+                if (!slot.isActive) continue
+                val idle = slot.idleMs()
+                val timeout = if (purpose == AudioPurpose.MEDIA) IDLE_TIMEOUT_MEDIA_MS else IDLE_TIMEOUT_OTHER_MS
+                if (idle >= timeout) {
+                    slot.stop()
+                    coordinator.onPurposeStopped(purpose)
+                    Log.i(TAG, "Auto-stopped idle $purpose (idle ${idle}ms)")
+                    DiagnosticLog.i("audio", "Auto-stopped idle $purpose (${idle}ms)")
+                    changed = true
+                }
             }
-        }
-        if (changed) {
-            updateStats()
+            if (changed) {
+                updateStats()
+            }
         }
     }
 }

--- a/app/src/main/java/com/openautolink/app/audio/AudioPurposeSlot.kt
+++ b/app/src/main/java/com/openautolink/app/audio/AudioPurposeSlot.kt
@@ -5,20 +5,19 @@ import android.media.AudioFormat
 import android.media.AudioTrack
 import android.os.Process
 import android.util.Log
+import com.openautolink.app.diagnostics.DiagnosticLog
 import com.openautolink.app.transport.AudioPurpose
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 /**
- * One AudioTrack + AudioRingBuffer per audio purpose.
- * Based on app_v1's production-proven approach:
- * - Ring buffer absorbs TCP/network jitter (500ms capacity)
- * - Dedicated URGENT_AUDIO thread drains at steady rate
- * - Pre-fill 80ms before calling AudioTrack.play()
- * - Non-blocking writes with residual tracking (no data loss)
- * - Steady 10ms write pacing from dedicated thread
+ * One AudioTrack plus a generation-owned bounded writer per audio purpose.
+ *
+ * - Pending PCM is capped at 250 ms; overflow discards oldest queued chunks.
+ * - AudioTrack.write() runs on a dedicated URGENT_AUDIO thread per purpose.
+ * - Stop/focus loss retire the exact writer generation before flushing.
+ * - Phone-ingress time, sink write time, and stale-drop totals are tracked
+ *   separately so uploaded logs reveal latency instead of merely throughput.
  */
 class AudioPurposeSlot(
     val purpose: AudioPurpose,
@@ -28,14 +27,16 @@ class AudioPurposeSlot(
 ) {
     companion object {
         private const val TAG = "AudioPurposeSlot"
+        private const val MAX_PENDING_AUDIO_MS = 250
+        private const val DROP_LOG_INTERVAL_NS = 2_000_000_000L
     }
 
     private var audioTrack: AudioTrack? = null
     private var aacDecoder: AacDecoder? = null
+    private val lifecycleLock = Any()
 
-    /** Per-purpose write thread — isolates blocking AudioTrack.write() calls
-     *  so one purpose stalling doesn't block others. */
-    private var writeExecutor: ExecutorService? = null
+    /** One bounded, generation-owned writer per active interval. */
+    @Volatile private var drain: BoundedAudioDrain? = null
 
     private val active = AtomicBoolean(false)
     private val released = AtomicBoolean(false)
@@ -43,6 +44,7 @@ class AudioPurposeSlot(
 
     val framesWritten = AtomicLong(0)
     val underrunCount = AtomicLong(0)
+    private val staleBytesDropped = AtomicLong(0)
 
     // Diagnostic counters
     @Volatile var startedAtNs: Long = 0L
@@ -52,6 +54,10 @@ class AudioPurposeSlot(
     @Volatile var totalWriteCalls: Long = 0L
     @Volatile var slowWriteCount: Long = 0L  // writes > 60ms
     @Volatile var hwUnderrunCount: Long = 0L
+    private val dropStatsLock = Any()
+    @Volatile private var lastDropLogNs: Long = 0L
+    @Volatile private var droppedChunksSinceLog: Long = 0L
+    @Volatile private var droppedBytesSinceLog: Long = 0L
 
     fun initialize() {
         if (released.get()) return
@@ -80,96 +86,184 @@ class AudioPurposeSlot(
     }
 
     fun start() {
-        if (released.get() || active.get()) return
-        val track = audioTrack ?: return
-        active.set(true)
-        startedAtNs = System.nanoTime()
-
-        // Create per-purpose write thread with URGENT_AUDIO priority
-        writeExecutor = Executors.newSingleThreadExecutor { r ->
-            Thread(r, "AudioWrite-$purpose").apply {
-                isDaemon = true
-            }
+        synchronized(lifecycleLock) {
+            if (released.get() || active.get()) return@synchronized
+            val track = audioTrack ?: return@synchronized
+            startedAtNs = System.nanoTime()
+            track.play()
+            startDrain(track)
+            active.set(true)
+            Log.d(TAG, "$purpose started (bounded per-purpose writer)")
         }
-
-        track.play()
-        Log.d(TAG, "$purpose started (per-purpose write thread)")
     }
 
     fun stop() {
-        pausedByFocusLoss.set(false)
-        if (!active.getAndSet(false)) return
-        startedAtNs = 0L
-        lastFeedTimeNs = 0L
-        writeExecutor?.shutdown()
-        writeExecutor = null
-        audioTrack?.pause()
-        audioTrack?.flush()
-        Log.d(TAG, "$purpose stopped")
+        synchronized(lifecycleLock) {
+            pausedByFocusLoss.set(false)
+            if (!active.getAndSet(false)) return@synchronized
+            startedAtNs = 0L
+            lastFeedTimeNs = 0L
+            retireDrain(reason = "stop")
+            Log.d(TAG, "$purpose stopped")
+        }
     }
 
     fun pause() {
-        if (!active.getAndSet(false)) return
-        pausedByFocusLoss.set(true)
-        audioTrack?.pause()
-        Log.d(TAG, "$purpose paused")
+        synchronized(lifecycleLock) {
+            if (!active.getAndSet(false)) return@synchronized
+            pausedByFocusLoss.set(true)
+            retireDrain(reason = "focus-loss")
+            Log.d(TAG, "$purpose paused")
+        }
     }
 
     fun resume() {
-        if (released.get() || active.get()) return
-        if (!pausedByFocusLoss.getAndSet(false)) return
-        val track = audioTrack ?: return
-        active.set(true)
-        track.play()
-        Log.d(TAG, "$purpose resumed")
+        synchronized(lifecycleLock) {
+            if (released.get() || active.get()) return@synchronized
+            if (!pausedByFocusLoss.getAndSet(false)) return@synchronized
+            val track = audioTrack ?: return@synchronized
+            startedAtNs = System.nanoTime()
+            lastFeedTimeNs = 0L
+            track.play()
+            startDrain(track)
+            active.set(true)
+            Log.d(TAG, "$purpose resumed")
+        }
     }
 
     val isPausedByFocus: Boolean get() = pausedByFocusLoss.get()
 
-    /**
-     * Submit PCM to per-purpose write thread. Non-blocking for the caller —
-     * the blocking AudioTrack.write() runs on this slot's own thread,
-     * so one purpose stalling doesn't block others.
-     */
+    /** Submit PCM without allowing stale pending audio to grow unbounded. */
     fun feedPcm(data: ByteArray) {
         if (!active.get()) return
-        val executor = writeExecutor ?: return
+        // This is the phone-ingress clock. Updating it inside the delayed writer
+        // made the idle timer wait for stale queued audio to finish first.
+        val nowNs = System.nanoTime()
+        val prevNs = lastFeedTimeNs
+        lastFeedTimeNs = nowNs
+        if (prevNs > 0) {
+            val gapMs = (nowNs - prevNs) / 1_000_000
+            if (gapMs > maxGapMs) maxGapMs = gapMs
+        }
 
-        executor.execute {
-            val track = audioTrack ?: return@execute
-            if (!active.get()) return@execute
+        val result = drain?.offer(data) ?: return
+        if (result.droppedChunks > 0) {
+            recordStaleDrop(
+                chunks = result.droppedChunks,
+                bytes = result.droppedBytes,
+                pendingBytes = result.queuedBytes,
+                source = "queue",
+                nowNs = nowNs,
+            )
+        }
+    }
 
-            // Set thread priority on first call (executor reuses one thread)
-            if (totalWriteCalls == 0L) {
-                Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO)
-            }
+    private fun startDrain(track: AudioTrack) {
+        val bytesPerSecond = sampleRate.toLong() * channelCount * 2L
+        val maxQueuedBytes = (bytesPerSecond * MAX_PENDING_AUDIO_MS / 1000L)
+            .coerceAtLeast(1L)
+            .coerceAtMost(Int.MAX_VALUE.toLong())
+            .toInt()
+        val newDrain = BoundedAudioDrain(
+            maxQueuedBytes = maxQueuedBytes,
+            threadName = "AudioWrite-$purpose",
+            onWorkerStart = { Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_AUDIO) },
+            onWrite = { pcm -> writePcm(track, pcm) },
+            onPause = { track.pause() },
+            onFlush = { track.flush() },
+        )
+        drain = newDrain
+        val generation = newDrain.start()
+        DiagnosticLog.i(
+            "audio",
+            "Audio drain started: purpose=$purpose generation=$generation latencyCapMs=$MAX_PENDING_AUDIO_MS",
+        )
+    }
 
-            // Measure inter-frame gap
-            val nowNs = System.nanoTime()
-            val prevNs = lastFeedTimeNs
-            lastFeedTimeNs = nowNs
-            if (prevNs > 0) {
-                val gapMs = (nowNs - prevNs) / 1_000_000
-                if (gapMs > maxGapMs) maxGapMs = gapMs
-            }
+    private fun writePcm(track: AudioTrack, data: ByteArray) {
+        val writeStartNs = System.nanoTime()
+        val writtenBytes = track.write(
+            data,
+            0,
+            data.size,
+            AudioTrack.WRITE_NON_BLOCKING,
+        )
+        val writeMs = (System.nanoTime() - writeStartNs) / 1_000_000
 
-            // Measure AudioTrack.write() blocking duration
-            val writeStartNs = System.nanoTime()
-            track.write(data, 0, data.size) // blocking — only blocks THIS purpose's thread
-            val writeMs = (System.nanoTime() - writeStartNs) / 1_000_000
+        totalWriteCalls++
+        if (writtenBytes > 0) {
+            framesWritten.addAndGet(writtenBytes.toLong() / (channelCount * 2))
+        }
+        if (writtenBytes < data.size) {
+            val staleBytes = if (writtenBytes > 0) data.size - writtenBytes else data.size
+            recordStaleDrop(
+                chunks = 1,
+                bytes = staleBytes,
+                pendingBytes = drain?.pendingBytes ?: 0,
+                source = "sink",
+                nowNs = System.nanoTime(),
+            )
+        }
+        if (writtenBytes < 0) {
+            DiagnosticLog.w("audio", "AudioTrack write failed: purpose=$purpose result=$writtenBytes")
+        }
+        if (writeMs > maxWriteMs) maxWriteMs = writeMs
+        if (writeMs > 60) slowWriteCount++
+        if (totalWriteCalls % 50 == 0L) {
+            try {
+                hwUnderrunCount = track.underrunCount.toLong()
+            } catch (_: Exception) {}
+        }
+    }
 
-            totalWriteCalls++
-            framesWritten.addAndGet(data.size.toLong() / (channelCount * 2))
-            if (writeMs > maxWriteMs) maxWriteMs = writeMs
-            if (writeMs > 60) slowWriteCount++
-
-            // Sample HW underrun count periodically
-            if (totalWriteCalls % 50 == 0L) {
-                try {
-                    hwUnderrunCount = track.underrunCount.toLong()
-                } catch (_: Exception) {}
+    private fun recordStaleDrop(
+        chunks: Int,
+        bytes: Int,
+        pendingBytes: Int,
+        source: String,
+        nowNs: Long,
+    ) {
+        if (bytes <= 0) return
+        staleBytesDropped.addAndGet(bytes.toLong())
+        synchronized(dropStatsLock) {
+            droppedChunksSinceLog += chunks
+            droppedBytesSinceLog += bytes
+            if (lastDropLogNs == 0L || nowNs - lastDropLogNs >= DROP_LOG_INTERVAL_NS) {
+                val message = "Dropped stale PCM: purpose=$purpose source=$source " +
+                    "chunks=$droppedChunksSinceLog bytes=$droppedBytesSinceLog " +
+                    "pending=$pendingBytes latencyCapMs=$MAX_PENDING_AUDIO_MS"
+                Log.w(TAG, message)
+                DiagnosticLog.w("audio", message)
+                droppedChunksSinceLog = 0
+                droppedBytesSinceLog = 0
+                lastDropLogNs = nowNs
             }
         }
+    }
+
+    private fun retireDrain(reason: String) {
+        val retiredDecoder = aacDecoder
+        aacDecoder = null
+        retiredDecoder?.stop()
+        val retired = drain
+        drain = null
+        val result = if (retired != null) {
+            retired.stopAndFlush()
+        } else {
+            audioTrack?.pause()
+            audioTrack?.flush()
+            null
+        }
+        if (result != null && result.droppedBytes > 0) {
+            staleBytesDropped.addAndGet(result.droppedBytes.toLong())
+        }
+        val message = "Audio stop applied: purpose=$purpose reason=$reason " +
+            "generation=${result?.generation ?: -1} " +
+            "droppedQueuedChunks=${result?.droppedChunks ?: 0} " +
+            "droppedQueuedBytes=${result?.droppedBytes ?: 0} " +
+            "aacRetired=${retiredDecoder != null} flushed=true"
+        Log.i(TAG, message)
+        DiagnosticLog.i("audio", message)
     }
 
     fun setVolume(volume: Float) {
@@ -182,29 +276,38 @@ class AudioPurposeSlot(
      */
     fun feedAac(data: ByteArray) {
         if (!active.get()) return
-        var decoder = aacDecoder
-        if (decoder == null) {
-            decoder = AacDecoder(sampleRate, channelCount) { pcm -> feedPcm(pcm) }
+        val existing = aacDecoder
+        val decoder = if (existing != null) {
+            existing
+        } else {
+            lateinit var decoder: AacDecoder
+            decoder = AacDecoder(sampleRate, channelCount) { pcm ->
+                if (aacDecoder === decoder && active.get()) feedPcm(pcm)
+            }
             aacDecoder = decoder
             decoder.start()
             Log.i(TAG, "$purpose: AAC decoder started (${sampleRate}Hz ${channelCount}ch)")
+            decoder
         }
         decoder.queueAacFrame(data)
     }
 
     fun release() {
-        if (released.getAndSet(true)) return
-        stop()
-        aacDecoder?.stop()
-        aacDecoder = null
-        writeExecutor?.shutdownNow()
-        writeExecutor = null
-        audioTrack?.release()
-        audioTrack = null
-        Log.d(TAG, "$purpose released")
+        synchronized(lifecycleLock) {
+            if (released.getAndSet(true)) return@synchronized
+            stop()
+            aacDecoder?.stop()
+            aacDecoder = null
+            drain = null
+            audioTrack?.release()
+            audioTrack = null
+            Log.d(TAG, "$purpose released")
+        }
     }
 
     val isActive: Boolean get() = active.get()
+    val pendingAudioBytes: Int get() = drain?.pendingBytes ?: 0
+    val staleAudioBytesDropped: Long get() = staleBytesDropped.get()
     val ringBufferAvailable: Int get() = 0
     val ringBufferCapacity: Int get() = 0
 

--- a/app/src/main/java/com/openautolink/app/audio/BoundedAudioDrain.kt
+++ b/app/src/main/java/com/openautolink/app/audio/BoundedAudioDrain.kt
@@ -1,0 +1,183 @@
+package com.openautolink.app.audio
+
+import java.util.ArrayDeque
+
+/**
+ * Single-writer audio drain with a bounded newest-data queue.
+ *
+ * [offer] never blocks the protocol callback. When the pending-byte budget is
+ * exceeded, the oldest queued chunks are discarded so a temporary slow
+ * AudioTrack cannot turn into seconds of stale playback. [stopAndFlush]
+ * invalidates the exact writer generation, clears pending chunks, waits for an
+ * in-flight write to leave the sink, and only then flushes it.
+ */
+internal class BoundedAudioDrain(
+    maxQueuedBytes: Int,
+    private val threadName: String,
+    private val onWrite: (ByteArray) -> Unit,
+    private val onPause: () -> Unit,
+    private val onFlush: () -> Unit,
+    private val onWorkerStart: () -> Unit = {},
+    private val onChunkClaimed: () -> Unit = {},
+    private val onChunkFinished: () -> Unit = {},
+) {
+    data class OfferResult(
+        val accepted: Boolean,
+        val droppedChunks: Int,
+        val droppedBytes: Int,
+        val queuedBytes: Int,
+    )
+
+    data class StopResult(
+        val generation: Long,
+        val droppedChunks: Int,
+        val droppedBytes: Int,
+    )
+
+    private data class Chunk(val generation: Long, val data: ByteArray)
+
+    private val byteBudget = maxQueuedBytes.coerceAtLeast(1)
+    private val monitor = Object()
+    private val writeLock = Any()
+    private val queue = ArrayDeque<Chunk>()
+
+    private var queuedBytes = 0
+    private var generation = 0L
+    private var running = false
+    private var worker: Thread? = null
+    private var claimedChunk: Chunk? = null
+    private var claimedWriting = false
+
+    val pendingBytes: Int
+        get() = synchronized(monitor) { queuedBytes }
+
+    val pendingChunks: Int
+        get() = synchronized(monitor) { queue.size }
+
+    fun start(): Long = synchronized(monitor) {
+        check(!running) { "audio drain is already running" }
+        generation++
+        val workerGeneration = generation
+        running = true
+        worker = Thread({ drainLoop(workerGeneration) }, threadName).apply {
+            isDaemon = true
+            start()
+        }
+        workerGeneration
+    }
+
+    fun offer(data: ByteArray): OfferResult = synchronized(monitor) {
+        if (!running || data.isEmpty()) {
+            return@synchronized OfferResult(
+                accepted = false,
+                droppedChunks = 0,
+                droppedBytes = 0,
+                queuedBytes = queuedBytes,
+            )
+        }
+
+        var droppedChunks = 0
+        var droppedBytes = 0
+        var queuedData = data
+        if (data.size > byteBudget) {
+            val trimBytes = data.size - byteBudget
+            queuedData = data.copyOfRange(trimBytes, data.size)
+            droppedChunks++
+            droppedBytes += trimBytes
+        }
+        while (queue.isNotEmpty() && queuedBytes + queuedData.size > byteBudget) {
+            val stale = queue.removeFirst()
+            queuedBytes -= stale.data.size
+            droppedChunks++
+            droppedBytes += stale.data.size
+        }
+
+        queue.addLast(Chunk(generation, queuedData))
+        queuedBytes += queuedData.size
+        monitor.notifyAll()
+        OfferResult(
+            accepted = true,
+            droppedChunks = droppedChunks,
+            droppedBytes = droppedBytes,
+            queuedBytes = queuedBytes,
+        )
+    }
+
+    fun stopAndFlush(): StopResult {
+        val result: StopResult
+        synchronized(monitor) {
+            val stoppedGeneration = generation
+            running = false
+            generation++
+            var droppedBytes = 0
+            for (chunk in queue) droppedBytes += chunk.data.size
+            val claimedDrop = claimedChunk?.takeIf {
+                !claimedWriting && it.generation == stoppedGeneration
+            }
+            result = StopResult(
+                generation = stoppedGeneration,
+                droppedChunks = queue.size + if (claimedDrop != null) 1 else 0,
+                droppedBytes = droppedBytes + (claimedDrop?.data?.size ?: 0),
+            )
+            queue.clear()
+            queuedBytes = 0
+            worker = null
+            monitor.notifyAll()
+        }
+
+        // Pause first. Android's streaming AudioTrack can otherwise leave a
+        // blocking write waiting for playback capacity while stop waits for the
+        // same write to release this lock.
+        onPause()
+        // Do not interrupt the worker here: it may already be inside the sink.
+        // notifyAll() above wakes a worker waiting for queued data.
+        // If a write already entered the sink, let it return before flushing.
+        // If it has not entered yet, its generation check below will reject it.
+        synchronized(writeLock) {
+            onFlush()
+        }
+        return result
+    }
+
+    private fun drainLoop(workerGeneration: Long) {
+        onWorkerStart()
+        while (true) {
+            val chunk = synchronized(monitor) {
+                while (running && generation == workerGeneration && queue.isEmpty()) {
+                    try {
+                        monitor.wait()
+                    } catch (_: InterruptedException) {
+                        // Re-check generation/running state below.
+                    }
+                }
+                if (!running || generation != workerGeneration) return
+                queue.removeFirst().also {
+                    queuedBytes -= it.data.size
+                    claimedChunk = it
+                    claimedWriting = false
+                }
+            }
+
+            try {
+                onChunkClaimed()
+                synchronized(writeLock) {
+                    val current = synchronized(monitor) {
+                        val valid = running && generation == workerGeneration &&
+                            chunk.generation == workerGeneration
+                        if (valid) claimedWriting = true
+                        valid
+                    }
+                    if (current) onWrite(chunk.data)
+                }
+            } finally {
+                synchronized(monitor) {
+                    if (claimedChunk === chunk) {
+                        claimedChunk = null
+                        claimedWriting = false
+                    }
+                }
+                onChunkFinished()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -16,6 +16,8 @@ import com.openautolink.app.transport.usb.UsbConnectionManager
 import com.openautolink.app.video.VideoFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -28,6 +30,7 @@ import kotlinx.coroutines.launch
 import java.io.InputStream
 import java.io.OutputStream
 import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * AA session backed by native aasdk via JNI.
@@ -86,6 +89,48 @@ class AasdkSession(
 
     private val _controlMessages = MutableSharedFlow<ControlMessage>(extraBufferCapacity = 64)
     val controlMessages: Flow<ControlMessage> = _controlMessages.asSharedFlow()
+
+    /**
+     * Native audio callbacks arrive on one io_service strand. The mailbox keeps
+     * only the latest lifecycle state for each of the five purposes, while a
+     * conflated wake signal preserves nonblocking delivery without an unbounded
+     * peer-driven queue.
+     */
+    private val pendingAudioLifecycle = AudioLifecycleMailbox()
+    private val audioLifecycleSignals = Channel<Unit>(Channel.CONFLATED)
+    private val audioLifecycleLock = Any()
+    private val audioLifecycleClosed = AtomicBoolean(false)
+    private val audioLifecycleJob: Job = scope.launch {
+        for (signal in audioLifecycleSignals) {
+            while (true) {
+                var rejected: ControlMessage? = null
+                val hadMessage = synchronized(audioLifecycleLock) {
+                    if (audioLifecycleClosed.get()) {
+                        false
+                    } else {
+                        val message = pendingAudioLifecycle.poll()
+                            ?: return@synchronized false
+                        if (!_controlMessages.tryEmit(message)) rejected = message
+                        true
+                    }
+                }
+                if (!hadMessage) break
+                rejected?.let { message ->
+                    val requeued = synchronized(audioLifecycleLock) {
+                        !audioLifecycleClosed.get() && pendingAudioLifecycle.offerFirst(message)
+                    }
+                    if (requeued) {
+                        delay(1)
+                    } else {
+                        com.openautolink.app.diagnostics.DiagnosticLog.e(
+                            "audio",
+                            "Audio lifecycle publication rejected: ${message::class.simpleName}",
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     private val _vehicleEnergyForecast = MutableStateFlow<VehicleEnergyForecast?>(null)
     val vehicleEnergyForecast: StateFlow<VehicleEnergyForecast?> =
@@ -577,6 +622,7 @@ class AasdkSession(
     }
 
     fun stop() {
+        closeAudioLifecycle()
         explicitStop = true
         OalLog.i(TAG, "Stopping aasdk session")
         cancelPendingReconnect("explicit stop")
@@ -887,14 +933,7 @@ class AasdkSession(
     }
 
     override fun onAudioFrame(data: ByteArray, purpose: Int, sampleRate: Int, channels: Int) {
-        val audioPurpose = when (purpose) {
-            0 -> AudioPurpose.MEDIA
-            1 -> AudioPurpose.NAVIGATION
-            2 -> AudioPurpose.ALERT
-            3 -> AudioPurpose.ASSISTANT
-            4 -> AudioPurpose.PHONE_CALL
-            else -> AudioPurpose.MEDIA
-        }
+        val audioPurpose = audioPurposeFromWire(purpose)
         val frame = AudioFrame(
             direction = AudioFrame.DIRECTION_PLAYBACK,
             data = data,
@@ -904,6 +943,70 @@ class AasdkSession(
         )
         _audioFrames.tryEmit(frame)
     }
+
+    override fun onAudioStart(purpose: Int, sampleRate: Int, channels: Int) {
+        queueAudioLifecycle(
+            ControlMessage.AudioStart(
+                purpose = audioPurposeFromWire(purpose),
+                sampleRate = sampleRate,
+                channels = channels,
+            ),
+        )
+    }
+
+    override fun onAudioStop(purpose: Int) {
+        queueAudioLifecycle(ControlMessage.AudioStop(audioPurposeFromWire(purpose)))
+    }
+
+    private fun queueAudioLifecycle(message: ControlMessage) {
+        val purpose = when (message) {
+            is ControlMessage.AudioStart -> message.purpose
+            is ControlMessage.AudioStop -> message.purpose
+            else -> return
+        }
+        val accepted = synchronized(audioLifecycleLock) {
+            if (audioLifecycleClosed.get()) {
+                false
+            } else {
+                pendingAudioLifecycle.offer(message)
+                if (audioLifecycleSignals.trySend(Unit).isFailure) {
+                    pendingAudioLifecycle.remove(message)
+                    false
+                } else {
+                    true
+                }
+            }
+        }
+        if (!accepted) {
+            com.openautolink.app.diagnostics.DiagnosticLog.e(
+                "audio",
+                "Audio lifecycle control rejected: ${message::class.simpleName} purpose=$purpose",
+            )
+        }
+    }
+
+    private fun closeAudioLifecycle() {
+        synchronized(audioLifecycleLock) {
+            if (!audioLifecycleClosed.compareAndSet(false, true)) return
+            pendingAudioLifecycle.clear()
+            audioLifecycleSignals.close()
+        }
+        audioLifecycleJob.cancel()
+        com.openautolink.app.diagnostics.DiagnosticLog.i(
+            "audio",
+            "Audio lifecycle delivery retired: pending=0 consumerCancelled=true",
+        )
+    }
+
+    private fun audioPurposeFromWire(purpose: Int): AudioPurpose =
+        when (purpose) {
+            0 -> AudioPurpose.MEDIA
+            1 -> AudioPurpose.NAVIGATION
+            2 -> AudioPurpose.ALERT
+            3 -> AudioPurpose.ASSISTANT
+            4 -> AudioPurpose.PHONE_CALL
+            else -> AudioPurpose.MEDIA
+        }
 
     override fun onMicRequest(open: Boolean) {
         scope.launch {

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
@@ -41,6 +41,12 @@ interface AasdkSessionCallback {
      */
     fun onAudioFrame(data: ByteArray, purpose: Int, sampleRate: Int, channels: Int)
 
+    /** Phone activated an audio sink purpose. */
+    fun onAudioStart(purpose: Int, sampleRate: Int, channels: Int)
+
+    /** Phone stopped an audio sink purpose; queued playback must be flushed. */
+    fun onAudioStop(purpose: Int)
+
     /**
      * Phone requests mic open/close.
      * @param open true = start capturing mic, false = stop

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AudioLifecycleMailbox.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AudioLifecycleMailbox.kt
@@ -1,0 +1,96 @@
+package com.openautolink.app.transport.aasdk
+
+import com.openautolink.app.transport.AudioPurpose
+import com.openautolink.app.transport.ControlMessage
+import java.util.ArrayDeque
+
+/**
+ * Bounded ordered mailbox for peer-driven audio lifecycle callbacks.
+ *
+ * Global arrival order is preserved across purposes. For each of the five
+ * purposes, only the latest two transitions are retained, capping the mailbox
+ * at ten entries while preserving the latest Stop -> Start or Start -> Stop.
+ */
+internal class AudioLifecycleMailbox(
+    private val maxPerPurpose: Int = 2,
+) {
+    private data class Entry(
+        val purpose: AudioPurpose,
+        val message: ControlMessage,
+    )
+
+    private val lock = Any()
+    private val queue = ArrayDeque<Entry>()
+
+    val size: Int
+        get() = synchronized(lock) { queue.size }
+
+    fun offer(message: ControlMessage) {
+        val purpose = message.audioPurpose() ?: return
+        synchronized(lock) {
+            // A repeated state supersedes its older payload (for example, a
+            // newer Start format) and belongs at its actual arrival position.
+            val reverse = queue.descendingIterator()
+            while (reverse.hasNext()) {
+                val pending = reverse.next()
+                if (pending.purpose == purpose && pending.message.javaClass == message.javaClass) {
+                    reverse.remove()
+                    break
+                }
+            }
+
+            queue.addLast(Entry(purpose, message))
+            while (queue.count { it.purpose == purpose } > maxPerPurpose) {
+                val forward = queue.iterator()
+                while (forward.hasNext()) {
+                    if (forward.next().purpose == purpose) {
+                        forward.remove()
+                        break
+                    }
+                }
+            }
+        }
+    }
+
+    fun poll(): ControlMessage? = synchronized(lock) {
+        queue.pollFirst()?.message
+    }
+
+    fun offerFirst(message: ControlMessage): Boolean {
+        val purpose = message.audioPurpose() ?: return false
+        return synchronized(lock) {
+            queue.addFirst(Entry(purpose, message))
+            while (queue.count { it.purpose == purpose } > maxPerPurpose) {
+                val forward = queue.iterator()
+                while (forward.hasNext()) {
+                    if (forward.next().purpose == purpose) {
+                        forward.remove()
+                        break
+                    }
+                }
+            }
+            queue.any { it.message === message }
+        }
+    }
+
+    fun remove(message: ControlMessage): Boolean = synchronized(lock) {
+        val iterator = queue.iterator()
+        while (iterator.hasNext()) {
+            if (iterator.next().message === message) {
+                iterator.remove()
+                return@synchronized true
+            }
+        }
+        false
+    }
+
+    fun clear() = synchronized(lock) {
+        queue.clear()
+    }
+
+    private fun ControlMessage.audioPurpose(): AudioPurpose? = when (this) {
+        is ControlMessage.AudioStart -> purpose
+        is ControlMessage.AudioStop -> purpose
+        else -> null
+    }
+}

--- a/app/src/test/java/com/openautolink/app/audio/AacDecoderTeardownContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/audio/AacDecoderTeardownContractTest.kt
@@ -1,0 +1,40 @@
+package com.openautolink.app.audio
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AacDecoderTeardownContractTest {
+
+    @Test
+    fun `stop joins decoder thread before releasing MediaCodec`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/audio/AacDecoder.kt",
+        ).readText()
+        val stop = source.substringAfter("fun stop()")
+            .substringBefore("fun queueAacFrame(")
+
+        val runningFalse = stop.indexOf("running = false")
+        val joinLoop = stop.indexOf("while (thread?.isAlive == true)")
+        val join = stop.indexOf("thread.join()")
+        val codecStop = stop.indexOf("codec?.stop()")
+        val codecRelease = stop.indexOf("codec?.release()")
+
+        assertTrue(runningFalse >= 0)
+        assertTrue(joinLoop > runningFalse)
+        assertTrue(join > joinLoop)
+        assertTrue(codecStop > join)
+        assertTrue(codecRelease > codecStop)
+        assertTrue(stop.contains("Thread.currentThread().interrupt()"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        error("Could not locate $path")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/audio/AudioLifecycleWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/audio/AudioLifecycleWiringContractTest.kt
@@ -1,0 +1,101 @@
+package com.openautolink.app.audio
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioLifecycleWiringContractTest {
+
+    @Test
+    fun `native media start and stop reach Kotlin control messages`() {
+        val callback = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt",
+        ).readText()
+        val kotlinSession = projectFile(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        ).readText()
+        val nativeHeader = projectFile("app/src/main/cpp/jni_session.h").readText()
+        val nativeSession = projectFile("app/src/main/cpp/jni_session.cpp").readText()
+        val handlers = projectFile("app/src/main/cpp/jni_channel_handlers.cpp").readText()
+        val manager = projectFile(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        ).readText()
+
+        assertTrue(callback.contains("fun onAudioStart(purpose: Int, sampleRate: Int, channels: Int)"))
+        assertTrue(callback.contains("fun onAudioStop(purpose: Int)"))
+
+        assertTrue(nativeHeader.contains("jmethodID onAudioStart"))
+        assertTrue(nativeHeader.contains("jmethodID onAudioStop"))
+        assertTrue(nativeHeader.contains("void dispatchAudioStart("))
+        assertTrue(nativeHeader.contains("void dispatchAudioStop("))
+        assertTrue(nativeSession.contains("GetMethodID(cbClass, \"onAudioStart\", \"(III)V\")"))
+        assertTrue(nativeSession.contains("GetMethodID(cbClass, \"onAudioStop\", \"(I)V\")"))
+        assertTrue(nativeSession.contains("CallVoidMethod(callbackRef_, cbMethods_.onAudioStart"))
+        assertTrue(nativeSession.contains("CallVoidMethod(callbackRef_, cbMethods_.onAudioStop"))
+
+        val startHandler = handlers.substringAfter("onMediaChannelStartIndication(")
+            .substringBefore("onMediaChannelStopIndication(")
+        val stopHandler = handlers.substringAfter("onMediaChannelStopIndication(")
+            .substringBefore("onMediaWithTimestampIndication(")
+        assertTrue(startHandler.contains("session_.dispatchAudioStart("))
+        assertTrue(stopHandler.contains("session_.dispatchAudioStop(purposeFromType())"))
+
+        assertTrue(kotlinSession.contains("override fun onAudioStart("))
+        assertTrue(kotlinSession.contains("ControlMessage.AudioStart("))
+        assertTrue(kotlinSession.contains("override fun onAudioStop(purpose: Int)"))
+        assertTrue(kotlinSession.contains("ControlMessage.AudioStop("))
+        val audioCallbacks = kotlinSession.substringAfter("override fun onAudioStart(")
+            .substringBefore("override fun onMicRequest(")
+        assertTrue(kotlinSession.contains("Channel<Unit>(Channel.CONFLATED)"))
+        assertTrue(kotlinSession.contains("pendingAudioLifecycle = AudioLifecycleMailbox()"))
+        assertTrue(kotlinSession.contains("pendingAudioLifecycle.poll()"))
+        assertTrue(kotlinSession.contains("pendingAudioLifecycle.offer(message)"))
+        assertTrue(kotlinSession.contains("pendingAudioLifecycle.remove(message)"))
+        assertTrue(kotlinSession.contains("audioLifecycleClosed = AtomicBoolean(false)"))
+        assertTrue(kotlinSession.contains("audioLifecycleJob.cancel()"))
+        assertTrue(kotlinSession.contains("pendingAudioLifecycle.clear()"))
+        assertTrue(kotlinSession.contains("if (audioLifecycleClosed.get())"))
+        assertTrue(!kotlinSession.contains("Channel.UNLIMITED"))
+        assertTrue(kotlinSession.contains("for (signal in audioLifecycleSignals)"))
+        val lifecycleConsumer = kotlinSession.substringAfter("private val audioLifecycleJob: Job")
+            .substringBefore("private val _vehicleEnergyForecast")
+        assertTrue(lifecycleConsumer.contains("synchronized(audioLifecycleLock)"))
+        assertTrue(lifecycleConsumer.contains("_controlMessages.tryEmit(message)"))
+        assertTrue(lifecycleConsumer.contains("pendingAudioLifecycle.offerFirst(message)"))
+        assertTrue(lifecycleConsumer.contains("delay(1)"))
+        assertTrue(!lifecycleConsumer.contains("_controlMessages.emit(message)"))
+        assertTrue(
+            "Publication and final close must share one non-suspending lock boundary",
+            lifecycleConsumer.indexOf("synchronized(audioLifecycleLock)") <
+                lifecycleConsumer.indexOf("_controlMessages.tryEmit(message)"),
+        )
+        val finalStop = kotlinSession.substringAfter("fun stop()")
+            .substringBefore("fun forceReconnect")
+        assertTrue(finalStop.contains("closeAudioLifecycle()"))
+        assertTrue(
+            "Final teardown must retire lifecycle delivery before stopping transports",
+            finalStop.indexOf("closeAudioLifecycle()") < finalStop.indexOf("_tcpConnector?.stop()"),
+        )
+        assertTrue(audioCallbacks.contains("queueAudioLifecycle("))
+        assertTrue(
+            "Native audio lifecycle callbacks share one strand; separate coroutine launches can reorder them",
+            !audioCallbacks.contains("scope.launch"),
+        )
+        assertTrue(audioCallbacks.contains("Audio lifecycle control rejected:"))
+
+        assertTrue(manager.contains("is ControlMessage.AudioStart ->"))
+        assertTrue(manager.contains("_audioPlayer?.startPurpose("))
+        assertTrue(manager.contains("is ControlMessage.AudioStop ->"))
+        assertTrue(manager.contains("_audioPlayer?.stopPurpose(message.purpose)"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        error("Could not locate $path")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/audio/AudioPurposeSlotWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/audio/AudioPurposeSlotWiringContractTest.kt
@@ -1,0 +1,118 @@
+package com.openautolink.app.audio
+
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioPurposeSlotWiringContractTest {
+
+    @Test
+    fun `purpose slot bounds pending latency and records ingress before queueing`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/audio/AudioPurposeSlot.kt",
+        ).readText()
+
+        assertTrue(source.contains("MAX_PENDING_AUDIO_MS = 250"))
+        assertTrue(source.contains("BoundedAudioDrain("))
+        assertTrue(source.contains("maxQueuedBytes ="))
+
+        val feed = source.substringAfter("fun feedPcm(data: ByteArray)")
+            .substringBefore("fun setVolume(")
+        assertTrue(feed.contains("lastFeedTimeNs = nowNs"))
+        assertTrue(feed.contains("drain?.offer(data)"))
+        assertTrue(
+            "Idle time must measure phone ingress, not delayed AudioTrack writes",
+            feed.indexOf("lastFeedTimeNs = nowNs") < feed.indexOf("drain?.offer(data)"),
+        )
+        assertTrue(feed.contains("Dropped stale PCM:"))
+        assertTrue(source.contains("AudioTrack.WRITE_NON_BLOCKING"))
+        assertTrue(source.contains("writtenBytes < data.size"))
+        assertTrue(source.contains("recordStaleDrop("))
+        assertTrue(source.contains("val pendingAudioBytes:"))
+        assertTrue(source.contains("val staleAudioBytesDropped:"))
+
+        val player = projectFile(
+            "app/src/main/java/com/openautolink/app/audio/AudioPlayerImpl.kt",
+        ).readText()
+        assertTrue(player.contains("pending=${'$'}{slot.pendingAudioBytes}"))
+        assertTrue(player.contains("staleDropped=${'$'}{slot.staleAudioBytesDropped}"))
+        assertTrue(player.contains("private val slotLifecycleLock = Any()"))
+        val playerFrame = player.substringAfter("override fun onAudioFrame(")
+            .substringBefore("override fun startPurpose(")
+        val playerStart = player.substringAfter("override fun startPurpose(")
+            .substringBefore("override fun stopPurpose(")
+        val playerStop = player.substringAfter("override fun stopPurpose(")
+            .substringBefore("override fun setVolume(")
+        assertTrue(playerFrame.contains("synchronized(slotLifecycleLock)"))
+        assertTrue(playerFrame.contains("val slot = resolvePlaybackSlot(frame) ?: return@synchronized"))
+        assertTrue(playerFrame.contains("slot.feedPcm(frame.data)"))
+        assertTrue(
+            "Frame submission must stay inside the same owner lock as slot resolution",
+            playerFrame.indexOf("synchronized(slotLifecycleLock)") <
+                playerFrame.indexOf("val slot = resolvePlaybackSlot(frame)") &&
+                playerFrame.indexOf("val slot = resolvePlaybackSlot(frame)") <
+                playerFrame.indexOf("slot.feedPcm(frame.data)"),
+        )
+        val resolver = player.substringAfter("private fun resolvePlaybackSlot(")
+            .substringBefore("override fun startPurpose(")
+        assertTrue(resolver.contains("synchronized(slotLifecycleLock)"))
+        assertTrue(resolver.contains("explicitStopTimes[frame.purpose]"))
+        assertTrue(resolver.contains("startPurpose(frame.purpose"))
+        assertTrue(playerStart.contains("synchronized(slotLifecycleLock)"))
+        assertTrue(playerStop.contains("synchronized(slotLifecycleLock)"))
+    }
+
+    @Test
+    fun `stop and focus loss retire the exact drain before playback can resume`() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/audio/AudioPurposeSlot.kt",
+        ).readText()
+
+        val stop = source.substringAfter("fun stop()")
+            .substringBefore("fun pause()")
+        val pause = source.substringAfter("fun pause()")
+            .substringBefore("fun resume()")
+        val resume = source.substringAfter("fun resume()")
+            .substringBefore("val isPausedByFocus")
+
+        assertTrue(stop.contains("retireDrain(reason = \"stop\")"))
+        assertTrue(pause.contains("retireDrain(reason = \"focus-loss\")"))
+        assertTrue(resume.contains("startDrain(track)"))
+        assertTrue(source.contains("private val lifecycleLock = Any()"))
+        assertTrue(source.contains("@Volatile private var drain:"))
+        val start = source.substringAfter("fun start()")
+            .substringBefore("fun stop()")
+        assertTrue(start.contains("synchronized(lifecycleLock)"))
+        assertTrue(stop.contains("synchronized(lifecycleLock)"))
+        assertTrue(
+            "The slot must not accept frames until its exact writer exists",
+            start.indexOf("startDrain(track)") < start.indexOf("active.set(true)"),
+        )
+        assertTrue(source.contains("Audio stop applied:"))
+        assertTrue(source.contains("flushed=true"))
+        val aacFeed = source.substringAfter("fun feedAac(data: ByteArray)")
+            .substringBefore("fun release()")
+        assertTrue(aacFeed.contains("aacDecoder === decoder && active.get()"))
+        val retire = source.substringAfter("private fun retireDrain(reason: String)")
+            .substringBefore("fun setVolume(")
+        assertTrue(retire.contains("val retiredDecoder = aacDecoder"))
+        assertTrue(retire.indexOf("aacDecoder = null") < retire.indexOf("retiredDecoder?.stop()"))
+        assertTrue(retire.contains("aacRetired=${'$'}{retiredDecoder != null}"))
+        val drain = projectFile(
+            "app/src/main/java/com/openautolink/app/audio/BoundedAudioDrain.kt",
+        ).readText()
+        val drainStop = drain.substringAfter("fun stopAndFlush()")
+            .substringBefore("private fun drainLoop")
+        assertTrue(drainStop.indexOf("onPause()") < drainStop.indexOf("synchronized(writeLock)"))
+    }
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        error("Could not locate $path")
+    }
+}

--- a/app/src/test/java/com/openautolink/app/audio/BoundedAudioDrainTest.kt
+++ b/app/src/test/java/com/openautolink/app/audio/BoundedAudioDrainTest.kt
@@ -1,0 +1,200 @@
+package com.openautolink.app.audio
+
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BoundedAudioDrainTest {
+
+    @Test
+    fun `empty chunks are rejected without consuming queue entries`() {
+        val drain = BoundedAudioDrain(
+            maxQueuedBytes = 8,
+            threadName = "bounded-audio-empty-test",
+            onWrite = {},
+            onPause = {},
+            onFlush = {},
+        )
+
+        drain.start()
+        repeat(1_000) {
+            assertFalse(drain.offer(ByteArray(0)).accepted)
+        }
+        assertEquals(0, drain.pendingBytes)
+        assertEquals(0, drain.pendingChunks)
+        drain.stopAndFlush()
+    }
+
+    @Test
+    fun `overflow keeps newest queued audio instead of replaying stale chunks`() {
+        val firstWriteEntered = CountDownLatch(1)
+        val releaseFirstWrite = CountDownLatch(1)
+        val allExpectedWrites = CountDownLatch(3)
+        val writes = Collections.synchronizedList(mutableListOf<Int>())
+        val drain = BoundedAudioDrain(
+            maxQueuedBytes = 8,
+            threadName = "bounded-audio-overflow-test",
+            onWrite = { data ->
+                writes += data.first().toInt()
+                allExpectedWrites.countDown()
+                if (data.first() == 1.toByte()) {
+                    firstWriteEntered.countDown()
+                    assertTrue(releaseFirstWrite.await(2, TimeUnit.SECONDS))
+                }
+            },
+            onPause = {},
+            onFlush = {},
+        )
+
+        drain.start()
+        drain.offer(byteArrayOf(1, 1, 1, 1))
+        assertTrue(firstWriteEntered.await(2, TimeUnit.SECONDS))
+
+        drain.offer(byteArrayOf(2, 2, 2, 2))
+        drain.offer(byteArrayOf(3, 3, 3, 3))
+        val overflow = drain.offer(byteArrayOf(4, 4, 4, 4))
+
+        assertEquals(1, overflow.droppedChunks)
+        assertEquals(4, overflow.droppedBytes)
+        assertEquals(8, overflow.queuedBytes)
+
+        releaseFirstWrite.countDown()
+        assertTrue(allExpectedWrites.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(1, 3, 4), writes.toList())
+
+        drain.stopAndFlush()
+    }
+
+    @Test
+    fun `oversized chunk keeps only its newest bytes within the budget`() {
+        val firstWriteEntered = CountDownLatch(1)
+        val releaseFirstWrite = CountDownLatch(1)
+        val secondWriteCompleted = CountDownLatch(1)
+        val writes = Collections.synchronizedList(mutableListOf<ByteArray>())
+        val drain = BoundedAudioDrain(
+            maxQueuedBytes = 8,
+            threadName = "bounded-audio-oversized-test",
+            onWrite = { data ->
+                writes += data
+                if (writes.size == 1) {
+                    firstWriteEntered.countDown()
+                    assertTrue(releaseFirstWrite.await(2, TimeUnit.SECONDS))
+                } else {
+                    secondWriteCompleted.countDown()
+                }
+            },
+            onPause = {},
+            onFlush = {},
+        )
+
+        drain.start()
+        drain.offer(byteArrayOf(99))
+        assertTrue(firstWriteEntered.await(2, TimeUnit.SECONDS))
+        val result = drain.offer(ByteArray(12) { it.toByte() })
+
+        assertEquals(1, result.droppedChunks)
+        assertEquals(4, result.droppedBytes)
+        assertEquals(8, result.queuedBytes)
+
+        releaseFirstWrite.countDown()
+        assertTrue(secondWriteCompleted.await(2, TimeUnit.SECONDS))
+        assertArrayEquals(ByteArray(8) { (it + 4).toByte() }, writes[1])
+        drain.stopAndFlush()
+    }
+
+    @Test
+    fun `stop flushes after in flight write and queued audio cannot cross generation`() {
+        val firstWriteEntered = CountDownLatch(1)
+        val releaseFirstWrite = CountDownLatch(1)
+        val freshWriteCompleted = CountDownLatch(1)
+        val pauseApplied = CountDownLatch(1)
+        val writes = Collections.synchronizedList(mutableListOf<Int>())
+        val events = Collections.synchronizedList(mutableListOf<String>())
+        val drain = BoundedAudioDrain(
+            maxQueuedBytes = 16,
+            threadName = "bounded-audio-stop-test",
+            onWrite = { data ->
+                val id = data.first().toInt()
+                writes += id
+                events += "write-$id"
+                if (id == 1) {
+                    firstWriteEntered.countDown()
+                    assertTrue(releaseFirstWrite.await(2, TimeUnit.SECONDS))
+                } else if (id == 3) {
+                    freshWriteCompleted.countDown()
+                }
+            },
+            onPause = {
+                events += "pause"
+                pauseApplied.countDown()
+            },
+            onFlush = { events += "flush" },
+        )
+
+        val firstGeneration = drain.start()
+        drain.offer(byteArrayOf(1, 1, 1, 1))
+        assertTrue(firstWriteEntered.await(2, TimeUnit.SECONDS))
+        drain.offer(byteArrayOf(2, 2, 2, 2))
+
+        var stopResult: BoundedAudioDrain.StopResult? = null
+        val stopper = Thread {
+            stopResult = drain.stopAndFlush()
+        }.also { it.start() }
+
+        assertTrue("stop must pause the sink before waiting for its write", pauseApplied.await(2, TimeUnit.SECONDS))
+        assertTrue("stop must wait until the in-flight write can be flushed", stopper.isAlive)
+        releaseFirstWrite.countDown()
+        stopper.join(2_000)
+        assertFalse("stop must complete after the in-flight write returns", stopper.isAlive)
+
+        assertEquals(1, stopResult?.droppedChunks)
+        assertEquals(4, stopResult?.droppedBytes)
+        assertEquals(listOf(1), writes.toList())
+        assertEquals(listOf("write-1", "pause", "flush"), events.toList())
+
+        val secondGeneration = drain.start()
+        assertTrue(secondGeneration > firstGeneration)
+        drain.offer(byteArrayOf(3, 3, 3, 3))
+        assertTrue(freshWriteCompleted.await(2, TimeUnit.SECONDS))
+        assertEquals(listOf(1, 3), writes.toList())
+
+        drain.stopAndFlush()
+    }
+
+    @Test
+    fun `stop accounts for chunk claimed before sink lock`() {
+        val chunkClaimed = CountDownLatch(1)
+        val releaseClaim = CountDownLatch(1)
+        val chunkFinished = CountDownLatch(1)
+        val writes = Collections.synchronizedList(mutableListOf<Int>())
+        val drain = BoundedAudioDrain(
+            maxQueuedBytes = 8,
+            threadName = "bounded-audio-claimed-stop-test",
+            onWrite = { writes += it.first().toInt() },
+            onPause = {},
+            onFlush = {},
+            onChunkClaimed = {
+                chunkClaimed.countDown()
+                assertTrue(releaseClaim.await(2, TimeUnit.SECONDS))
+            },
+            onChunkFinished = { chunkFinished.countDown() },
+        )
+
+        drain.start()
+        drain.offer(byteArrayOf(7, 7, 7, 7))
+        assertTrue(chunkClaimed.await(2, TimeUnit.SECONDS))
+
+        val result = drain.stopAndFlush()
+        assertEquals(1, result.droppedChunks)
+        assertEquals(4, result.droppedBytes)
+
+        releaseClaim.countDown()
+        assertTrue(chunkFinished.await(2, TimeUnit.SECONDS))
+        assertTrue(writes.isEmpty())
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/aasdk/AudioLifecycleMailboxTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/aasdk/AudioLifecycleMailboxTest.kt
@@ -1,0 +1,108 @@
+package com.openautolink.app.transport.aasdk
+
+import com.openautolink.app.transport.AudioPurpose
+import com.openautolink.app.transport.ControlMessage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioLifecycleMailboxTest {
+
+    @Test
+    fun `poll preserves lifecycle order across purposes`() {
+        val mailbox = AudioLifecycleMailbox()
+        val mediaStart = start(AudioPurpose.MEDIA, 48_000, 2)
+        val navStart = start(AudioPurpose.NAVIGATION, 16_000, 1)
+        val mediaStop = ControlMessage.AudioStop(AudioPurpose.MEDIA)
+
+        mailbox.offer(mediaStart)
+        mailbox.offer(navStart)
+        mailbox.offer(mediaStop)
+
+        assertEquals(listOf(mediaStart, navStart, mediaStop), drain(mailbox))
+    }
+
+    @Test
+    fun `mailbox keeps latest transition pair per purpose and remains globally bounded`() {
+        val mailbox = AudioLifecycleMailbox()
+        for (purpose in AudioPurpose.entries) {
+            mailbox.offer(start(purpose, 1, 1))
+            mailbox.offer(ControlMessage.AudioStop(purpose))
+            mailbox.offer(start(purpose, 2, 1))
+        }
+
+        assertTrue(mailbox.size <= AudioPurpose.entries.size * 2)
+        val messages = drain(mailbox)
+        for (purpose in AudioPurpose.entries) {
+            val perPurpose = messages.filter { it.purpose() == purpose }
+            assertEquals(2, perPurpose.size)
+            assertTrue(perPurpose[0] is ControlMessage.AudioStop)
+            assertEquals(start(purpose, 2, 1), perPurpose[1])
+        }
+    }
+
+    @Test
+    fun `new duplicate moves to its actual arrival position`() {
+        val mailbox = AudioLifecycleMailbox()
+        val oldMediaStart = start(AudioPurpose.MEDIA, 1, 1)
+        val navStart = start(AudioPurpose.NAVIGATION, 1, 1)
+        val newMediaStart = start(AudioPurpose.MEDIA, 2, 1)
+
+        mailbox.offer(oldMediaStart)
+        mailbox.offer(navStart)
+        mailbox.offer(newMediaStart)
+
+        assertEquals(listOf(navStart, newMediaStart), drain(mailbox))
+    }
+
+    @Test
+    fun `remove withdraws only the exact rejected message`() {
+        val mailbox = AudioLifecycleMailbox()
+        val mediaStop = ControlMessage.AudioStop(AudioPurpose.MEDIA)
+        val mediaStart = start(AudioPurpose.MEDIA, 48_000, 2)
+        mailbox.offer(mediaStop)
+        mailbox.offer(mediaStart)
+
+        assertTrue(mailbox.remove(mediaStart))
+        assertEquals(listOf(mediaStop), drain(mailbox))
+    }
+
+    @Test
+    fun `clear drops every pending lifecycle transition`() {
+        val mailbox = AudioLifecycleMailbox()
+        mailbox.offer(start(AudioPurpose.MEDIA, 48_000, 2))
+        mailbox.offer(ControlMessage.AudioStop(AudioPurpose.NAVIGATION))
+
+        mailbox.clear()
+
+        assertEquals(0, mailbox.size)
+        assertEquals(null, mailbox.poll())
+    }
+
+    @Test
+    fun `rejected publication can be retried at the front without reordering`() {
+        val mailbox = AudioLifecycleMailbox()
+        val mediaStart = start(AudioPurpose.MEDIA, 48_000, 2)
+        val navStart = start(AudioPurpose.NAVIGATION, 16_000, 1)
+        mailbox.offer(mediaStart)
+        mailbox.offer(navStart)
+
+        val claimed = mailbox.poll()
+        mailbox.offerFirst(claimed!!)
+
+        assertEquals(listOf(mediaStart, navStart), drain(mailbox))
+    }
+
+    private fun start(purpose: AudioPurpose, rate: Int, channels: Int) =
+        ControlMessage.AudioStart(purpose, rate, channels)
+
+    private fun drain(mailbox: AudioLifecycleMailbox): List<ControlMessage> = buildList {
+        while (true) add(mailbox.poll() ?: break)
+    }
+
+    private fun ControlMessage.purpose(): AudioPurpose = when (this) {
+        is ControlMessage.AudioStart -> purpose
+        is ControlMessage.AudioStop -> purpose
+        else -> error("not an audio lifecycle message")
+    }
+}


### PR DESCRIPTION
## Summary

- dispatch native audio Start/Stop events through JNI into the existing player lifecycle
- replace the unbounded PCM executor with a generation-owned 250 ms newest-audio queue
- use nonblocking AudioTrack writes and account partial/unwritten PCM as stale drops
- preserve Start/Stop transitions in a bounded two-event-per-purpose lifecycle mailbox
- synchronously pause, retire, and flush the exact writer on Stop or audio-focus loss
- serialize slot replacement/start/stop across lifecycle and frame collectors
- expose `pending` and `staleDropped` runtime evidence for the next road upload

## Incident evidence

Car 0.1.472 accumulated 44.5 seconds of stale PCM while AA metadata and controls stayed current. Native Stop events at 16:24:51 and 16:25:14 never reached Kotlin; playback retired only after the old queue drained plus the idle timeout.

Closes #111

## Verification

- strict RED/GREEN tests for bounded PCM, claimed-stop accounting, owner races, globally ordered lifecycle delivery, teardown fencing, and AAC decoder retirement
- focused audio/lifecycle tests: 15 passed, 0 failed/errors/skipped
- full `:app:testDebugUnitTest --rerun-tasks`: 449 passed, 0 failed/errors/skipped
- `:app:externalNativeBuildDebug --rerun-tasks`: arm64-v8a and x86_64 passed
- added-line security scan: no findings

## Runtime status

This is a shipped-code attempt pending vehicle verification. The next upload must show `Audio stop (type=0)` followed immediately by `Audio stop applied: purpose=MEDIA`, with periodic `pending=` remaining sub-second and audible tracks matching the AA UI.
