### PR TITLE
fix(wpp): enforce selected interface end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ The phone is the access point; the car is a client. Single-phone optimized — s
 
 ## Features
 
-- **Wireless (WPP)** — Bluetooth handshake plus Google's WiFi Projection Protocol, the path factory head units use. Required on Android Auto 17.4+
+- **Wireless (WPP)** — Bluetooth handshake plus Google's WiFi Projection Protocol, the path factory head units use. Required on Android Auto 17.4+. Advertisement, discovery, and transport are locked to one explicitly selected head-unit interface (default: GM `ap_br_swlan0`) with no cross-interface fallback
 - **Car Hotspot mode** — phones join the car's built-in WiFi like home WiFi. Multi-phone support, no hotspot toggling (Android Auto 17.3 and older)
-- **Phone Hotspot mode** — phone is the AP, car is the client. Simpler single-phone fallback for cars without a built-in hotspot
+- **Phone Hotspot mode** — phone is the AP, car is the client. Legacy single-phone fallback for Android Auto 17.3 and older; stock 17.4+ WPP cannot make a phone join its own hotspot
 - **USB cable support** — AOA v2 direct connection for wired setups
 - **aasdk v1.6 native protocol** — battle-tested C++ AA library via JNI, not a reimplementation
 - **EV battery data in Android Auto** — battery %, range, fuel type, charge port forwarded from VHAL into AA. Google Maps shows battery level alongside navigation

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -71,15 +71,6 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         val WPP_BSSID = stringPreferencesKey("wpp_bssid")
 
         /**
-         * Optional manual override for the address advertised to the phone.
-         *
-         * A connected car has several interfaces up at once and auto-detection
-         * can pick one the phone cannot route to (seen in-vehicle: advertised
-         * 172.16.101.100 while the phone was on 10.2.110.109). Blank = auto.
-         */
-        val WPP_LOCAL_IP = stringPreferencesKey("wpp_local_ip")
-
-        /**
          * Network interface whose address is advertised to the phone.
          *
          * Defaults to [DEFAULT_WPP_AP_INTERFACE], the bridged SoftAP on AAOS.
@@ -460,14 +451,12 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         prefs[WPP_CHANNEL_MHZ] ?: 0
     }
 
-    /** Manual head-unit IP for WPP, or blank to auto-detect. */
-    val wppLocalIp: Flow<String> = dataStore.data.map { prefs ->
-        prefs[WPP_LOCAL_IP] ?: ""
-    }
-
     /** Interface whose IPv4 is advertised to the phone. */
     val wppApInterface: Flow<String> = dataStore.data.map { prefs ->
-        prefs[WPP_AP_INTERFACE] ?: DEFAULT_WPP_AP_INTERFACE
+        prefs[WPP_AP_INTERFACE]
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+            ?: DEFAULT_WPP_AP_INTERFACE
     }
 
     val directTransport: Flow<String> = dataStore.data.map { prefs ->
@@ -629,16 +618,14 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         dataStore.edit { it[WPP_BSSID] = bssid.trim() }
     }
 
-    suspend fun setWppLocalIp(ip: String) {
-        dataStore.edit { it[WPP_LOCAL_IP] = ip.trim() }
-    }
-
     suspend fun setWppChannelMhz(mhz: Int) {
         dataStore.edit { it[WPP_CHANNEL_MHZ] = mhz }
     }
 
     suspend fun setWppApInterface(name: String) {
-        dataStore.edit { it[WPP_AP_INTERFACE] = name.trim() }
+        dataStore.edit {
+            it[WPP_AP_INTERFACE] = name.trim().ifEmpty { DEFAULT_WPP_AP_INTERFACE }
+        }
     }
 
     suspend fun setHotspotPassword(password: String) {

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -186,6 +186,7 @@ class SettingsReceiver : BroadcastReceiver() {
                     micSourcePreference = prefs.micSource.first(),
                     scalingMode = prefs.videoScalingMode.first(),
                     directTransport = prefs.directTransport.first(),
+                    wppInterfaceName = prefs.wppApInterface.first(),
                     hotspotSsid = prefs.hotspotSsid.first(),
                     hotspotPassword = prefs.hotspotPassword.first(),
                     videoAutoNegotiate = prefs.videoAutoNegotiate.first(),

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -138,15 +138,40 @@ class SessionManager(
     private val wirelessAdmissionLock = Any()
     private var wirelessSessionAdmission:
         com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token? = null
+    /** Serializes lifecycle interruption with the final WPP admission decision. */
+    private val transportStartInterruptLock = Any()
+    private var transportStartInterruptGeneration = 0L
+
+    private fun currentTransportStartGeneration(): Long =
+        synchronized(transportStartInterruptLock) { transportStartInterruptGeneration }
+
+    private fun interruptPendingTransportStart(reason: String) {
+        synchronized(transportStartInterruptLock) { transportStartInterruptGeneration += 1L }
+        aasdkSession?.cancelPendingWppTransportStart(reason)
+    }
+
+    private fun installWirelessSessionAdmissionIfCurrent(
+        transportMode: String,
+        wppInterfaceName: String,
+        expectedGeneration: Long,
+    ): com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token? =
+        synchronized(transportStartInterruptLock) {
+            if (transportStartInterruptGeneration != expectedGeneration) null
+            else installWirelessSessionAdmission(transportMode, wppInterfaceName)
+        }
 
     private fun installWirelessSessionAdmission(
         transportMode: String,
+        wppInterfaceName: String,
     ): com.openautolink.app.transport.bluetooth.WppSessionAdmission.Token =
         synchronized(wirelessAdmissionLock) {
             wirelessSessionAdmission?.let {
                 AaWirelessBtControl.clearSessionOwner(it)
             }
-            AaWirelessBtControl.installSessionOwner(transportMode).also { token ->
+            AaWirelessBtControl.installSessionOwner(
+                transportMode,
+                wppInterfaceName.takeIf { transportMode == AppPreferences.DIRECT_TRANSPORT_WPP },
+            ).also { token ->
                 wirelessSessionAdmission = token
             }
         }
@@ -1038,6 +1063,7 @@ class SessionManager(
         micSourcePreference: String = "car",
         scalingMode: String = "letterbox",
         directTransport: String = "hotspot",
+        wppInterfaceName: String = AppPreferences.DEFAULT_WPP_AP_INTERFACE,
         hotspotSsid: String = "",
         hotspotPassword: String = "",
         videoAutoNegotiate: Boolean = true,
@@ -1069,6 +1095,7 @@ class SessionManager(
         wppRearmSource: String? = null,
     ) {
         val requestGeneration = lifecycleGeneration
+        val transportStartGeneration = currentTransportStartGeneration()
         startMutex.lock()
         try {
         kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
@@ -1305,7 +1332,7 @@ class SessionManager(
                 startupOutcome.complete(Unit)
                 return@launch
             }
-                startSession(directTransport, hotspotSsid, hotspotPassword,
+                startSession(directTransport, wppInterfaceName, hotspotSsid, hotspotPassword,
                     videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
                     aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
                     aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
@@ -1313,7 +1340,7 @@ class SessionManager(
                     driveSide, hideClock, hideSignal, hideBattery, scalingMode,
                     manualIpAddress,
                     safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                    gpsForwarding, galVersion, wppRearmSource)
+                    gpsForwarding, galVersion, wppRearmSource, transportStartGeneration)
                 startupOutcome.complete(Unit)
             } catch (e: Exception) {
                 wppRearmSource?.let { source ->
@@ -1346,8 +1373,9 @@ class SessionManager(
         }
     }
 
-    private fun startSession(
-        directTransport: String, hotspotSsid: String, hotspotPassword: String,
+    private suspend fun startSession(
+        directTransport: String, wppInterfaceName: String,
+        hotspotSsid: String, hotspotPassword: String,
         videoAutoNegotiate: Boolean = true, codec: String = "h264",
         aaResolution: String = "1080p", aaDpi: Int = 160, aaAutoDpi: Boolean = true,
         aaWidthMargin: Int = 0, aaHeightMargin: Int = 0, aaPixelAspect: Int = -1,
@@ -1363,6 +1391,7 @@ class SessionManager(
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
         wppRearmSource: String? = null,
+        transportStartGeneration: Long,
     ) {
         aasdkSession?.stop()
         _transportMode.value = directTransport
@@ -1374,6 +1403,12 @@ class SessionManager(
             }
             return
         }
+        // Discovery policy belongs to this immutable session settings snapshot,
+        // not to live DataStore edits made while an older session is still active.
+        com.openautolink.app.transport.PhoneDiscovery.getInstance(ctx)
+            .setInterfaceConstraint(
+                wppInterfaceName.takeIf { directTransport == AppPreferences.DIRECT_TRANSPORT_WPP },
+            )
 
         // Map resolution string to pixel dimensions. Strings are the AA
         // VideoCodecResolutionType enum values; portrait variants use the
@@ -1605,6 +1640,7 @@ class SessionManager(
 
         val session = AasdkSession(scope, ctx)
         session.transportMode = directTransport
+        session.wppInterfaceName = wppInterfaceName
         // Effective AA content_insets:
         //  - In `system_ui_visible` mode, the SurfaceView is already inside
         //    the chrome-free area (Compose padding handles it), so AA's
@@ -1744,11 +1780,29 @@ class SessionManager(
             }
         }
 
+        if (currentTransportStartGeneration() != transportStartGeneration) {
+            throw IllegalStateException("Session start interrupted before transport creation")
+        }
         session.start()
+        if (currentTransportStartGeneration() != transportStartGeneration) {
+            session.cancelPendingWppTransportStart("lifecycle interrupt")
+            throw IllegalStateException("Session start interrupted during transport creation")
+        }
+        if (directTransport == AppPreferences.DIRECT_TRANSPORT_WPP &&
+            !session.awaitWppTransportReady()
+        ) {
+            throw IllegalStateException(
+                "Selected WPP interface '$wppInterfaceName' did not bind; admission withheld",
+            )
+        }
         // Publish SDP only after this exact protocol owner has installed all
         // callbacks and bound its transport. This closes the cold-start and
         // USB→WPP preference races without delaying native negotiation itself.
-        val ownerToken = installWirelessSessionAdmission(directTransport)
+        val ownerToken = installWirelessSessionAdmissionIfCurrent(
+            directTransport,
+            wppInterfaceName,
+            transportStartGeneration,
+        ) ?: throw IllegalStateException("Session start interrupted before admission")
         wppRearmSource?.let { source ->
             val ownerInstalled = AaWirelessBtControl.isCurrentSessionOwner(ownerToken)
             val message = "WPP rearm outcome: source=$source " +
@@ -1887,6 +1941,7 @@ class SessionManager(
     }
 
     suspend fun stop() {
+        interruptPendingTransportStart("stop")
         startMutex.lock()
         try {
             kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) {
@@ -1988,6 +2043,7 @@ class SessionManager(
         micSourcePreference: String = "car",
         scalingMode: String = "letterbox",
         directTransport: String = "hotspot",
+        wppInterfaceName: String = AppPreferences.DEFAULT_WPP_AP_INTERFACE,
         hotspotSsid: String = "",
         hotspotPassword: String = "",
         videoAutoNegotiate: Boolean = true,
@@ -2026,9 +2082,10 @@ class SessionManager(
 
         // If islands were never initialized, do a full start
         if (_audioPlayer == null) {
+            interruptPendingTransportStart("reconnect")
             start(
                 codecPreference, micSourcePreference, scalingMode, directTransport,
-                hotspotSsid, hotspotPassword, videoAutoNegotiate, aaResolution,
+                wppInterfaceName, hotspotSsid, hotspotPassword, videoAutoNegotiate, aaResolution,
                 aaDpi, aaAutoDpi, aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
                 aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins, videoFps,
                 driveSide, hideClock, hideSignal, hideBattery,
@@ -2071,6 +2128,8 @@ class SessionManager(
                     "restarting now would destroy the socket the phone is about to use")
             return
         }
+        interruptPendingTransportStart("reconnect")
+        val transportStartGeneration = currentTransportStartGeneration()
         reconnectInProgress = true
         reconnectStartedAt = System.currentTimeMillis()
         val requestGeneration = lifecycleGeneration
@@ -2120,13 +2179,13 @@ class SessionManager(
                 } catch (_: Exception) {}
                 doReconnectAfterCancel(
                     codecPreference, micSourcePreference, scalingMode, directTransport,
-                    hotspotSsid, hotspotPassword, videoAutoNegotiate, aaResolution,
+                    wppInterfaceName, hotspotSsid, hotspotPassword, videoAutoNegotiate, aaResolution,
                     aaDpi, aaAutoDpi, aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
                     aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
                     videoFps, driveSide, hideClock, hideSignal, hideBattery,
                     volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                     effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-                    gpsForwarding, galVersion,
+                    gpsForwarding, galVersion, transportStartGeneration,
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
@@ -2144,7 +2203,8 @@ class SessionManager(
 
     private suspend fun doReconnectAfterCancel(
         codecPreference: String, micSourcePreference: String, scalingMode: String,
-        directTransport: String, hotspotSsid: String, hotspotPassword: String,
+        directTransport: String, wppInterfaceName: String,
+        hotspotSsid: String, hotspotPassword: String,
         videoAutoNegotiate: Boolean, aaResolution: String, aaDpi: Int,
         aaAutoDpi: Boolean,
         aaWidthMargin: Int, aaHeightMargin: Int, aaPixelAspect: Int,
@@ -2158,6 +2218,7 @@ class SessionManager(
         safeAreaTop: Int, safeAreaBottom: Int, safeAreaLeft: Int, safeAreaRight: Int,
         gpsForwarding: Boolean,
         galVersion: String,
+        transportStartGeneration: Long,
     ) {
         observeJob = null
         decoderWatchJob = null
@@ -2204,7 +2265,7 @@ class SessionManager(
         // 8. Start the replacement protocol session synchronously while the
         // lifecycle mutex is held. Only after its exact owner is installed do
         // we publish the long-lived watcher job.
-        startSession(directTransport, hotspotSsid, hotspotPassword,
+        startSession(directTransport, wppInterfaceName, hotspotSsid, hotspotPassword,
             videoAutoNegotiate, codecPreference, aaResolution, aaDpi, aaAutoDpi,
             aaWidthMargin, aaHeightMargin, aaPixelAspect, aaTargetLayoutWidthDp,
             aaViewingDistanceMm, aaDecoderAdditionalDepth, aaAutoMargins,
@@ -2212,7 +2273,8 @@ class SessionManager(
             driveSide, hideClock, hideSignal, hideBattery, scalingMode,
             manualIpAddress,
             safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
-            gpsForwarding, galVersion)
+            gpsForwarding, galVersion,
+            transportStartGeneration = transportStartGeneration)
 
         observeJob = scope.launch {
             decoderWatchJob = launch { watchDecoderState() }

--- a/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
+++ b/app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt
@@ -206,6 +206,32 @@ class PhoneDiscovery private constructor(private val context: Context) {
     private val sweepScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var sweepJob: Job? = null
 
+    /** Global WPP constraint applied even to diagnostics/manual discovery callers. */
+    @Volatile private var interfaceConstraint: String? = null
+
+    fun setInterfaceConstraint(interfaceName: String?) {
+        val normalized = interfaceName?.trim()?.takeIf { it.isNotEmpty() }
+        if (interfaceConstraint == normalized) return
+        stopSweep()
+        interfaceConstraint = normalized
+        if (normalized != null) {
+            synchronized(lock) {
+                byKey.entries.removeAll { (_, entry) ->
+                    entry.host?.let { !isHostAllowed(it) } == true
+                }
+            }
+            publish()
+        }
+        OalLog.i(TAG, "Discovery interface constraint: ${normalized ?: "none"}")
+    }
+
+    private fun isHostAllowed(host: String): Boolean {
+        val selected = interfaceConstraint ?: return true
+        val localIpv4 = currentIpv4Addresses().firstOrNull { it.iface == selected }?.ip
+            ?: return false
+        return WppInterfacePolicy.isPeerOnSelectedSubnet(localIpv4, host)
+    }
+
     /** Last wall-clock ms at which the \"no IPv4 interface\" warning was emitted. */
     @Volatile private var lastNoIfaceWarnMs: Long = 0L
 
@@ -481,7 +507,7 @@ class PhoneDiscovery private constructor(private val context: Context) {
 
         // Manual override path: scan only the user-specified interface, no
         // fallback. If the named interface isn't present, log + abort.
-        val forced = forcedInterfaceName?.takeIf { it.isNotBlank() }
+        val forced = interfaceConstraint ?: forcedInterfaceName?.takeIf { it.isNotBlank() }
         if (forced != null) {
             val match = all.filter { it.iface == forced }
             if (match.isEmpty()) {
@@ -536,6 +562,13 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * Run the sweep over [candidates], probing every host on each /24.
      * Returns the count of phones added to the discovery state.
      */
+    private data class SweepPlan(
+        val iface: String,
+        val prefix: String,
+        val localIpv4: String,
+        val selfLastOctet: Int,
+    )
+
     private suspend fun runSweepPhase(
         label: String,
         candidates: List<IfaceAddress>,
@@ -545,21 +578,21 @@ class PhoneDiscovery private constructor(private val context: Context) {
             if (parts.size != 4) return@mapNotNull null
             val prefix = "${parts[0]}.${parts[1]}.${parts[2]}"
             val selfLastOctet = parts[3].toIntOrNull() ?: -1
-            Triple(c.iface, prefix, selfLastOctet)
-        }.distinctBy { it.second }
+            SweepPlan(c.iface, prefix, c.ip, selfLastOctet)
+        }.distinctBy { it.prefix }
         if (plans.isEmpty()) return@coroutineScope 0
         var totalDone = 0
         var totalFound = 0
         val totalTargets = plans.size * 254
-        plans.forEach { triple ->
-            val iface = triple.first
-            val prefix = triple.second
-            val selfLastOctet = triple.third
+        plans.forEach { plan ->
+            val iface = plan.iface
+            val prefix = plan.prefix
+            val selfLastOctet = plan.selfLastOctet
             val targets: List<String> = (1..254).filter { it != selfLastOctet }.map { "$prefix.$it" }
             targets.chunked(SWEEP_PARALLELISM).forEach { chunk ->
                 val deferreds = chunk.map { ip ->
                     async(Dispatchers.IO) {
-                        val ident = probeHost(ip)
+                        val ident = probeHost(ip, sourceIpv4 = plan.localIpv4)
                         if (ident != null) {
                             // Remember where the companion lives so the Bluetooth
                             // advertiser can ask it for its AA proxy port.
@@ -587,7 +620,7 @@ class PhoneDiscovery private constructor(private val context: Context) {
                 _sweepProgress.value = "$label sweep $iface… $totalDone/$totalTargets ($totalFound found)"
             }
         }
-        _sweepProgress.value = "$label sweep complete: $totalFound phone(s) on ${plans.map { it.second + ".0/24" }}"
+        _sweepProgress.value = "$label sweep complete: $totalFound phone(s) on ${plans.map { it.prefix + ".0/24" }}"
         OalLog.i(TAG, "$label sweep complete: $totalFound phone(s)")
         totalFound
     }
@@ -626,10 +659,14 @@ class PhoneDiscovery private constructor(private val context: Context) {
             ?.takeIf { it in 1..65535 }
             ?: 0
 
-    private suspend fun probeHost(host: String): IdentityResult? = withContext(Dispatchers.IO) {
+    private suspend fun probeHost(
+        host: String,
+        sourceIpv4: String,
+    ): IdentityResult? = withContext(Dispatchers.IO) {
         withTimeoutOrNull((SWEEP_CONNECT_TIMEOUT_MS + SWEEP_READ_TIMEOUT_MS + 200).toLong()) {
             val socket = Socket()
             try {
+                socket.bind(InetSocketAddress(sourceIpv4, 0))
                 socket.connect(InetSocketAddress(host, IDENTITY_PORT), SWEEP_CONNECT_TIMEOUT_MS)
                 socket.soTimeout = SWEEP_READ_TIMEOUT_MS
                 val out = socket.getOutputStream()
@@ -702,6 +739,7 @@ class PhoneDiscovery private constructor(private val context: Context) {
     suspend fun udpBroadcast(
         broadcastAddress: String? = null,
         listenWindowMs: Long = 600L,
+        sourceIpv4: String? = null,
     ): Int = withContext(Dispatchers.IO) {
         val target = try {
             if (broadcastAddress != null) InetAddress.getByName(broadcastAddress)
@@ -712,10 +750,16 @@ class PhoneDiscovery private constructor(private val context: Context) {
         }
         var socket: DatagramSocket? = null
         try {
-            socket = DatagramSocket().apply {
+            val datagramSocket = DatagramSocket(null).apply {
+                reuseAddress = true
+                bind(
+                    if (sourceIpv4 != null) InetSocketAddress(sourceIpv4, 0)
+                    else InetSocketAddress(0),
+                )
                 broadcast = true
                 soTimeout = 200 // per-receive timeout; loop until window elapses
             }
+            socket = datagramSocket
             val payload = OalProtocol.IDENTITY_PROBE_REQUEST.toByteArray(Charsets.UTF_8)
             val outPacket = DatagramPacket(payload, payload.size, target, OalProtocol.UDP_DISCOVERY_PORT)
             socket.send(outPacket)
@@ -732,6 +776,12 @@ class PhoneDiscovery private constructor(private val context: Context) {
                     continue
                 }
                 val replyHost = recvPacket.address?.hostAddress ?: continue
+                if (sourceIpv4 != null &&
+                    !WppInterfacePolicy.isPeerOnSelectedSubnet(sourceIpv4, replyHost)
+                ) {
+                    OalLog.i(TAG, "UDP discovery rejected $replyHost — outside selected source $sourceIpv4")
+                    continue
+                }
                 val replyText = String(
                     recvPacket.data, recvPacket.offset, recvPacket.length, Charsets.UTF_8,
                 ).trimEnd('\n', '\r')
@@ -779,6 +829,24 @@ class PhoneDiscovery private constructor(private val context: Context) {
         return "${parts[0]}.${parts[1]}.${parts[2]}.255"
     }
 
+    /** Broadcast only on the explicitly selected interface. */
+    suspend fun udpBroadcastOnInterface(
+        forcedInterfaceName: String,
+        listenWindowMs: Long = 600L,
+    ): Int {
+        val entry = currentIpv4Addresses().firstOrNull { it.iface == forcedInterfaceName }
+        if (entry == null) {
+            OalLog.w(TAG, "UDP discovery skipped — selected interface '$forcedInterfaceName' is unavailable")
+            return 0
+        }
+        val bcast = broadcastFor24(entry.ip) ?: return 0
+        return udpBroadcast(
+            broadcastAddress = bcast,
+            listenWindowMs = listenWindowMs,
+            sourceIpv4 = entry.ip,
+        )
+    }
+
     /**
      * Run a UDP broadcast on every usable /24 we have a local address on.
      * Mirrors the sweep's interface-enumeration logic but completes in a
@@ -786,6 +854,10 @@ class PhoneDiscovery private constructor(private val context: Context) {
      * all interfaces.
      */
     suspend fun udpBroadcastAllInterfaces(listenWindowMs: Long = 600L): Int {
+        val constrained = interfaceConstraint
+        if (constrained != null) {
+            return udpBroadcastOnInterface(constrained, listenWindowMs)
+        }
         val ifaces = currentIpv4Addresses()
         if (ifaces.isEmpty()) return 0
         // Prefer AP-bridge interfaces first (GM `ap_br_swlan0` etc.) — same
@@ -876,6 +948,11 @@ class PhoneDiscovery private constructor(private val context: Context) {
         mdnsServiceName: String?,
         viaSource: SourceBit,
     ) {
+        if (host != null && !isHostAllowed(host)) {
+            OalLog.i(TAG, "Discovery rejected $host — outside selected interface constraint " +
+                    "${interfaceConstraint ?: "none"}")
+            return
+        }
         // Every discovery source funnels through here, so this is the one place
         // that always has the freshest address for the Bluetooth advertiser.
         host?.takeIf { it.isNotBlank() }?.let {

--- a/app/src/main/java/com/openautolink/app/transport/WppInterfacePolicy.kt
+++ b/app/src/main/java/com/openautolink/app/transport/WppInterfacePolicy.kt
@@ -1,0 +1,91 @@
+package com.openautolink.app.transport
+
+/**
+ * One-interface contract for WPP networking.
+ *
+ * The configured interface is authoritative. A missing interface never degrades
+ * to another live NIC, and a peer is usable only when it belongs to the selected
+ * interface's current IPv4 subnet using Android's reported prefix length.
+ */
+object WppInterfacePolicy {
+    data class InterfaceIpv4(
+        val name: String,
+        val address: String,
+        val prefixLength: Int = 24,
+    )
+
+    fun selectedIpv4(
+        selectedInterfaceName: String,
+        interfaces: List<InterfaceIpv4>,
+    ): String? = interfaces
+        .firstOrNull { it.name == selectedInterfaceName && parseIpv4(it.address) != null }
+        ?.address
+
+    fun isPeerOnSelectedSubnet(
+        selectedLocalIpv4: String,
+        peerHost: String,
+        prefixLength: Int = livePrefixLength(selectedLocalIpv4) ?: 24,
+    ): Boolean {
+        if (prefixLength !in 0..32) return false
+        val local = parseIpv4(selectedLocalIpv4) ?: return false
+        val peer = parseIpv4(stripPort(peerHost)) ?: return false
+        val mask = if (prefixLength == 0) 0 else -1 shl (32 - prefixLength)
+        return (toIpv4Int(local) and mask) == (toIpv4Int(peer) and mask)
+    }
+
+    fun liveInterfaceIpv4(interfaceName: String): InterfaceIpv4? = runCatching {
+        val networkInterface = java.net.NetworkInterface.getByName(interfaceName)
+            ?.takeIf { it.isUp && !it.isLoopback && !it.isVirtual }
+            ?: return@runCatching null
+        networkInterface.interfaceAddresses
+            .firstNotNullOfOrNull { interfaceAddress ->
+                val address = interfaceAddress.address as? java.net.Inet4Address
+                    ?: return@firstNotNullOfOrNull null
+                if (address.isLoopbackAddress || address.isLinkLocalAddress) {
+                    return@firstNotNullOfOrNull null
+                }
+                InterfaceIpv4(
+                    name = networkInterface.name,
+                    address = address.hostAddress ?: return@firstNotNullOfOrNull null,
+                    prefixLength = interfaceAddress.networkPrefixLength.toInt(),
+                )
+            }
+    }.getOrNull()
+
+    fun liveIpv4(interfaceName: String): String? = liveInterfaceIpv4(interfaceName)?.address
+
+    private fun livePrefixLength(localIpv4: String): Int? = runCatching {
+        val interfaces = java.net.NetworkInterface.getNetworkInterfaces() ?: return@runCatching null
+        interfaces.toList().firstNotNullOfOrNull { networkInterface ->
+            networkInterface.interfaceAddresses.firstNotNullOfOrNull { interfaceAddress ->
+                val address = interfaceAddress.address as? java.net.Inet4Address
+                    ?: return@firstNotNullOfOrNull null
+                if (address.hostAddress == localIpv4) interfaceAddress.networkPrefixLength.toInt()
+                else null
+            }
+        }
+    }.getOrNull()
+
+    private fun toIpv4Int(octets: IntArray): Int =
+        (octets[0] shl 24) or (octets[1] shl 16) or (octets[2] shl 8) or octets[3]
+
+    private fun stripPort(host: String): String {
+        val trimmed = host.trim()
+        if (trimmed.count { it == ':' } != 1) return trimmed
+        val separator = trimmed.lastIndexOf(':')
+        val port = trimmed.substring(separator + 1).toIntOrNull()
+        return if (port != null && port in 1..65535) trimmed.substring(0, separator) else trimmed
+    }
+
+    private fun parseIpv4(value: String): IntArray? {
+        val parts = value.split('.')
+        if (parts.size != 4) return null
+        val octets = IntArray(4)
+        for (index in parts.indices) {
+            val octet = parts[index].toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            octets[index] = octet
+        }
+        return octets
+    }
+}

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -11,6 +11,8 @@ import com.openautolink.app.navigation.VehicleEnergyForecast
 import com.openautolink.app.transport.AudioPurpose
 import com.openautolink.app.transport.ConnectionState
 import com.openautolink.app.transport.ControlMessage
+import com.openautolink.app.transport.WppInterfacePolicy
+import com.openautolink.app.transport.bluetooth.AaWirelessBtControl
 import com.openautolink.app.transport.hotspot.TcpConnector
 import com.openautolink.app.transport.usb.UsbConnectionManager
 import com.openautolink.app.video.VideoFrame
@@ -140,15 +142,13 @@ class AasdkSession(
 
     var sdrConfig = AasdkSdrConfig()
 
-    // TCP connector — used in "hotspot" transport mode (Car Hotspot / Phone Hotspot)
+    // TCP connector — hotspot transport or WPP's companion-proxy route.
     @Volatile private var _tcpConnector: TcpConnector? = null
     /** Serializes connector ownership, socket handoff, and synchronous teardown. */
     private val connectionStartLock = Any()
 
-    /**
-     * WPP inbound listener. Only non-null in "wpp" transport mode, where the phone
-     * connects to us rather than the other way round.
-     */
+    /** WPP inbound fallback while no companion-proxy endpoint has been selected. */
+    @Volatile
     private var _wppServer: com.openautolink.app.transport.hotspot.WppTcpServer? = null
 
     // -- (A) Video frame-flow diagnostic counters --
@@ -166,8 +166,11 @@ class AasdkSession(
     // USB connection manager — only used in "usb" transport mode
     private var _usbConnectionManager: UsbConnectionManager? = null
 
-    /** Current transport mode: "hotspot" or "usb" */
+    /** Current transport mode: "hotspot", "usb", or "wpp". */
     var transportMode: String = "hotspot"
+
+    /** Immutable interface name owned by this WPP session generation. */
+    var wppInterfaceName: String = "ap_br_swlan0"
 
     /** Manual IP address for testing (emulator). Overrides gateway/mDNS discovery. */
     var manualIpAddress: String? = null
@@ -238,12 +241,12 @@ class AasdkSession(
     }
 
     /**
-     * Google WiFi Projection Protocol: the phone connects to US.
+     * Google WiFi Projection Protocol bootstrap.
      *
-     * The opposite direction to [startTcp]. In WPP the head unit advertises its
-     * `{ip, port}` over Bluetooth RFCOMM (see `AaWirelessBtServer`) and the phone
-     * then opens the TCP connection inbound. Proven against AA 17.4 on 2026-08-06:
-     * full BT handshake, WiFi association, then an inbound connection from the phone.
+     * Standard WPP advertises the head unit's `{ip, port}` over Bluetooth RFCOMM
+     * and the phone opens TCP inbound. On GM, OAL may instead advertise the
+     * companion's phone-local proxy; then [dialCompanion] stops this inbound
+     * listener and the car dials outbound from the same selected interface.
      *
      * The native session neither knows nor cares which side dialled — it needs a
      * connected socket — so this reuses [handleConnection] unchanged.
@@ -278,10 +281,13 @@ class AasdkSession(
                     startTcp(manualIp = address)
                 }
             // One recovery owner performs exactly one refresh. If a companion is
-            // known, its connector is started first so the phone cannot beat us to
-            // the proxy; otherwise the listener below is bound while SDP returns.
-            com.openautolink.app.transport.bluetooth.AaWirelessBtControl.readvertise()
-            if (known != null) return
+            // known, its source-bound connector is started before publication. If
+            // not, the bind-ready callback below publishes only after the selected-
+            // interface listener really exists.
+            if (known != null) {
+                com.openautolink.app.transport.bluetooth.AaWirelessBtControl.readvertise()
+                return
+            }
         } else {
             OalLog.i(TAG, "Initial WPP owner installed — waiting for its admitted Bluetooth " +
                     "handshake instead of pre-dialling a cached companion")
@@ -307,7 +313,8 @@ class AasdkSession(
         // moment it selects the loopback endpoint and therefore knows the address.
         // See AaWirelessBtControl -> onCompanionSelected.
 
-        OalLog.i(TAG, "Starting aasdk session (WPP transport — phone connects to us)")
+        OalLog.i(TAG, "Starting WPP selected-interface inbound listener; " +
+                "the handshake may switch to the companion's outbound proxy")
         _wppServer?.stop()
         lateinit var server: com.openautolink.app.transport.hotspot.WppTcpServer
         server = com.openautolink.app.transport.hotspot.WppTcpServer(
@@ -325,9 +332,31 @@ class AasdkSession(
                     }
                 }
             },
+            onBound = {
+                if (recovery) {
+                    OalLog.i(TAG, "WPP recovery listener bound — refreshing SDP")
+                    com.openautolink.app.transport.bluetooth.AaWirelessBtControl.readvertise()
+                }
+            },
+            bindInterfaceName = wppInterfaceName,
         )
         _wppServer = server
         server.start()
+    }
+
+    /** Wait until WPP has a real selected-interface listener before admission. */
+    suspend fun awaitWppTransportReady(): Boolean {
+        if (transportMode != "wpp") return true
+        return _wppServer?.awaitBound() == true
+    }
+
+    /** Resolve a pending bind wait before a lifecycle replacement queues on its mutex. */
+    fun cancelPendingWppTransportStart(reason: String) {
+        if (transportMode != "wpp") return
+        val server = _wppServer ?: return
+        OalLog.i(TAG, "Cancelling WPP transport start before $reason")
+        server.stop()
+        if (_wppServer === server) _wppServer = null
     }
 
     /**
@@ -410,7 +439,7 @@ class AasdkSession(
     }
 
     private fun startTcp(manualIp: String? = null) {
-        OalLog.i(TAG, "Starting aasdk session (TCP/hotspot transport)")
+        OalLog.i(TAG, "Starting TCP connector (hotspot or WPP companion-proxy transport)")
         synchronized(connectionStartLock) {
             // Record at the common ownership boundary. WPP restart calls startTcp()
             // directly, so recording only in dialCompanion() leaves the guard stale.
@@ -451,6 +480,19 @@ class AasdkSession(
                     }
                 },
             )
+            // WPP owns exactly one interface end-to-end; bind its selected source.
+            if (transportMode == "wpp") {
+                val selectedSourceIpv4 = WppInterfacePolicy.liveIpv4(wppInterfaceName)
+                if (selectedSourceIpv4 == null) {
+                    OalLog.e(TAG, "Selected WPP interface $wppInterfaceName has no live IPv4 — " +
+                            "aborting connector start; no fallback allowed")
+                    connector.stop()
+                    if (_tcpConnector === connector) _tcpConnector = null
+                    _connectionState.value = ConnectionState.DISCONNECTED
+                    return@synchronized
+                }
+                connector.sourceIpv4 = selectedSourceIpv4
+            }
             // An explicit dial target wins over the configured manual IP.
             connector.manualIp = manualIp ?: manualIpAddress
             _tcpConnector = connector

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import com.openautolink.app.diagnostics.OalLog
 import com.openautolink.app.transport.OalProtocol
+import com.openautolink.app.transport.WppInterfacePolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -232,12 +233,15 @@ object AaWirelessBtControl {
 
     fun hasCurrentWppOwner(): Boolean = sessionAdmission.currentWppOwner() != null
 
-    fun installSessionOwner(transportMode: String): WppSessionAdmission.Token {
+    fun installSessionOwner(
+        transportMode: String,
+        wppInterfaceName: String? = null,
+    ): WppSessionAdmission.Token {
         val token = synchronized(this) {
-            sessionAdmission.installSession(transportMode)
+            sessionAdmission.installSession(transportMode, wppInterfaceName)
         }
         OalLog.i(TAG, "Session admission installed: generation=${token.generation} " +
-                "transport=${token.transportMode}")
+                "transport=${token.transportMode} interface=${token.wppInterfaceName ?: "none"}")
         if (transportMode == "wpp") {
             ensureAdvertising()
         } else {
@@ -406,7 +410,7 @@ object AaWirelessBtControl {
     private fun startBootstrapCompanionDiscovery(
         attempt: BootstrapAttempt,
         candidates: List<String>,
-        manualIp: String?,
+        selectedLocalIpv4: String,
     ) {
         scope.launch {
             val deadline = System.currentTimeMillis() + WppBootstrapPolicy.DISCOVERY_DEADLINE_MS
@@ -439,8 +443,8 @@ object AaWirelessBtControl {
                     val remainingMs = (deadline - System.currentTimeMillis())
                         .coerceIn(1L, 5_000L)
                         .toInt()
-                    found = findCompanionOnAnySubnet(
-                        manualIp = manualIp,
+                    found = findCompanionOnSelectedInterface(
+                        selectedLocalIpv4 = selectedLocalIpv4,
                         phoneBtAddress = attempt.phoneBtAddress,
                         phoneBtName = attempt.phoneBtName,
                         overallTimeoutMs = remainingMs,
@@ -517,6 +521,14 @@ object AaWirelessBtControl {
         reportedPhoneId: String? = null,
         reportedFriendlyName: String? = null,
     ) {
+        val selectedLocalIpv4 = currentSelectedWppIpv4()
+        if (selectedLocalIpv4 == null ||
+            !WppInterfacePolicy.isPeerOnSelectedSubnet(selectedLocalIpv4, host)
+        ) {
+            OalLog.i(TAG, "Rejecting companion at $host — outside selected WPP interface " +
+                    "subnet (${selectedLocalIpv4 ?: "unavailable"})")
+            return
+        }
         val liveProbe = askCompanion(host, connectTimeoutMs = 800)
         val probe = liveProbe ?: reportedProxyPort?.let { port ->
             CompanionProbe(reportedPhoneId, reportedFriendlyName, port)
@@ -832,14 +844,21 @@ object AaWirelessBtControl {
      * Discovery's global address history is intentionally excluded: it can contain
      * every nearby phone and was the source of cross-phone speculative dials.
      */
-    fun withIdentityValidatedCompanion(action: (String) -> Unit): String? =
-        synchronized(phoneClaimLock) {
+    fun withIdentityValidatedCompanion(action: (String) -> Unit): String? {
+        val selectedLocalIpv4 = currentSelectedWppIpv4() ?: return null
+        return synchronized(phoneClaimLock) {
             val btAddress = activePhoneBt ?: return null
             if (phoneIdByBtAddress[btAddress].isNullOrBlank()) return null
             val address = lastAddressByPhone[btAddress] ?: return null
+            if (!WppInterfacePolicy.isPeerOnSelectedSubnet(selectedLocalIpv4, address)) {
+                OalLog.i(TAG, "Rejecting cached companion at $address — outside selected " +
+                        "WPP interface subnet ($selectedLocalIpv4)")
+                return null
+            }
             action(address)
             address
         }
+    }
 
     /**
      * Reset attempt ownership on ignition off while retaining address hints.
@@ -855,11 +874,15 @@ object AaWirelessBtControl {
     fun resetForNextIgnition() {
         // Snapshot the addresses BEFORE clearing them — the notify is async and
         // would otherwise race the clear and find nothing to send to.
+        val selectedLocalIpv4 = currentSelectedWppIpv4()
         val targets = buildList {
             lastKnownPhoneIp?.let { add(it) }
             synchronized(recentPhoneIps) { addAll(recentPhoneIps) }
-        }.distinct()
-        notifyCompanionOfShutdown(targets)
+        }.distinct().filter { target ->
+            selectedLocalIpv4 != null &&
+                WppInterfacePolicy.isPeerOnSelectedSubnet(selectedLocalIpv4, target)
+        }
+        notifyCompanionOfShutdown(targets, selectedLocalIpv4)
         releaseActivePhone()
         // Keep address hints across ignition. A stale address costs one bounded
         // probe before the attempt-owned scan; clearing every address forces every
@@ -892,12 +915,13 @@ object AaWirelessBtControl {
      * companion still discovers the loss the slow way. Delivering it saves the
      * next connection from a pooled socket to a car that no longer exists.
      */
-    private fun notifyCompanionOfShutdown(targets: List<String>) {
-        if (targets.isEmpty()) return
+    private fun notifyCompanionOfShutdown(targets: List<String>, sourceIpv4: String?) {
+        if (targets.isEmpty() || sourceIpv4 == null) return
         for (ip in targets) {
             scope.launch {
                 runCatching {
                     java.net.Socket().use { s ->
+                        s.bind(java.net.InetSocketAddress(sourceIpv4, 0))
                         s.connect(java.net.InetSocketAddress(ip, IDENTITY_PORT), 250)
                         s.getOutputStream().apply { write("BYE!\n".toByteArray()); flush() }
                     }
@@ -976,6 +1000,14 @@ object AaWirelessBtControl {
      */
     @Volatile
     var activePhoneCompanionIp: String? = null
+        private set
+
+    /** Name and IPv4 currently owned by the explicit WPP interface selection. */
+    @Volatile
+    private var selectedWppInterfaceName: String? = null
+
+    @Volatile
+    var selectedWppInterfaceIpv4: String? = null
         private set
 
     private fun isDebuggableBuild(context: Context): Boolean =
@@ -1108,15 +1140,28 @@ object AaWirelessBtControl {
                 return
             }
             val prefs = com.openautolink.app.data.AppPreferences.getInstance(context)
-            val apInterface = prefs.wppApInterface.first()
+            val apInterface = expectedOwner.wppInterfaceName
+            if (apInterface.isNullOrBlank()) {
+                OalLog.e(TAG, "Not advertising — WPP session owner has no interface")
+                return
+            }
+            selectedWppInterfaceName = apInterface
 
-            // Common readiness chokepoint. Ignition/socket-death recovery used to
-            // bypass this and could publish a telematics address before the car AP.
+            // Common readiness chokepoint. The selected interface is authoritative:
+            // never advertise or dial through another live NIC when it is absent.
             awaitApInterface(apInterface)
             if (!sessionAdmission.isCurrent(expectedOwner)) {
                 OalLog.i(TAG, "Not advertising — WPP owner changed while waiting for AP")
                 return
             }
+            val interfaceIpv4 = localIpv4Address(apInterface)
+            if (interfaceIpv4 == null) {
+                selectedWppInterfaceIpv4 = null
+                OalLog.w(TAG, "Not advertising — selected WPP interface '$apInterface' " +
+                        "is unavailable or has no IPv4 address")
+                return
+            }
+            selectedWppInterfaceIpv4 = interfaceIpv4
 
             val ssid = intent?.getStringExtra("ssid")?.takeIf { it.isNotBlank() }
                 ?: prefs.hotspotSsid.first()
@@ -1125,12 +1170,12 @@ object AaWirelessBtControl {
             val bssid = intent?.getStringExtra("bssid")?.takeIf { it.isNotBlank() }
                 ?: prefs.wppBssid.first()
             val port = intent?.getIntExtra("port", 5277) ?: 5277
-            // The address the phone is told to dial. Detected from the live
-            // interface rather than stored, because it changes with the network.
-            val ip = intent?.getStringExtra("ip")?.takeIf { it.isNotBlank() }
-                ?: prefs.wppLocalIp.first().takeIf { it.isNotBlank() }
-                ?: localIpv4Address(apInterface)
-                ?: ""
+            val requestedIp = intent?.getStringExtra("ip")?.takeIf { it.isNotBlank() }
+            if (requestedIp != null && requestedIp != interfaceIpv4) {
+                OalLog.w(TAG, "Ignoring WPP IP override $requestedIp — selected interface " +
+                        "$apInterface owns $interfaceIpv4")
+            }
+            val ip = interfaceIpv4
 
             val problems = buildList {
                 if (ssid.isBlank()) add("SSID is empty")
@@ -1153,8 +1198,6 @@ object AaWirelessBtControl {
             )
             startAdvertising(
                 context, creds,
-                manualIp = intent?.getStringExtra("ip")?.takeIf { it.isNotBlank() }
-                    ?: prefs.wppLocalIp.first().takeIf { it.isNotBlank() },
                 apInterface = apInterface,
                 expectedOwner = expectedOwner,
             )
@@ -1226,76 +1269,31 @@ object AaWirelessBtControl {
             kotlinx.coroutines.delay(1_000)
         }
         OalLog.w(TAG, "$apInterface did not appear within ${timeoutMs}ms — " +
-                "advertising anyway with whatever address is available")
+                "strict WPP interface selection prevents fallback advertising")
     }
 
-    /**
-     * Last-resort scan for the companion across EVERY network the head unit is on.
-     *
-     * A Blazer has two independent radios and they sit on different networks:
-     *
-     *   ap_br_swlan0  the telematics module's AP ("Blazing", 10.2.110.x) that the
-     *                 phone joins — and whose inbound filtering is the reason the
-     *                 loopback endpoint exists at all
-     *   wlan0         the head unit's own Android WiFi, a client only. Observed on
-     *                 home WiFi (192.168.0.104) and on the phone's hotspot
-     *                 (10.187.47.188), never on Blazing
-     *
-     * An earlier version scanned only the telematics subnet and so missed the
-     * companion entirely when it was reachable over wlan0: at 16:34:29 the scan of
-     * 10.2.110.0/24 found nothing, and 25s later discovery reported the phone at
-     * 10.187.47.73 — the phone-hotspot subnet, via the other radio.
-     *
-     * Which radio carries the traffic does not matter to the design; only that the
-     * head unit can dial the companion. Reaching it over the phone's own hotspot is
-     * arguably better, since the phone is the AP there and the telematics module's
-     * filtering is bypassed completely.
-     */
-    private fun findCompanionOnAnySubnet(
-        manualIp: String?,
+    /** Scan only the explicitly selected WPP interface subnet. */
+    private fun findCompanionOnSelectedInterface(
+        selectedLocalIpv4: String,
         phoneBtAddress: String,
         phoneBtName: String?,
         overallTimeoutMs: Int = 20_000,
     ): ResolvedCompanion? {
-        val localIps = buildList {
-            manualIp?.takeIf { it.isNotBlank() }?.let { add(it) }
-            addAll(allLocalIpv4())
-        }.distinct()
-        if (localIps.isEmpty()) return null
-
-        val deadline = System.currentTimeMillis() + overallTimeoutMs
-        for (ip in localIps) {
-            val prefix = ip.substringBeforeLast('.', "")
-            if (prefix.isEmpty()) continue
-            val remainingMs = (deadline - System.currentTimeMillis()).coerceAtLeast(1L).toInt()
-            OalLog.i(TAG, "Scanning $prefix.0/24 for the companion")
-            scanSubnet(
-                prefix = prefix,
-                ourIp = ip,
-                phoneBtAddress = phoneBtAddress,
-                phoneBtName = phoneBtName,
-                overallTimeoutMs = remainingMs,
-            )?.let { return it }
-            if (System.currentTimeMillis() >= deadline) break
-        }
-        OalLog.w(TAG, "No companion on any local subnet (${localIps.joinToString()})")
-        return null
-    }
-
-    /** Every non-loopback IPv4 the head unit currently holds, across both radios. */
-    private fun allLocalIpv4(): List<String> = runCatching {
-        java.net.NetworkInterface.getNetworkInterfaces().toList()
-            .filter { it.isUp && !it.isLoopback && !it.isVirtual }
-            // The telematics module also exposes several vt* interfaces on
-            // 172.16.x that lead nowhere useful; scanning them wastes seconds.
-            .filterNot { it.name.startsWith("vt") }
-            .flatMap { nif ->
-                nif.inetAddresses.toList()
-                    .filterIsInstance<java.net.Inet4Address>()
-                    .filter { !it.isLoopbackAddress && !it.isLinkLocalAddress }
-                    .mapNotNull { it.hostAddress }
+        val prefix = selectedLocalIpv4.substringBeforeLast('.', "")
+        if (prefix.isEmpty()) return null
+        OalLog.i(TAG, "Scanning selected WPP interface subnet $prefix.0/24 for the companion")
+        return scanSubnet(
+            prefix = prefix,
+            ourIp = selectedLocalIpv4,
+            phoneBtAddress = phoneBtAddress,
+            phoneBtName = phoneBtName,
+            overallTimeoutMs = overallTimeoutMs,
+        ).also {
+            if (it == null) {
+                OalLog.w(TAG, "No companion on selected WPP interface subnet $prefix.0/24")
             }
-    }.getOrDefault(emptyList())
+        }
+    }
 
     /**
      * Scans one /24 for the companion, returning its address AND proxy port.
@@ -1371,15 +1369,20 @@ object AaWirelessBtControl {
     private fun askCompanion(
         phoneIp: String,
         connectTimeoutMs: Int = 1200,
-    ): CompanionProbe? = runCatching {
-        java.net.Socket().use { sock ->
-            sock.connect(java.net.InetSocketAddress(phoneIp, IDENTITY_PORT), connectTimeoutMs)
-            sock.soTimeout = connectTimeoutMs
-            sock.getOutputStream().apply { write("OAL?\n".toByteArray()); flush() }
-            val reply = sock.getInputStream().bufferedReader().readLine().orEmpty()
-            CompanionIdentityPolicy.parseProbe(reply)
-        }
-    }.getOrNull()
+    ): CompanionProbe? {
+        val sourceIpv4 = selectedWppInterfaceIpv4 ?: return null
+        if (!WppInterfacePolicy.isPeerOnSelectedSubnet(sourceIpv4, phoneIp)) return null
+        return runCatching {
+            java.net.Socket().use { sock ->
+                sock.bind(java.net.InetSocketAddress(sourceIpv4, 0))
+                sock.connect(java.net.InetSocketAddress(phoneIp, IDENTITY_PORT), connectTimeoutMs)
+                sock.soTimeout = connectTimeoutMs
+                sock.getOutputStream().apply { write("OAL?\n".toByteArray()); flush() }
+                val reply = sock.getInputStream().bufferedReader().readLine().orEmpty()
+                CompanionIdentityPolicy.parseProbe(reply)
+            }
+        }.getOrNull()
+    }
 
     private fun probeMatchesBluetoothOwner(
         phoneBtAddress: String,
@@ -1449,62 +1452,33 @@ object AaWirelessBtControl {
         return fallback
     }
 
-    private fun localIpv4Address(apInterface: String): String? = runCatching {
-        data class Candidate(val name: String, val addr: String)
+    private fun currentSelectedWppIpv4(): String? {
+        val interfaceName = selectedWppInterfaceName ?: return null
+        return localIpv4Address(interfaceName).also { selectedWppInterfaceIpv4 = it }
+    }
 
+    /** Resolve only the explicitly selected interface. */
+    private fun localIpv4Address(apInterface: String): String? = runCatching {
         val candidates = java.net.NetworkInterface.getNetworkInterfaces().toList()
             .filter { it.isUp && !it.isLoopback && !it.isVirtual }
             .flatMap { nif ->
                 nif.inetAddresses.toList()
                     .filterIsInstance<java.net.Inet4Address>()
                     .filter { !it.isLoopbackAddress && !it.isLinkLocalAddress }
-                    .mapNotNull { it.hostAddress?.let { a -> Candidate(nif.name, a) } }
+                    .mapNotNull { it.hostAddress?.let { address ->
+                        WppInterfacePolicy.InterfaceIpv4(nif.name, address)
+                    } }
             }
-        if (candidates.isEmpty()) return@runCatching null
-
-        // Interface tiers. The configured AP interface wins outright; the rest
-        // are fallbacks for OEMs that name it differently, so a wrong setting
-        // degrades to a guess rather than to nothing.
-        fun tier(name: String): Int = when {
-            name == apInterface -> 0
-            name.startsWith("ap_br_") || name.startsWith("ap") ||
-                name.startsWith("swlan") || name == "wlan1" -> 1
-            name.startsWith("wlan") -> 2
-            else -> 3
-        }
-        fun isPrivate(a: String): Boolean =
-            a.startsWith("10.") || a.startsWith("192.168.") ||
-                (a.startsWith("172.") && a.substringAfter('.').substringBefore('.').toIntOrNull()
-                    ?.let { it in 16..31 } == true)
-
-        // A gateway-looking address (x.y.z.1) is a strong signal for "this
-        // interface IS the access point", since an AP is the gateway for its
-        // clients. Ranks above interface-name guessing, which varies by OEM.
-        fun looksLikeGateway(a: String) = a.endsWith(".1")
-
-        val chosen = candidates.sortedWith(
-            compareBy<Candidate> { tier(it.name) }
-                .thenBy { if (looksLikeGateway(it.addr)) 0 else 1 }
-                .thenBy { if (isPrivate(it.addr)) 0 else 1 }
-        ).first()
-
-        // Always log, not just when ambiguous: the car AP has used several
-        // different subnets across multi-week epochs, so the value used by each
-        // handshake must remain visible even though it is usually stable per cycle.
-        run {
-            OalLog.i(TAG, "Local address candidates: " +
-                    candidates.joinToString { "${it.name}=${it.addr}" } +
-                    " — advertising ${chosen.addr} (${chosen.name}). " +
-                    "If the phone joins the AP but projection never starts, compare this " +
-                    "against the phone's own address: they must share a subnet.")
-        }
-        chosen.addr
+        val chosen = WppInterfacePolicy.selectedIpv4(apInterface, candidates)
+        OalLog.i(TAG, "Local address candidates: " +
+                candidates.joinToString { "${it.name}=${it.address}" } +
+                " — selected $apInterface=${chosen ?: "unavailable"}; no fallback allowed")
+        chosen
     }.getOrNull()
 
     private fun startAdvertising(
         context: Context,
         creds: AaWirelessBtServer.WifiCredentials,
-        manualIp: String?,
         apInterface: String,
         expectedOwner: WppSessionAdmission.Token,
     ) {
@@ -1551,11 +1525,8 @@ object AaWirelessBtControl {
         // stated plainly in the log, not inferred later from the phone's silence.
         val canAdvertise = bt.canAdvertise()
         OalLog.i(TAG, "SDP advertise capability: $canAdvertise")
-        // Re-resolve on every handshake. The AP is usually stable across ignition
-        // cycles but has changed across longer epochs, so no cached address is a
-        // permanent source of truth.
-        // Honour a manual override if one is set, otherwise look it up live.
-        bt.setAddressResolver { manualIp ?: localIpv4Address(apInterface) }
+        // Re-resolve the exact selected interface on every handshake. No fallback.
+        bt.setAddressResolver { localIpv4Address(apInterface) }
 
         // Endpoint selection, evaluated per handshake.
         //
@@ -1620,9 +1591,9 @@ object AaWirelessBtControl {
             // it is a cheap fact about the current interfaces rather than a guess
             // about elapsed time, but the fast path — try the remembered address
             // first — is what actually matters.
-            val localPrefixes = allLocalIpv4().mapNotNull {
-                it.substringBeforeLast('.', "").takeIf(String::isNotEmpty)
-            }.toSet()
+            val selectedLocalIpv4 = localIpv4Address(apInterface)
+                ?: return@setEndpointResolver null
+            selectedWppInterfaceIpv4 = selectedLocalIpv4
             // The address this phone used last time goes first.
             //
             // The address history is shared across phones, so with two phones in
@@ -1637,12 +1608,12 @@ object AaWirelessBtControl {
                 synchronized(recentPhoneIps) { addAll(recentPhoneIps) }
             }.distinct()
             val candidates = allKnown.filter { ip ->
-                ip.substringBeforeLast('.', "") in localPrefixes
+                WppInterfacePolicy.isPeerOnSelectedSubnet(selectedLocalIpv4, ip)
             }
             val dropped = allKnown - candidates.toSet()
             if (dropped.isNotEmpty()) {
-                OalLog.i(TAG, "Ignoring ${dropped.joinToString()} — not on any subnet " +
-                        "this car is currently on (${localPrefixes.joinToString()})")
+                OalLog.i(TAG, "Ignoring ${dropped.joinToString()} — outside selected WPP " +
+                        "interface $apInterface subnet ($selectedLocalIpv4)")
             }
             // companionIp tracks WHICH address answered, from either path. It has
             // to be set everywhere proxyPort is, or the dial below is skipped and
@@ -1706,8 +1677,8 @@ object AaWirelessBtControl {
                 }
                 // The scan returns the port too — asking again would cost another
                 // slow round trip over the telematics bridge.
-                findCompanionOnAnySubnet(
-                    manualIp = manualIp,
+                findCompanionOnSelectedInterface(
+                    selectedLocalIpv4 = selectedLocalIpv4,
                     phoneBtAddress = phoneBtAddress,
                     phoneBtName = phoneBtName,
                 )?.let { resolved ->
@@ -1805,7 +1776,7 @@ object AaWirelessBtControl {
                             "knownAddrs=${allKnown.joinToString().ifEmpty { "none" }} " +
                             "usable=${candidates.joinToString().ifEmpty { "none" }} — " +
                             "waiting for companion discovery after AP association")
-                    startBootstrapCompanionDiscovery(attempt, candidates, manualIp)
+                    startBootstrapCompanionDiscovery(attempt, candidates, selectedLocalIpv4)
                     AaWirelessBtServer.Endpoint.PhoneLoopback(OalProtocol.WPP_PROXY_PORT)
                 }
             }

--- a/app/src/main/java/com/openautolink/app/transport/bluetooth/WppSessionAdmission.kt
+++ b/app/src/main/java/com/openautolink/app/transport/bluetooth/WppSessionAdmission.kt
@@ -11,14 +11,23 @@ class WppSessionAdmission {
     class Token internal constructor(
         val generation: Long,
         val transportMode: String,
+        /** Immutable interface selected by this protocol-session generation. */
+        val wppInterfaceName: String?,
     )
 
     private val lock = Any()
     private var generation = 0L
     private var active: Token? = null
 
-    fun installSession(transportMode: String): Token = synchronized(lock) {
-        Token(++generation, transportMode).also { active = it }
+    fun installSession(
+        transportMode: String,
+        wppInterfaceName: String? = null,
+    ): Token = synchronized(lock) {
+        val ownedInterface = wppInterfaceName?.trim()?.takeIf { it.isNotEmpty() }
+        require(transportMode != "wpp" || ownedInterface != null) {
+            "WPP session admission requires an immutable interface name"
+        }
+        Token(++generation, transportMode, ownedInterface).also { active = it }
     }
 
     fun clearSession(token: Token): Boolean = synchronized(lock) {

--- a/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
+++ b/app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt
@@ -5,6 +5,7 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
 import com.openautolink.app.diagnostics.OalLog
+import com.openautolink.app.transport.WppInterfacePolicy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -59,6 +60,9 @@ class TcpConnector(
      * dial succeeds, so moving onto a real phone hotspot re-enables the path.
      */
     private var gatewayFailures = 0
+
+    /** When set, bind outbound sockets to this selected local IPv4. */
+    var sourceIpv4: String? = null
 
     /** When set, connects only to this IP (skips mDNS and gateway discovery). */
     var manualIp: String? = null
@@ -192,9 +196,20 @@ class TcpConnector(
             OalLog.d(TAG, "Skipping unusable (IPv6) host from $source: $host")
             return false
         }
+        val sourceIpv4 = sourceIpv4
+        if (sourceIpv4 != null &&
+            !WppInterfacePolicy.isPeerOnSelectedSubnet(sourceIpv4, host)
+        ) {
+            OalLog.i(TAG, "Skipping $host from $source — outside selected WPP source subnet $sourceIpv4")
+            return false
+        }
         OalLog.i(TAG, "Connecting to $host:$port ($source)")
         return try {
             val socket = Socket()
+            if (sourceIpv4 != null) {
+                socket.bind(InetSocketAddress(sourceIpv4, 0))
+                OalLog.i(TAG, "Binding TCP connector to selected WPP source $sourceIpv4")
+            }
             socket.connect(InetSocketAddress(host, port), CONNECT_TIMEOUT_MS)
             // Socket.connect() is blocking and is not cancelled with connectJob.
             // A different Bluetooth phone can replace this connector while the
@@ -215,7 +230,11 @@ class TcpConnector(
             } catch (e: Exception) {
                 OalLog.d(TAG, "TCP keepalive tuning unavailable: ${e.message}")
             }
-            OalLog.i(TAG, "Connected to companion at $host:$port ($source)")
+            if (sourceIpv4 != null) {
+                OalLog.i(TAG, "Connected to companion at $host:$port from $sourceIpv4 ($source)")
+            } else {
+                OalLog.i(TAG, "Connected to companion at $host:$port ($source)")
+            }
             // A successful dial is the strongest evidence of where the companion
             // is — better than any cache or scan. Publish it so the Bluetooth
             // handshake does not go looking for an address we are already

--- a/app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt
+++ b/app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt
@@ -3,9 +3,12 @@ package com.openautolink.app.transport.hotspot
 import android.os.ParcelFileDescriptor
 import android.system.Os
 import com.openautolink.app.diagnostics.OalLog
+import com.openautolink.app.transport.WppInterfacePolicy
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.net.InetSocketAddress
@@ -38,12 +41,11 @@ import java.net.Socket
  * advertised a port with nothing bound to it. `/proc/net/tcp` on the head unit
  * showed no listener on 5277.
  *
- * ## Why this matters beyond fixing the test
- *
- * With a listener in place the phone connects **directly to the head unit**. The
- * companion app is not in the wireless path at all — no mDNS, no UDP probe, no
- * identity port, no warm proxy. That removes the entire class of companion-side
- * bridge faults from wireless projection.
+ * This is the standards-compatible inbound path and the fallback while the
+ * companion endpoint is unknown. OAL's preferred GM path still uses companion
+ * discovery and advertises a phone-local loopback proxy; that handshake stops
+ * this listener and makes the car dial the companion from the same selected
+ * interface because the vehicle AP blocks phone-to-car inbound traffic.
  *
  * ## Contract
  *
@@ -54,6 +56,10 @@ import java.net.Socket
 class WppTcpServer(
     private val scope: CoroutineScope,
     private val onSocketReady: (Socket) -> Unit,
+    /** Called only after the selected-interface socket has actually bound. */
+    private val onBound: () -> Unit = {},
+    /** Immutable interface name owned by this WPP session generation. */
+    private val bindInterfaceName: String,
     /** Port to bind. Must match the port advertised in the WifiStartRequest. */
     private val port: Int = DEFAULT_PORT,
 ) {
@@ -69,13 +75,20 @@ class WppTcpServer(
 
         /** Accept backlog. One phone at a time; a small backlog absorbs retries. */
         private const val BACKLOG = 4
+        private const val BIND_ADDRESS_WAIT_MS = 46_000L
     }
 
+    private enum class LifecycleState { NEW, RUNNING, STOPPED }
+
+    private val lifecycleLock = Any()
     private var serverSocket: ServerSocket? = null
     private var acceptJob: Job? = null
+    private val bindOutcome = CompletableDeferred<Boolean>()
 
     @Volatile
-    private var isRunning = false
+    private var lifecycleState = LifecycleState.NEW
+
+    private fun isRunning(): Boolean = lifecycleState == LifecycleState.RUNNING
 
     /** True while a session owns the accepted socket. Guards against duplicates. */
     private val sessionActive = java.util.concurrent.atomic.AtomicBoolean(false)
@@ -86,43 +99,108 @@ class WppTcpServer(
         private set
 
     fun start() {
-        if (isRunning) return
-        isRunning = true
-        acceptJob = scope.launch(Dispatchers.IO) { acceptLoop() }
+        synchronized(lifecycleLock) {
+            if (lifecycleState != LifecycleState.NEW) return
+            lifecycleState = LifecycleState.RUNNING
+            acceptJob = scope.launch(Dispatchers.IO) { acceptLoop() }
+        }
     }
 
-    private suspend fun acceptLoop() {
-        try {
-            // Bind on all interfaces: in WPP the phone may reach us over the car's
-            // AP, the phone's own hotspot, or a shared network, and we do not know
-            // which local address it will use until it arrives.
-            serverSocket = ServerSocket().apply {
-                reuseAddress = true
-                bind(InetSocketAddress(port), BACKLOG)
-            }
-            boundPort = serverSocket?.localPort ?: 0
-            OalLog.i(TAG, "WPP TCP server listening on 0.0.0.0:$boundPort — " +
-                    "phone will connect here after the Bluetooth handshake")
-        } catch (e: Exception) {
-            OalLog.e(TAG, "Failed to bind WPP TCP port $port: ${e.message}")
-            isRunning = false
-            return
-        }
+    /** Positive readiness signal used to prevent SDP publication before bind. */
+    suspend fun awaitBound(): Boolean = bindOutcome.await()
 
-        while (isRunning && scope.isActive) {
-            val socket = try {
-                serverSocket?.accept()
-            } catch (e: Exception) {
-                if (isRunning) OalLog.w(TAG, "WPP accept() failed: ${e.message}")
-                null
-            } ?: run {
-                // Socket closed under us — nothing to recover to.
-                if (isRunning && serverSocket == null) return
+    private suspend fun acceptLoop() {
+        var uncommittedSocket: ServerSocket? = null
+        try {
+            val deadline = System.currentTimeMillis() + BIND_ADDRESS_WAIT_MS
+            var selectedAddress = WppInterfacePolicy.liveIpv4(bindInterfaceName)
+            if (selectedAddress == null) {
+                OalLog.i(TAG, "Waiting for selected WPP interface before binding TCP server")
+            }
+            while (isRunning() && scope.isActive && selectedAddress == null &&
+                System.currentTimeMillis() < deadline
+            ) {
+                delay(250)
+                selectedAddress = WppInterfacePolicy.liveIpv4(bindInterfaceName)
+            }
+            val bindAddress = selectedAddress
+            if (bindAddress == null) {
+                OalLog.e(TAG, "Selected WPP interface unavailable — TCP server not bound")
+                synchronized(lifecycleLock) {
+                    if (lifecycleState == LifecycleState.RUNNING) {
+                        lifecycleState = LifecycleState.STOPPED
+                    }
+                    bindOutcome.complete(false)
+                }
                 return
             }
 
+            val candidate = ServerSocket()
+            uncommittedSocket = candidate
+            candidate.reuseAddress = true
+            candidate.bind(InetSocketAddress(bindAddress, port), BACKLOG)
+            val committed = synchronized(lifecycleLock) {
+                if (lifecycleState != LifecycleState.RUNNING) {
+                    false
+                } else {
+                    serverSocket = candidate
+                    boundPort = candidate.localPort
+                    uncommittedSocket = null
+                    true
+                }
+            }
+            if (!committed) {
+                runCatching { candidate.close() }
+                bindOutcome.complete(false)
+                return
+            }
+
+            synchronized(lifecycleLock) {
+                if (lifecycleState != LifecycleState.RUNNING || serverSocket !== candidate) {
+                    bindOutcome.complete(false)
+                    return
+                }
+                OalLog.i(TAG, "WPP selected-interface inbound listener ready on " +
+                        "$bindAddress:$boundPort")
+                bindOutcome.complete(true)
+                runCatching { onBound() }
+                    .onFailure { OalLog.w(TAG, "WPP bind-ready callback failed: ${it.message}") }
+            }
+        } catch (e: Exception) {
+            runCatching { uncommittedSocket?.close() }
+            OalLog.e(TAG, "Failed to bind WPP TCP port $port: ${e.message}")
+            synchronized(lifecycleLock) {
+                if (lifecycleState == LifecycleState.RUNNING) {
+                    lifecycleState = LifecycleState.STOPPED
+                }
+                bindOutcome.complete(false)
+            }
+            return
+        }
+
+        while (isRunning() && scope.isActive) {
+            val listeningSocket = synchronized(lifecycleLock) {
+                serverSocket?.takeIf { lifecycleState == LifecycleState.RUNNING }
+            } ?: break
+            val socket = try {
+                listeningSocket.accept()
+            } catch (e: Exception) {
+                if (isRunning()) OalLog.w(TAG, "WPP accept() failed: ${e.message}")
+                null
+            } ?: break
+
+            val remoteHost = runCatching { socket.inetAddress?.hostAddress }.getOrNull()
             val remote = runCatching { socket.remoteSocketAddress?.toString() ?: "?" }
                 .getOrDefault("?")
+            val bindAddress = listeningSocket.inetAddress?.hostAddress
+            if (remoteHost == null || bindAddress == null ||
+                !WppInterfacePolicy.isPeerOnSelectedSubnet(bindAddress, remoteHost)
+            ) {
+                OalLog.w(TAG, "Rejecting WPP connection from $remote — outside selected " +
+                        "interface subnet (${bindAddress ?: "unavailable"})")
+                runCatching { socket.close() }
+                continue
+            }
             OalLog.i(TAG, "Phone connected over WPP from $remote")
             // Log the peer address explicitly: on a flat /23 an open port attracts
             // unrelated LAN traffic, and gearhead may reconnect the phone under a
@@ -153,6 +231,7 @@ class WppTcpServer(
 
             onSocketReady(socket)
         }
+        stop()
     }
 
     /**
@@ -187,14 +266,26 @@ class WppTcpServer(
     }
 
     fun stop() {
-        if (!isRunning && serverSocket == null) return
-        isRunning = false
-        runCatching { serverSocket?.close() }
-        serverSocket = null
-        acceptJob?.cancel()
-        acceptJob = null
-        boundPort = 0
-        sessionActive.set(false)
+        var socketToClose: ServerSocket? = null
+        var jobToCancel: Job? = null
+        val transitioned = synchronized(lifecycleLock) {
+            if (lifecycleState == LifecycleState.STOPPED) {
+                false
+            } else {
+                lifecycleState = LifecycleState.STOPPED
+                socketToClose = serverSocket
+                serverSocket = null
+                jobToCancel = acceptJob
+                acceptJob = null
+                boundPort = 0
+                sessionActive.set(false)
+                bindOutcome.complete(false)
+                true
+            }
+        }
+        if (!transitioned) return
+        runCatching { socketToClose?.close() }
+        jobToCancel?.cancel()
         OalLog.i(TAG, "WPP TCP server stopped")
     }
 }

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -644,6 +644,12 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
             val hotspotSsid = preferences.hotspotSsid.first()
             val hotspotPassword = preferences.hotspotPassword.first()
             val directTransport = preferences.directTransport.first()
+            val wppInterfaceName = preferences.wppApInterface.first()
+            if (directTransport == AppPreferences.DIRECT_TRANSPORT_WPP) {
+                phoneDiscovery.setInterfaceConstraint(wppInterfaceName)
+            } else {
+                phoneDiscovery.setInterfaceConstraint(null)
+            }
             wppRearmSource?.let {
                 val rejection = WppWakeReconnectPolicy.preStartRejection(
                     wppSelectedNow = directTransport == AppPreferences.DIRECT_TRANSPORT_WPP,
@@ -833,6 +839,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 micSourcePreference = micSrc,
                 scalingMode = scalingMode,
                 directTransport = directTransport,
+                wppInterfaceName = wppInterfaceName,
                 hotspotSsid = hotspotSsid,
                 hotspotPassword = hotspotPassword,
                 videoAutoNegotiate = videoAutoNeg,
@@ -1049,6 +1056,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     ?: known.firstOrNull { it.phoneId == activeId }?.friendlyName
             }.collect { name -> _phoneName.value = name }
         }
+
         // Continuously run mDNS discovery while in Car Hotspot mode. This
         // keeps `knownPhones` "online" status fresh and lets the floating
         // switcher button surface phones the moment they appear on the AP.
@@ -1389,9 +1397,9 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                         state == SessionState.IDLE
                     // USB has nothing to sweep for. WPP does: the sweep is how we
                     // learn the companion's address, which the Bluetooth advertiser
-                    // needs to ask for its AA proxy port. It never dials the phone
-                    // in WPP mode — the phone connects to us — so running it is
-                    // discovery only.
+                    // needs to ask for its AA proxy port. The sweep itself never
+                    // dials; a later admitted Bluetooth handshake may choose the
+                    // companion proxy and source-bind the car's outbound dial.
                     val transportNow = preferences.directTransport.first()
                     if (transportNow == AppPreferences.DIRECT_TRANSPORT_USB) continue
                     if (!idleAndCarHotspot) continue
@@ -1403,7 +1411,14 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                     // Cheap-first: a single UDP broadcast costs ~1 packet
                     // and ~600ms wall time. Only escalate to the full /24
                     // sweep if broadcast comes back empty.
-                    val hits = try { phoneDiscovery.udpBroadcastAllInterfaces(listenWindowMs = 600L) } catch (_: Exception) { 0 }
+                    val hits = try {
+                        if (transportNow == AppPreferences.DIRECT_TRANSPORT_WPP) {
+                            val wppInterface = preferences.wppApInterface.first()
+                            phoneDiscovery.udpBroadcastOnInterface(wppInterface, listenWindowMs = 600L)
+                        } else {
+                            phoneDiscovery.udpBroadcastAllInterfaces(listenWindowMs = 600L)
+                        }
+                    } catch (_: Exception) { 0 }
                     if (hits == 0) {
                         kickSweep()
                     }
@@ -1620,6 +1635,16 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
      */
     private fun kickSweep() {
         viewModelScope.launch {
+            val transport = try { preferences.directTransport.first() } catch (_: Exception) { "" }
+            if (transport == AppPreferences.DIRECT_TRANSPORT_WPP) {
+                val wppInterface = try {
+                    preferences.wppApInterface.first()
+                } catch (_: Exception) {
+                    AppPreferences.DEFAULT_WPP_AP_INTERFACE
+                }
+                phoneDiscovery.startSweep(forcedInterfaceName = wppInterface)
+                return@launch
+            }
             val auto = try { preferences.carHotspotAutoInterface.first() } catch (_: Exception) { true }
             if (auto) {
                 phoneDiscovery.startSweep()

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -315,9 +315,9 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
             text = when (uiState.directTransport) {
                 "usb" -> "Phone connects to the car over a USB cable using AOA v2. The Wi-Fi connection mode below is ignored. A device picker is shown on the projection screen so the OS only prompts for the phone you select."
                 AppPreferences.DIRECT_TRANSPORT_WPP ->
-                    "The phone connects to the car directly, the way a factory head unit works — no companion app needed. " +
-                        "The car advertises itself over Bluetooth, then hands the phone the Wi-Fi details below. " +
-                        "Pair the phone to this head unit over Bluetooth first, and make sure \"Phone calls\" is enabled for it."
+                    "Factory-style Bluetooth/WPP startup. The companion app is required: " +
+                        "the car advertises the selected Wi-Fi path, then dials the companion proxy on that same interface. " +
+                        "Pair Bluetooth first and keep \"Phone calls\" enabled."
                 else -> "Phone and car talk over the shared Wi-Fi network configured below."
             },
             style = MaterialTheme.typography.bodySmall,
@@ -376,26 +376,55 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
                 },
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
             )
-            LocalEchoTextField(
-                value = uiState.wppApInterface,
-                onValueChange = { viewModel.updateWppApInterface(it) },
-                label = { Text("Hotspot network interface") },
-                singleLine = true,
-                supportingText = {
-                    Text("The interface serving the car's hotspot. Default \"${AppPreferences.DEFAULT_WPP_AP_INTERFACE}\" is correct for AAOS head units — only change it if the phone joins the hotspot but projection never starts.")
-                },
+            var wppInterfaceMenuOpen by remember { mutableStateOf(false) }
+            var wppInterfaces by remember { mutableStateOf(viewModel.listCarHotspotInterfaces()) }
+            Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
-            )
-            LocalEchoTextField(
-                value = uiState.wppLocalIp,
-                onValueChange = { viewModel.updateWppLocalIp(it) },
-                label = { Text("Head unit IP (optional)") },
-                singleLine = true,
-                supportingText = {
-                    Text("Leave blank — this is detected automatically each time. Only set it to diagnose a one-off problem, and clear it afterwards: the car's hotspot subnet is stable across ignition cycles but can change across multi-week epochs, so a fixed value will eventually stop working.")
-                },
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
-            )
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("WPP network interface", style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        uiState.wppApInterface.ifBlank { AppPreferences.DEFAULT_WPP_AP_INTERFACE },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        "All WPP advertising, discovery, and traffic is restricted to this interface. " +
+                            "GM EVs normally use ${AppPreferences.DEFAULT_WPP_AP_INTERFACE}.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Box {
+                    FilledTonalButton(onClick = {
+                        wppInterfaces = viewModel.listCarHotspotInterfaces()
+                        wppInterfaceMenuOpen = true
+                    }) { Text("Choose") }
+                    androidx.compose.material3.DropdownMenu(
+                        expanded = wppInterfaceMenuOpen,
+                        onDismissRequest = { wppInterfaceMenuOpen = false },
+                    ) {
+                        if (wppInterfaces.isEmpty()) {
+                            androidx.compose.material3.DropdownMenuItem(
+                                text = { Text("No active IPv4 interfaces") },
+                                onClick = { wppInterfaceMenuOpen = false },
+                                enabled = false,
+                            )
+                        } else {
+                            wppInterfaces.forEach { (name, ip) ->
+                                androidx.compose.material3.DropdownMenuItem(
+                                    text = { Text("$name  ($ip)") },
+                                    onClick = {
+                                        viewModel.updateWppApInterface(name)
+                                        wppInterfaceMenuOpen = false
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
             LocalEchoTextField(
                 value = uiState.wppBssid,
                 onValueChange = { viewModel.updateWppBssid(it) },
@@ -414,9 +443,10 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
             )
         }
-        Spacer(modifier = Modifier.height(12.dp))
+        if (uiState.directTransport == AppPreferences.DIRECT_TRANSPORT_HOTSPOT) {
+            Spacer(modifier = Modifier.height(12.dp))
 
-        SectionHeader("Connection Mode")
+            SectionHeader("Connection Mode")
         Spacer(modifier = Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
@@ -615,12 +645,14 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
             }
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
-        HorizontalDivider(modifier = Modifier.fillMaxWidth(0.5f))
-        Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(20.dp))
+            HorizontalDivider(modifier = Modifier.fillMaxWidth(0.5f))
+            Spacer(modifier = Modifier.height(16.dp))
+        }
 
-        // --- Manual IP (emulator/testing) ---
-        SectionHeader("Manual IP Address")
+        if (uiState.directTransport == AppPreferences.DIRECT_TRANSPORT_HOTSPOT) {
+            // --- Manual IP (emulator/testing) ---
+            SectionHeader("Manual IP Address")
         Spacer(modifier = Modifier.height(4.dp))
 
         Row(
@@ -681,6 +713,7 @@ private fun ConnectionTab(viewModel: SettingsViewModel, uiState: SettingsUiState
             }
 
             Spacer(modifier = Modifier.height(16.dp))
+        }
     }
 }
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -21,8 +21,6 @@ data class SettingsUiState(
     val hotspotPassword: String = AppPreferences.DEFAULT_HOTSPOT_PASSWORD,
     /** AP BSSID advertised to the phone in WPP mode. Must be entered by hand. */
     val wppBssid: String = "",
-    /** Manual head-unit IP for WPP; blank means auto-detect. */
-    val wppLocalIp: String = "",
     /** Interface serving the car's hotspot; its IPv4 is advertised to the phone. */
     val wppApInterface: String = AppPreferences.DEFAULT_WPP_AP_INTERFACE,
     /** Exact AP frequency in MHz sent to the phone; 0 = advertise the default 5GHz set. */
@@ -214,7 +212,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _hotspotSsidOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_SSID)
     private val _hotspotPasswordOverride = MutableStateFlow(AppPreferences.DEFAULT_HOTSPOT_PASSWORD)
     private val _wppBssidOverride = MutableStateFlow("")
-    private val _wppLocalIpOverride = MutableStateFlow("")
     private val _wppApInterfaceOverride = MutableStateFlow(AppPreferences.DEFAULT_WPP_AP_INTERFACE)
     private val _wppChannelMhzOverride = MutableStateFlow("")
     private val _directTransportOverride = MutableStateFlow(AppPreferences.DEFAULT_DIRECT_TRANSPORT)
@@ -228,9 +225,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
         viewModelScope.launch {
             preferences.wppBssid.collect { _wppBssidOverride.value = it }
-        }
-        viewModelScope.launch {
-            preferences.wppLocalIp.collect { _wppLocalIpOverride.value = it }
         }
         viewModelScope.launch {
             preferences.wppApInterface.collect { _wppApInterfaceOverride.value = it }
@@ -251,7 +245,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _hotspotPasswordOverride,
         _directTransportOverride,
         _wppBssidOverride,
-        _wppLocalIpOverride,
         _wppApInterfaceOverride,
         _wppChannelMhzOverride,
         galVersion,
@@ -260,10 +253,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         state.copy(
             hotspotSsid = arr[1] as String, hotspotPassword = arr[2] as String,
             directTransport = arr[3] as String, wppBssid = arr[4] as String,
-            wppLocalIp = arr[5] as String,
-            wppApInterface = arr[6] as String,
-            wppChannelMhz = arr[7] as String,
-            galVersion = arr[8] as String,
+            wppApInterface = arr[5] as String,
+            wppChannelMhz = arr[6] as String,
+            galVersion = arr[7] as String,
         )
     }.stateIn(
         viewModelScope,
@@ -360,11 +352,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun updateWppApInterface(name: String) {
         _wppApInterfaceOverride.value = name
         viewModelScope.launch { preferences.setWppApInterface(name) }
-    }
-
-    fun updateWppLocalIp(ip: String) {
-        _wppLocalIpOverride.value = ip
-        viewModelScope.launch { preferences.setWppLocalIp(ip) }
     }
 
     fun updateWppBssid(bssid: String) {
@@ -617,6 +604,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             val hotspotSsid = preferences.hotspotSsid.first()
             val hotspotPassword = preferences.hotspotPassword.first()
             val directTransport = preferences.directTransport.first()
+            val wppInterfaceName = _wppApInterfaceOverride.value
+            preferences.setWppApInterface(wppInterfaceName)
             val videoAutoNeg = preferences.videoAutoNegotiate.first()
             val aaRes = preferences.aaResolution.first()
             val aaDpi = preferences.aaDpi.first()
@@ -649,6 +638,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 micSourcePreference = micSrc,
                 scalingMode = scalingMode,
                 directTransport = directTransport,
+                wppInterfaceName = wppInterfaceName,
                 hotspotSsid = hotspotSsid,
                 hotspotPassword = hotspotPassword,
                 videoAutoNegotiate = videoAutoNeg,

--- a/app/src/test/java/com/openautolink/app/transport/WppInterfacePolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/WppInterfacePolicyTest.kt
@@ -1,0 +1,72 @@
+package com.openautolink.app.transport
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppInterfacePolicyTest {
+
+    private val interfaces = listOf(
+        WppInterfacePolicy.InterfaceIpv4("wlan0", "10.93.118.188"),
+        WppInterfacePolicy.InterfaceIpv4("ap_br_swlan0", "10.205.97.238"),
+    )
+
+    @Test
+    fun `configured interface resolves only its own live IPv4`() {
+        assertEquals(
+            "10.205.97.238",
+            WppInterfacePolicy.selectedIpv4("ap_br_swlan0", interfaces),
+        )
+    }
+
+    @Test
+    fun `missing configured interface never falls back to another interface`() {
+        assertNull(WppInterfacePolicy.selectedIpv4("missing0", interfaces))
+    }
+
+    @Test
+    fun `peer on selected interface subnet is accepted`() {
+        assertTrue(
+            WppInterfacePolicy.isPeerOnSelectedSubnet(
+                selectedLocalIpv4 = "10.205.97.238",
+                peerHost = "10.205.97.109:5277",
+            ),
+        )
+    }
+
+    @Test
+    fun `peer on another live interface subnet is rejected`() {
+        assertFalse(
+            WppInterfacePolicy.isPeerOnSelectedSubnet(
+                selectedLocalIpv4 = "10.205.97.238",
+                peerHost = "10.93.118.184",
+            ),
+        )
+    }
+
+    @Test
+    fun `actual prefix admits adjacent slash 24 inside slash 23`() {
+        assertTrue(
+            WppInterfacePolicy.isPeerOnSelectedSubnet(
+                selectedLocalIpv4 = "192.168.1.174",
+                peerHost = "192.168.0.35",
+                prefixLength = 23,
+            ),
+        )
+        assertFalse(
+            WppInterfacePolicy.isPeerOnSelectedSubnet(
+                selectedLocalIpv4 = "192.168.1.174",
+                peerHost = "192.168.0.35",
+                prefixLength = 24,
+            ),
+        )
+    }
+
+    @Test
+    fun `malformed and IPv6 peers are rejected`() {
+        assertFalse(WppInterfacePolicy.isPeerOnSelectedSubnet("10.205.97.238", "not-an-ip"))
+        assertFalse(WppInterfacePolicy.isPeerOnSelectedSubnet("10.205.97.238", "fe80::1"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/WppInterfaceWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/WppInterfaceWiringContractTest.kt
@@ -1,0 +1,252 @@
+package com.openautolink.app.transport
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WppInterfaceWiringContractTest {
+
+    @Test
+    fun `WPP address resolution has no cross-interface fallback`() {
+        val control = source(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        )
+
+        assertTrue(control.contains("WppInterfacePolicy.selectedIpv4("))
+        assertFalse(control.contains("findCompanionOnAnySubnet("))
+        assertFalse(control.contains("private fun allLocalIpv4()"))
+        assertFalse(control.contains("fun tier(name: String)"))
+    }
+
+    @Test
+    fun `WPP discovery rejects peers outside selected interface subnet`() {
+        val control = source(
+            "app/src/main/java/com/openautolink/app/transport/bluetooth/AaWirelessBtControl.kt",
+        )
+
+        assertTrue(control.contains("WppInterfacePolicy.isPeerOnSelectedSubnet("))
+        assertTrue(control.contains("Rejecting companion at ${'$'}host — outside selected WPP interface"))
+    }
+
+    @Test
+    fun `WPP idle sweep is forced to configured interface`() {
+        val projection = source(
+            "app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt",
+        )
+        val discovery = source(
+            "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
+        )
+
+        val manager = source(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        )
+
+        assertTrue(projection.contains("phoneDiscovery.startSweep(forcedInterfaceName = wppInterface)"))
+        assertTrue(projection.contains("phoneDiscovery.udpBroadcastOnInterface(wppInterface"))
+        assertFalse(projection.contains("preferences.wppApInterface,\n            ) { transport, interfaceName ->"))
+        assertTrue(manager.contains("wppInterfaceName.takeIf { directTransport == AppPreferences.DIRECT_TRANSPORT_WPP }"))
+
+        assertTrue(discovery.contains("private var interfaceConstraint"))
+        assertTrue(discovery.contains("val forced = interfaceConstraint ?: forcedInterfaceName"))
+        assertTrue(discovery.contains("if (host != null && !isHostAllowed(host))"))
+    }
+
+    @Test
+    fun `WPP TCP sweep binds every probe to selected source address`() {
+        val discovery = source(
+            "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
+        )
+
+        assertTrue(discovery.contains("probeHost(ip, sourceIpv4 = plan.localIpv4)"))
+        assertTrue(discovery.contains("socket.bind(InetSocketAddress(sourceIpv4, 0))"))
+    }
+
+    @Test
+    fun `WPP UDP discovery binds selected source address`() {
+        val discovery = source(
+            "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
+        )
+
+        assertTrue(discovery.contains("DatagramSocket(null)"))
+        assertTrue(discovery.contains("if (sourceIpv4 != null) InetSocketAddress(sourceIpv4, 0)"))
+        assertTrue(discovery.contains("WppInterfacePolicy.isPeerOnSelectedSubnet(sourceIpv4, replyHost)"))
+    }
+
+    @Test
+    fun `inbound WPP server binds and admits only selected interface subnet`() {
+        val server = source(
+            "app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt",
+        )
+        val aasdk = source(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        )
+
+        assertTrue(server.contains("private val bindInterfaceName: String"))
+        assertTrue(server.contains("WppInterfacePolicy.liveIpv4(bindInterfaceName)"))
+        assertTrue(server.contains("bind(InetSocketAddress(bindAddress, port), BACKLOG)"))
+        assertTrue(server.contains("WppInterfacePolicy.isPeerOnSelectedSubnet(bindAddress, remoteHost)"))
+        assertTrue(server.contains("private enum class LifecycleState { NEW, RUNNING, STOPPED }"))
+        assertTrue(server.contains("if (lifecycleState != LifecycleState.NEW) return"))
+        assertTrue(server.contains("if (lifecycleState != LifecycleState.RUNNING)"))
+        assertTrue(server.contains("runCatching { candidate.close() }"))
+        assertTrue(aasdk.contains("bindInterfaceName = wppInterfaceName"))
+        assertTrue(aasdk.contains("WppInterfacePolicy.liveIpv4(wppInterfaceName)"))
+        assertTrue(source("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+            .contains("session.wppInterfaceName = wppInterfaceName"))
+    }
+
+    @Test
+    fun `WPP admission waits for the selected-interface listener to bind`() {
+        val server = source(
+            "app/src/main/java/com/openautolink/app/transport/hotspot/WppTcpServer.kt",
+        )
+        val aasdk = source(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        )
+        val manager = source(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        )
+        val startBlock = manager.substringAfter("private suspend fun startSession(")
+            .substringBefore("private fun prepareNativeSessionStart")
+
+        assertTrue(server.contains("suspend fun awaitBound(): Boolean"))
+        assertTrue(server.contains("bindOutcome.complete(true)"))
+        assertTrue(aasdk.contains("suspend fun awaitWppTransportReady(): Boolean"))
+        val start = startBlock.indexOf("session.start()")
+        val await = startBlock.indexOf("session.awaitWppTransportReady()", startIndex = start)
+        val admit = startBlock.indexOf("installWirelessSessionAdmissionIfCurrent(", startIndex = start)
+        assertTrue(start >= 0)
+        assertTrue(await > start)
+        assertTrue(admit > await)
+    }
+
+    @Test
+    fun `changing WPP interface cancels a stale sweep before installing constraint`() {
+        val discovery = source(
+            "app/src/main/java/com/openautolink/app/transport/PhoneDiscovery.kt",
+        )
+        val block = discovery.substringAfter("fun setInterfaceConstraint(interfaceName: String?)")
+            .substringBefore("private fun isHostAllowed")
+
+        val stop = block.indexOf("stopSweep()")
+        val install = block.indexOf("interfaceConstraint = normalized")
+        assertTrue(stop >= 0)
+        assertTrue(install > stop)
+    }
+
+    @Test
+    fun `stop and reconnect cancel pending WPP bind before lifecycle mutex`() {
+        val manager = source(
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+        )
+        val stopBlock = manager.substringAfter("suspend fun stop()")
+            .substringBefore("private suspend fun stopWhileLifecycleLocked")
+        val reconnectBlock = manager.substringAfter("suspend fun reconnect(")
+            .substringBefore("private suspend fun doReconnectAfterCancel")
+
+        val stopCancel = stopBlock.indexOf("interruptPendingTransportStart(\"stop\")")
+        val stopLock = stopBlock.indexOf("startMutex.lock()")
+        val reconnectCancel = reconnectBlock.lastIndexOf("interruptPendingTransportStart(\"reconnect\")")
+        val reconnectLock = reconnectBlock.indexOf("startMutex.lock()")
+        val handshakeGuard = reconnectBlock.indexOf("AaWirelessBtControl.handshakeInFlight")
+        assertTrue(stopCancel >= 0)
+        assertTrue(stopLock > stopCancel)
+        assertTrue(reconnectCancel >= 0)
+        assertTrue(reconnectCancel > handshakeGuard)
+        assertTrue(reconnectLock > reconnectCancel)
+        assertTrue(manager.contains("interruptPendingTransportStart(\"stop\")"))
+        assertTrue(manager.contains("installWirelessSessionAdmissionIfCurrent("))
+        assertTrue(manager.contains("currentTransportStartGeneration() != transportStartGeneration"))
+    }
+
+    @Test
+    fun `WPP aborts instead of starting an unbound connector`() {
+        val aasdk = source(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        )
+        val block = aasdk.substringAfter("if (transportMode == \"wpp\")")
+            .substringBefore("// An explicit dial target wins")
+
+        assertTrue(block.contains("if (selectedSourceIpv4 == null)"))
+        assertTrue(block.contains("return@synchronized"))
+        assertTrue(block.indexOf("return@synchronized") < block.indexOf("connector.sourceIpv4"))
+    }
+
+    @Test
+    fun `WPP TCP connector binds selected source address`() {
+        val connector = source(
+            "app/src/main/java/com/openautolink/app/transport/hotspot/TcpConnector.kt",
+        )
+        val aasdk = source(
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+        )
+
+        assertTrue(connector.contains("socket.bind(InetSocketAddress(sourceIpv4, 0))"))
+        assertTrue(connector.contains("Connected to companion at ${'$'}host:${'$'}port from ${'$'}sourceIpv4"))
+        assertTrue(aasdk.contains("connector.sourceIpv4 = selectedSourceIpv4"))
+    }
+
+    @Test
+    fun `save and reconnect owns the synchronously selected WPP interface`() {
+        val viewModel = source(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt",
+        )
+        val saveBlock = viewModel.substringAfter("fun saveAndReconnect()")
+
+        val snapshot = saveBlock.indexOf("val wppInterfaceName = _wppApInterfaceOverride.value")
+        val persist = saveBlock.indexOf("preferences.setWppApInterface(wppInterfaceName)")
+        val reconnect = saveBlock.indexOf("sm.reconnect(")
+        assertTrue(snapshot >= 0)
+        assertTrue(persist > snapshot)
+        assertTrue(reconnect > persist)
+        assertFalse(saveBlock.contains(".setInterfaceConstraint(wppInterfaceName)"))
+        val manager = source("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+        val sessionBlock = manager.substringAfter("private suspend fun startSession(")
+            .substringBefore("// Map resolution string")
+        assertTrue(sessionBlock.contains(".setInterfaceConstraint("))
+        assertTrue(sessionBlock.contains("wppInterfaceName.takeIf"))
+    }
+
+    @Test
+    fun `WPP settings use a live interface selector instead of free text`() {
+        val settings = source(
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+        )
+        val wppBlock = settings
+            .substringAfter("if (uiState.directTransport == AppPreferences.DIRECT_TRANSPORT_WPP)")
+            .substringBefore("SectionHeader(\"Connection Mode\")")
+
+        assertTrue(wppBlock.contains("WPP network interface"))
+        assertTrue(wppBlock.contains("listCarHotspotInterfaces()"))
+        assertFalse(wppBlock.contains("onValueChange = { viewModel.updateWppApInterface(it) }"))
+    }
+
+    @Test
+    fun `blank persisted WPP interface resolves and saves as GM default`() {
+        val preferences = source(
+            "app/src/main/java/com/openautolink/app/data/AppPreferences.kt",
+        )
+        val readBlock = preferences.substringAfter("val wppApInterface: Flow<String>")
+            .substringBefore("val directTransport")
+        val writeBlock = preferences.substringAfter("suspend fun setWppApInterface(name: String)")
+            .substringBefore("suspend fun setDirectTransport")
+
+        assertTrue(readBlock.contains("takeIf { it.isNotEmpty() }"))
+        assertTrue(readBlock.contains("?: DEFAULT_WPP_AP_INTERFACE"))
+        assertTrue(writeBlock.contains("ifEmpty { DEFAULT_WPP_AP_INTERFACE }"))
+    }
+
+    private fun source(relativePath: String): String = projectFile(relativePath).readText()
+
+    private fun projectFile(relativePath: String): File {
+        var dir = File(System.getProperty("user.dir") ?: ".")
+        repeat(8) {
+            val candidate = File(dir, relativePath)
+            if (candidate.exists()) return candidate
+            val parent = dir.parentFile ?: return File(relativePath)
+            dir = parent
+        }
+        return File(relativePath)
+    }
+}

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppAdmissionWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppAdmissionWiringContractTest.kt
@@ -23,21 +23,29 @@ class WppAdmissionWiringContractTest {
         assertTrue(control.contains("if (!sessionAdmission.canAdvertise()) return null"))
         assertTrue(control.contains("expectedOwner: WppSessionAdmission.Token? = null"))
         assertTrue(control.contains("stopAdvertisingNow(\"re-advertise\", expectedOwner = owner)"))
-        val install = control.substringAfter("fun installSessionOwner(transportMode: String)")
+        val install = control.substringAfter("fun installSessionOwner(")
             .substringBefore("fun clearSessionOwner")
         assertTrue(install.contains("synchronized(this)"))
-        assertTrue(install.contains("sessionAdmission.installSession(transportMode)"))
+        assertTrue(install.contains("sessionAdmission.installSession(transportMode, wppInterfaceName)"))
+        assertTrue(control.contains("val apInterface = expectedOwner.wppInterfaceName"))
     }
 
     @Test
-    fun `initial owner waits for admitted handshake and recovery refreshes SDP once`() {
+    fun `initial owner waits and recovery publishes only after its transport is ready`() {
         val session = source("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt")
         val startWpp = session.substringAfter("private fun startWpp(recovery: Boolean = false)")
             .substringBefore("var onNativeSessionStarting")
 
         assertTrue(startWpp.indexOf("if (recovery)") < startWpp.indexOf("withIdentityValidatedCompanion"))
         assertTrue(startWpp.contains("Initial WPP owner installed"))
-        assertEquals(1, Regex("""AaWirelessBtControl\.readvertise\(\)""").findAll(session).count())
+        val knownBlock = startWpp.substringAfter("if (known != null)")
+            .substringBefore("return")
+        val boundBlock = startWpp.substringAfter("onBound = {")
+            .substringBefore("bindInterfaceName =")
+        assertTrue(knownBlock.contains("AaWirelessBtControl.readvertise()"))
+        assertTrue(boundBlock.contains("if (recovery)"))
+        assertTrue(boundBlock.contains("AaWirelessBtControl.readvertise()"))
+        assertEquals(2, Regex("""AaWirelessBtControl\.readvertise\(\)""").findAll(startWpp).count())
     }
 
     @Test

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppBootstrapPolicyTest.kt
@@ -103,7 +103,8 @@ class WppBootstrapPolicyTest {
 
         assertTrue(scanner.contains("bootstrapAttempt.get() !== attempt"))
         assertTrue(scanner.contains("val remainingMs = (deadline - System.currentTimeMillis())"))
-        assertTrue(scanner.contains("findCompanionOnAnySubnet("))
+        assertTrue(scanner.contains("findCompanionOnSelectedInterface("))
+        assertTrue(scanner.contains("selectedLocalIpv4 = selectedLocalIpv4"))
         assertTrue(scanner.contains("phoneBtAddress = attempt.phoneBtAddress"))
         assertTrue(scanner.contains("phoneBtName = attempt.phoneBtName"))
         assertTrue(scanner.contains("WppBootstrapPolicy.DISCOVERY_DEADLINE_MS"))

--- a/app/src/test/java/com/openautolink/app/transport/bluetooth/WppSessionAdmissionTest.kt
+++ b/app/src/test/java/com/openautolink/app/transport/bluetooth/WppSessionAdmissionTest.kt
@@ -20,7 +20,8 @@ class WppSessionAdmissionTest {
         val admission = WppSessionAdmission()
 
         assertFalse(admission.canAdvertise())
-        val wpp = admission.installSession("wpp")
+        val wpp = admission.installSession("wpp", "ap_br_swlan0")
+        assertTrue(wpp.wppInterfaceName == "ap_br_swlan0")
         assertTrue(admission.canAdvertise())
         assertTrue(admission.clearSession(wpp))
         assertFalse(admission.canAdvertise())
@@ -29,8 +30,8 @@ class WppSessionAdmissionTest {
     @Test
     fun `stale teardown cannot clear a replacement WPP owner`() {
         val admission = WppSessionAdmission()
-        val old = admission.installSession("wpp")
-        val replacement = admission.installSession("wpp")
+        val old = admission.installSession("wpp", "ap_br_swlan0")
+        val replacement = admission.installSession("wpp", "wlan1")
 
         assertFalse(admission.clearSession(old))
         assertTrue(admission.canAdvertise())

--- a/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/ui/projection/WppWakeReconnectPolicyTest.kt
@@ -332,9 +332,9 @@ class WppWakeReconnectPolicyTest {
         assertTrue(manager.contains("startupOutcome.await()"))
 
         val startBlock = manager
-            .substringAfter("private fun startSession(")
+            .substringAfter("private suspend fun startSession(")
             .substringBefore("private fun prepareNativeSessionStart")
-        val ownerInstall = startBlock.indexOf("val ownerToken = installWirelessSessionAdmission(directTransport)")
+        val ownerInstall = startBlock.indexOf("val ownerToken = installWirelessSessionAdmissionIfCurrent(")
         val ownerQuery = startBlock.indexOf("AaWirelessBtControl.isCurrentSessionOwner(ownerToken)", startIndex = ownerInstall)
         val outcomeLog = startBlock.indexOf("WPP rearm outcome: source=", startIndex = ownerQuery)
         assertTrue(ownerInstall >= 0)

--- a/app/src/test/java/com/openautolink/app/wake/SessionReadinessInstrumentationTest.kt
+++ b/app/src/test/java/com/openautolink/app/wake/SessionReadinessInstrumentationTest.kt
@@ -35,7 +35,7 @@ class SessionReadinessInstrumentationTest {
 
         val sessionStart = managerSource.indexOf("session.start()", startIndex = nativeEnd)
         val installOwner = managerSource.indexOf(
-            "installWirelessSessionAdmission(directTransport)",
+            "installWirelessSessionAdmissionIfCurrent(",
             startIndex = sessionStart,
         )
         val reportAdmission = managerSource.indexOf(


### PR DESCRIPTION
## Summary
- make the selected WPP network interface authoritative from Bluetooth advertisement through discovery and transport
- source-bind inbound and outbound sockets and reject peers outside the selected interface subnet
- fail visibly without fallback when the interface is unavailable
- add live interface selection, immutable session ownership, real prefix-length validation, and lifecycle race guards

## Verification
- 469/469 unit tests passed
- debug AAB prerequisites and APK assembly passed
- release R8 and lint passed

## Delivery
- car app only; companion unchanged
- Play Automotive internal release built separately from this exact commit