### PR TITLE
docs(cluster): describe retained bootstrap owner

### DIFF
--- a/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
@@ -38,8 +38,9 @@ import java.time.ZonedDateTime
  * GM has an internal cluster manager (OnStarTurnByTurnManager) that consumes
  * NavigationManager data and renders turn-by-turn on the instrument cluster.
  * [RelayScreen] exists only to satisfy the main-display host contract while the
- * bootstrap activity is transparent. The activity task is retired as soon as
- * this primary session owns a [NavigationManager].
+ * bootstrap activity is transparent. Once the primary session owns a
+ * [NavigationManager], the activity stays alive as the renderer owner but its
+ * task is moved behind the existing foreground task.
  *
  * Primary/secondary multiplexing handles Templates Host creating multiple sessions:
  * - AAOS emulator: creates DISPLAY_TYPE_MAIN + DISPLAY_TYPE_CLUSTER (two sessions)


### PR DESCRIPTION
## Summary

Correct the `ClusterMainSession` KDoc after PR #117's review-driven lifecycle change.

The final implementation deliberately keeps `CarAppActivity` alive as the Templates Host renderer owner and moves its invisible task behind the foreground. It does **not** retire the task at readiness. The old comment described the rejected intermediate design.

Documentation-only; no runtime behavior changes.

Follow-up to #117.
