### PR TITLE
fix(media): add gated GM controls (#113)

### DIFF
--- a/app/src/main/cpp/aasdk_jni.cpp
+++ b/app/src/main/cpp/aasdk_jni.cpp
@@ -261,6 +261,20 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeRequestKeyframe(
     }
 }
 
+/*
+ * Class:     com_openautolink_app_transport_aasdk_AasdkNative
+ * Method:    nativeSetHuMuted
+ */
+JNIEXPORT void JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSetHuMuted(
+    JNIEnv* /*env*/, jclass /*clazz*/, jboolean muted)
+{
+    std::lock_guard<std::mutex> lock(gSessionMutex);
+    if (gSession) {
+        gSession->setHeadUnitMuted(muted == JNI_TRUE);
+    }
+}
+
 // Typed vehicle sensor JNI methods — each calls the corresponding C++ method
 // that builds the correct SensorBatch protobuf and sends via sensorChannel_.
 

--- a/app/src/main/cpp/aasdk_jni.cpp
+++ b/app/src/main/cpp/aasdk_jni.cpp
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <mutex>
+#include <atomic>
 
 #include "jni_session.h"
 #include "jni_log_bridge.h"
@@ -22,6 +23,7 @@
 static JavaVM* gJvm = nullptr;
 static std::mutex gSessionMutex;  // protects create/start/stop (rare)
 static std::shared_ptr<openautolink::jni::JniSession> gSession;
+static std::atomic<jlong> gSessionGeneration{0};
 
 // Lock-free snapshot for hot-path calls (touch, sensor, mic, keyframe).
 // Writers (create/stop) update under gSessionMutex then store atomically.
@@ -60,7 +62,7 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeInstallCrashHandler(
  * Class:     com_openautolink_app_transport_aasdk_AasdkNative
  * Method:    nativeCreateSession
  */
-JNIEXPORT void JNICALL
+JNIEXPORT jlong JNICALL
 Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeCreateSession(
     JNIEnv* /*env*/, jclass /*clazz*/)
 {
@@ -72,7 +74,9 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeCreateSession(
     }
     auto session = std::make_shared<openautolink::jni::JniSession>(gJvm);
     std::atomic_store(&gSession, session);
-    LOGI("Native session created");
+    const jlong generation = gSessionGeneration.fetch_add(1) + 1;
+    LOGI("Native session created generation=%lld", static_cast<long long>(generation));
+    return generation;
 }
 
 /*
@@ -195,6 +199,31 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSendKeyEvent(
 
 /*
  * Class:     com_openautolink_app_transport_aasdk_AasdkNative
+ * Method:    nativeSendKeyPress
+ */
+JNIEXPORT jboolean JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSendKeyPress(
+    JNIEnv* /*env*/, jclass /*clazz*/, jint keyCode, jlong expectedGeneration)
+{
+    std::lock_guard<std::mutex> lock(gSessionMutex);
+    auto session = std::atomic_load(&gSession);
+    if (!session || gSessionGeneration.load() != expectedGeneration) return JNI_FALSE;
+    return session->sendKeyPress(keyCode) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSetExperimentalMediaControlsEnabled(
+    JNIEnv* /*env*/, jclass /*clazz*/, jboolean enabled, jlong expectedGeneration)
+{
+    std::lock_guard<std::mutex> lock(gSessionMutex);
+    auto session = std::atomic_load(&gSession);
+    if (!session || gSessionGeneration.load() != expectedGeneration) return JNI_FALSE;
+    return session->setExperimentalMediaControlsEnabled(enabled == JNI_TRUE)
+        ? JNI_TRUE : JNI_FALSE;
+}
+
+/*
+ * Class:     com_openautolink_app_transport_aasdk_AasdkNative
  * Method:    nativeSendGpsLocation
  */
 JNIEXPORT void JNICALL
@@ -263,16 +292,26 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeRequestKeyframe(
 
 /*
  * Class:     com_openautolink_app_transport_aasdk_AasdkNative
- * Method:    nativeSetHuMuted
+ * Method:    nativeSetHeadUnitMuted
  */
-JNIEXPORT void JNICALL
-Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSetHuMuted(
-    JNIEnv* /*env*/, jclass /*clazz*/, jboolean muted)
+JNIEXPORT jboolean JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSetHeadUnitMuted(
+    JNIEnv* /*env*/, jclass /*clazz*/, jboolean muted, jlong expectedGeneration)
 {
     std::lock_guard<std::mutex> lock(gSessionMutex);
-    if (gSession) {
-        gSession->setHeadUnitMuted(muted == JNI_TRUE);
-    }
+    auto session = std::atomic_load(&gSession);
+    if (!session || gSessionGeneration.load() != expectedGeneration) return JNI_FALSE;
+    return session->setHeadUnitMuted(muted == JNI_TRUE) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_openautolink_app_transport_aasdk_AasdkNative_nativePrimeHeadUnitMuted(
+    JNIEnv* /*env*/, jclass /*clazz*/, jboolean muted, jlong expectedGeneration)
+{
+    std::lock_guard<std::mutex> lock(gSessionMutex);
+    auto session = std::atomic_load(&gSession);
+    if (!session || gSessionGeneration.load() != expectedGeneration) return JNI_FALSE;
+    return session->primeHeadUnitMuted(muted == JNI_TRUE) ? JNI_TRUE : JNI_FALSE;
 }
 
 // Typed vehicle sensor JNI methods — each calls the corresponding C++ method

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -981,38 +981,99 @@ void JniSession::onAudioFocusRequest(
 
 void JniSession::sendUnsolicitedAudioFocusGain()
 {
-    auto focus = headUnitMuted_.load()
-        ? aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_LOSS
-        : aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN;
-    sendUnsolicitedAudioFocusState(static_cast<int>(focus));
+    // Off mode is byte-for-behavior compatible with the established path: every
+    // audio setup emits an unsolicited GAIN, with no experimental dedupe.
+    if (!experimentalMediaControlsEnabled_.load()) {
+        sendUnsolicitedAudioFocusState(static_cast<int>(
+            aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN));
+        return;
+    }
+
+    // In experimental mode, an explicitly primed unmuted state must not add a
+    // new unsolicited GAIN merely because the toggle was enabled.
+    flushHeadUnitAudioFocusState(headUnitMuteExplicit_.load());
 }
 
-void JniSession::setHeadUnitMuted(bool muted)
+bool JniSession::setHeadUnitMuted(bool muted)
 {
-    bool previous = headUnitMuted_.exchange(muted);
-    if (previous == muted) return;
+    if (stopped_ || !ioService_) {
+        nativeDiag(2, "audio", "HU mute state rejected: reason=session-retired");
+        return false;
+    }
+    headUnitMuted_.store(muted);
+    headUnitMuteExplicit_.store(true);
+    auto self = shared_from_this();
+    ioService_->post([self]() {
+        self->flushHeadUnitAudioFocusState(false);
+    });
+    nativeDiag(1, "audio", "HU mute state queued: muted=" +
+               std::string(muted ? "true" : "false"));
+    return true;
+}
 
-    LOGI("HU mute state changed: %s", muted ? "muted" : "unmuted");
+bool JniSession::primeHeadUnitMuted(bool muted)
+{
+    if (stopped_) return false;
+    headUnitMuted_.store(muted);
+    headUnitMuteExplicit_.store(true);
+    nativeDiag(1, "audio", "HU mute state primed without send: muted=" +
+               std::string(muted ? "true" : "false"));
+    return true;
+}
+
+bool JniSession::flushHeadUnitAudioFocusState(bool suppressInitialUnmuted)
+{
+    if (stopped_ || !controlChannel_ || !strand_) {
+        nativeDiag(1, "audio", "HU mute state primed: muted=" +
+                   std::string(headUnitMuted_.load() ? "true" : "false"));
+        return false;
+    }
+    const bool muted = headUnitMuted_.load();
+    const int desiredMute = muted ? 1 : 0;
+    if (lastQueuedHeadUnitMute_ == desiredMute) return true;
+    if (suppressInitialUnmuted && !muted && lastQueuedHeadUnitMute_ < 0) {
+        nativeDiag(1, "audio", "AA audio focus sync outcome=suppressed: "
+                   "state=GAIN reason=experimental-initial-unmuted");
+        return true;
+    }
     auto focus = muted
         ? aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_LOSS
         : aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN;
-    sendUnsolicitedAudioFocusState(static_cast<int>(focus));
+    const bool queued = sendUnsolicitedAudioFocusState(static_cast<int>(focus));
+    if (queued) lastQueuedHeadUnitMute_ = desiredMute;
+    return queued;
 }
 
-void JniSession::sendUnsolicitedAudioFocusState(int state)
+bool JniSession::sendUnsolicitedAudioFocusState(int state)
 {
+    if (stopped_ || !controlChannel_ || !strand_) {
+        nativeDiag(2, "audio", "AA audio focus sync outcome=rejected: state=" +
+                   std::to_string(state) + " reason=session-not-ready");
+        return false;
+    }
+    const int desiredMute =
+        state == static_cast<int>(
+            aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_LOSS) ? 1 : 0;
     auto self = shared_from_this();
-    ioService_->post([this, self, state]() {
-        if (stopped_ || !controlChannel_ || !strand_) return;
-        LOGI("Sending unsolicited audio focus state=%d", state);
-        aap_protobuf::service::control::message::AudioFocusNotification notification;
-        notification.set_focus_state(
-            static_cast<aap_protobuf::service::control::message::AudioFocusStateType>(state));
-        notification.set_unsolicited(true);
-        auto promise = aasdk::channel::SendPromise::defer(*strand_);
-        promise->then([]() {}, [this](const auto& e) { this->onChannelError(e); });
-        controlChannel_->sendAudioFocusResponse(notification, std::move(promise));
-    });
+    aap_protobuf::service::control::message::AudioFocusNotification notification;
+    notification.set_focus_state(
+        static_cast<aap_protobuf::service::control::message::AudioFocusStateType>(state));
+    notification.set_unsolicited(true);
+    auto promise = aasdk::channel::SendPromise::defer(*strand_);
+    promise->then(
+        [self, state]() {
+            self->nativeDiag(1, "audio", "AA audio focus sync outcome=sent: state=" +
+                             std::to_string(state));
+        },
+        [self, state, desiredMute](const aasdk::error::Error& e) {
+            if (self->lastQueuedHeadUnitMute_ == desiredMute) {
+                self->lastQueuedHeadUnitMute_ = -1;
+            }
+            self->nativeDiag(3, "audio", "AA audio focus sync outcome=failed: state=" +
+                             std::to_string(state) + " error=" + e.what());
+        });
+    controlChannel_->sendAudioFocusResponse(notification, std::move(promise));
+    return true;
 }
 
 void JniSession::onNavigationFocusRequest(
@@ -2134,6 +2195,68 @@ void JniSession::sendKeyEvent(int keyCode, bool isDown)
             });
         self->inputChannel_->sendInputReport(report, std::move(promise));
     });
+}
+
+bool JniSession::sendKeyPress(int keyCode)
+{
+    if (!experimentalMediaControlsEnabled_ || !streaming_ || !inputChannel_ || stopped_) {
+        nativeDiag(2, "input", "Key press rejected: keycode=" + std::to_string(keyCode) +
+                   " experimental=" + (experimentalMediaControlsEnabled_ ? "true" : "false") +
+                   " streaming=" + (streaming_ ? "true" : "false") +
+                   " inputChannel=" + (inputChannel_ ? "ready" : "null") +
+                   " stopped=" + (stopped_ ? "true" : "false"));
+        return false;
+    }
+
+    auto self = shared_from_this();
+    ioService_->post([self, keyCode]() {
+        if (!self->experimentalMediaControlsEnabled_ || self->stopped_ ||
+            !self->inputChannel_ || !self->strand_) {
+            self->nativeDiag(2, "input", "Key press send rejected: keycode=" +
+                             std::to_string(keyCode) + " reason=session-not-ready");
+            return;
+        }
+        auto completed = std::make_shared<std::atomic<int>>(0);
+        auto failed = std::make_shared<std::atomic<bool>>(false);
+        for (bool down : {true, false}) {
+            aap_protobuf::service::inputsource::message::InputReport report;
+            auto now = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now().time_since_epoch()).count();
+            report.set_timestamp(static_cast<uint64_t>(now));
+            auto* key = report.mutable_key_event()->add_keys();
+            key->set_keycode(static_cast<uint32_t>(keyCode));
+            key->set_down(down);
+            key->set_metastate(0);
+            key->set_longpress(false);
+
+            auto promise = aasdk::channel::SendPromise::defer(*self->strand_);
+            promise->then(
+                [self, keyCode, completed, failed]() {
+                    const int edges = completed->fetch_add(1) + 1;
+                    if (edges == 2 && !failed->load()) {
+                        self->nativeDiag(1, "input", "Key press send complete: keycode=" +
+                                         std::to_string(keyCode) + " edges=2");
+                    }
+                },
+                [self, keyCode, down, failed](const aasdk::error::Error& e) {
+                    failed->store(true);
+                    self->nativeDiag(3, "input", "Key press send failed: keycode=" +
+                                     std::to_string(keyCode) + " edge=" +
+                                     (down ? "down" : "up") + " error=" + e.what());
+                });
+            self->inputChannel_->sendInputReport(report, std::move(promise));
+        }
+    });
+    return true;
+}
+
+bool JniSession::setExperimentalMediaControlsEnabled(bool enabled)
+{
+    if (stopped_) return false;
+    experimentalMediaControlsEnabled_.store(enabled);
+    nativeDiag(1, "input", "Experimental MediaSession native gate enabled=" +
+               std::string(enabled ? "true" : "false"));
+    return true;
 }
 
 void JniSession::sendGpsLocation(double lat, double lon, double alt,

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -981,13 +981,38 @@ void JniSession::onAudioFocusRequest(
 
 void JniSession::sendUnsolicitedAudioFocusGain()
 {
-    LOGI("Sending unsolicited AUDIO_FOCUS_STATE_GAIN");
-    aap_protobuf::service::control::message::AudioFocusNotification notification;
-    notification.set_focus_state(aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN);
-    notification.set_unsolicited(true);
-    auto promise = aasdk::channel::SendPromise::defer(*strand_);
-    promise->then([]() {}, [this](const auto& e) { this->onChannelError(e); });
-    controlChannel_->sendAudioFocusResponse(notification, std::move(promise));
+    auto focus = headUnitMuted_.load()
+        ? aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_LOSS
+        : aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN;
+    sendUnsolicitedAudioFocusState(static_cast<int>(focus));
+}
+
+void JniSession::setHeadUnitMuted(bool muted)
+{
+    bool previous = headUnitMuted_.exchange(muted);
+    if (previous == muted) return;
+
+    LOGI("HU mute state changed: %s", muted ? "muted" : "unmuted");
+    auto focus = muted
+        ? aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_LOSS
+        : aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN;
+    sendUnsolicitedAudioFocusState(static_cast<int>(focus));
+}
+
+void JniSession::sendUnsolicitedAudioFocusState(int state)
+{
+    auto self = shared_from_this();
+    ioService_->post([this, self, state]() {
+        if (stopped_ || !controlChannel_ || !strand_) return;
+        LOGI("Sending unsolicited audio focus state=%d", state);
+        aap_protobuf::service::control::message::AudioFocusNotification notification;
+        notification.set_focus_state(
+            static_cast<aap_protobuf::service::control::message::AudioFocusStateType>(state));
+        notification.set_unsolicited(true);
+        auto promise = aasdk::channel::SendPromise::defer(*strand_);
+        promise->then([]() {}, [this](const auto& e) { this->onChannelError(e); });
+        controlChannel_->sendAudioFocusResponse(notification, std::move(promise));
+    });
 }
 
 void JniSession::onNavigationFocusRequest(

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -127,6 +127,12 @@ public:
     /** Send key event to phone. */
     void sendKeyEvent(int keyCode, bool isDown);
 
+    /** Queue a complete down/up media-key press as one native operation. */
+    bool sendKeyPress(int keyCode);
+
+    /** Gate only the experimental MediaSession command path. */
+    bool setExperimentalMediaControlsEnabled(bool enabled);
+
     /** Send GPS location to phone. */
     void sendGpsLocation(double lat, double lon, double alt,
                          float speed, float bearing, long long timestampMs);
@@ -162,7 +168,10 @@ public:
     void sendUnsolicitedAudioFocusGain();
 
     /** Mirror HU mute/unmute into unsolicited AA audio-focus notifications. */
-    void setHeadUnitMuted(bool muted);
+    bool setHeadUnitMuted(bool muted);
+
+    /** Record initial HU mute state without emitting a focus notification. */
+    bool primeHeadUnitMuted(bool muted);
 
     // ---- IControlServiceChannelEventHandler ----
     void onVersionResponse(uint16_t majorCode, uint16_t minorCode,
@@ -299,6 +308,10 @@ private:
     std::atomic<bool> aborted_{false};
     std::atomic<bool> sessionStoppedFired_{false};
     std::atomic<bool> headUnitMuted_{false};
+    std::atomic<bool> headUnitMuteExplicit_{false};
+    std::atomic<bool> experimentalMediaControlsEnabled_{false};
+    // IO-thread confined; reset only when an async send fails.
+    int lastQueuedHeadUnitMute_ = -1;
     // Reason string passed to Kotlin onSessionStopped. Defaults to "stopped";
     // ByeByeRequest from phone overrides this (e.g. "byebye_user_selection" when
     // the user taps the Exit button in the AA app launcher) so Kotlin can decide
@@ -334,7 +347,8 @@ private:
 
     void sendPing();
     void schedulePing();
-    void sendUnsolicitedAudioFocusState(int state);
+    bool flushHeadUnitAudioFocusState(bool suppressInitialUnmuted);
+    bool sendUnsolicitedAudioFocusState(int state);
 
 public:
     bool shouldSendAudioAcks() const { return sdrConfig_.sendAudioAcks; }

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -161,6 +161,9 @@ public:
     /** Send unsolicited AUDIO_FOCUS_STATE_GAIN to phone. */
     void sendUnsolicitedAudioFocusGain();
 
+    /** Mirror HU mute/unmute into unsolicited AA audio-focus notifications. */
+    void setHeadUnitMuted(bool muted);
+
     // ---- IControlServiceChannelEventHandler ----
     void onVersionResponse(uint16_t majorCode, uint16_t minorCode,
                            aap_protobuf::shared::MessageStatus status) override;
@@ -295,6 +298,7 @@ private:
     std::atomic<bool> pingOutstanding_{false};
     std::atomic<bool> aborted_{false};
     std::atomic<bool> sessionStoppedFired_{false};
+    std::atomic<bool> headUnitMuted_{false};
     // Reason string passed to Kotlin onSessionStopped. Defaults to "stopped";
     // ByeByeRequest from phone overrides this (e.g. "byebye_user_selection" when
     // the user taps the Exit button in the AA app launcher) so Kotlin can decide
@@ -330,6 +334,7 @@ private:
 
     void sendPing();
     void schedulePing();
+    void sendUnsolicitedAudioFocusState(int state);
 
 public:
     bool shouldSendAudioAcks() const { return sdrConfig_.sendAudioAcks; }

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -120,6 +120,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         // reports a usable gear. See issue #61.
         val ALWAYS_IN_PARK = booleanPreferencesKey("always_in_park")
         val CLUSTER_NAVIGATION = booleanPreferencesKey("cluster_navigation")
+        // Opt-in field trial for GM-native MediaSession controls and mute sync.
+        // Default off preserves the current activity/key-remap behavior.
+        val EXPERIMENTAL_GM_MEDIA_CONTROLS =
+            booleanPreferencesKey("experimental_gm_media_controls")
         val OVERLAY_STATS_BUTTON = booleanPreferencesKey("overlay_stats_button")
         val OVERLAY_PHONE_SWITCH_BUTTON = booleanPreferencesKey("overlay_phone_switch_button")
         val OVERLAY_RECONNECT_BUTTON = booleanPreferencesKey("overlay_reconnect_button")
@@ -309,6 +313,7 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_GPS_FORWARDING = true
         const val DEFAULT_ALWAYS_IN_PARK = false
         const val DEFAULT_CLUSTER_NAVIGATION = true
+        const val DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS = false
         const val DEFAULT_OVERLAY_STATS_BUTTON = true
         const val DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON = true
         const val DEFAULT_OVERLAY_RECONNECT_BUTTON = false
@@ -528,6 +533,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val clusterNavigation: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[CLUSTER_NAVIGATION] ?: DEFAULT_CLUSTER_NAVIGATION
+    }
+
+    val experimentalGmMediaControls: Flow<Boolean> = dataStore.data.map { prefs ->
+        prefs[EXPERIMENTAL_GM_MEDIA_CONTROLS] ?: DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS
     }
 
     val overlayStatsButton: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -785,6 +794,10 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setClusterNavigation(enabled: Boolean) {
         dataStore.edit { it[CLUSTER_NAVIGATION] = enabled }
+    }
+
+    suspend fun setExperimentalGmMediaControls(enabled: Boolean) {
+        dataStore.edit { it[EXPERIMENTAL_GM_MEDIA_CONTROLS] = enabled }
     }
 
     suspend fun setOverlayStatsButton(visible: Boolean) {

--- a/app/src/main/java/com/openautolink/app/media/GmMediaControlPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/media/GmMediaControlPolicy.kt
@@ -1,0 +1,40 @@
+package com.openautolink.app.media
+
+import android.view.KeyEvent
+
+/** Pure policy for the opt-in GM MediaSession control experiment. */
+object GmMediaControlPolicy {
+    enum class Command {
+        PLAY,
+        PAUSE,
+        STOP,
+        NEXT,
+        PREVIOUS,
+    }
+
+    fun keyCodeFor(command: Command, enabled: Boolean): Int? {
+        if (!enabled) return null
+        return when (command) {
+            Command.PLAY -> KeyEvent.KEYCODE_MEDIA_PLAY
+            Command.PAUSE,
+            Command.STOP -> KeyEvent.KEYCODE_MEDIA_PAUSE
+            Command.NEXT -> KeyEvent.KEYCODE_MEDIA_NEXT
+            Command.PREVIOUS -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
+        }
+    }
+
+    fun effectiveMuted(masterMuted: Boolean, streamMuted: Boolean): Boolean =
+        masterMuted || streamMuted
+
+    fun nextMuteState(
+        enabled: Boolean,
+        masterMuted: Boolean,
+        streamMuted: Boolean,
+        lastDeliveredMuted: Boolean?,
+    ): Boolean? {
+        if (!enabled) return null
+        val effectiveMuted = effectiveMuted(masterMuted, streamMuted)
+        if (lastDeliveredMuted == null) return true.takeIf { effectiveMuted }
+        return effectiveMuted.takeIf { it != lastDeliveredMuted }
+    }
+}

--- a/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
@@ -62,19 +62,20 @@ class OalMediaSessionManager private constructor(private val context: Context) {
 
     // Dedup: avoid redundant pushes to MediaSession
     private var lastPushedPlaying: Boolean? = null
+    private var lastPushedState = PlaybackStateCompat.STATE_NONE
+    private var lastPushedPosition = 0L
+    @Volatile private var experimentalControlsEnabled = false
 
     // Album art cache: avoid redundant BitmapFactory decodes
     private var cachedArtHash = 0
     private var cachedBitmap: android.graphics.Bitmap? = null
 
-    // Media control callback for routing steering wheel buttons to bridge
+    // Media control callback for routing GM's native MediaSession controls to AA.
+    @Volatile
     var mediaControlCallback: MediaControlCallback? = null
 
     interface MediaControlCallback {
-        fun onPlay()
-        fun onPause()
-        fun onSkipToNext()
-        fun onSkipToPrevious()
+        fun onCommand(command: GmMediaControlPolicy.Command)
     }
 
     fun initialize() {
@@ -83,10 +84,25 @@ class OalMediaSessionManager private constructor(private val context: Context) {
 
             mediaSession = MediaSessionCompat(context, "OpenAutoLinkMedia").apply {
                 setCallback(object : MediaSessionCompat.Callback() {
-                    override fun onPlay() { mediaControlCallback?.onPlay() }
-                    override fun onPause() { mediaControlCallback?.onPause() }
-                    override fun onSkipToNext() { mediaControlCallback?.onSkipToNext() }
-                    override fun onSkipToPrevious() { mediaControlCallback?.onSkipToPrevious() }
+                    override fun onPlay() {
+                        mediaControlCallback?.onCommand(GmMediaControlPolicy.Command.PLAY)
+                    }
+
+                    override fun onPause() {
+                        mediaControlCallback?.onCommand(GmMediaControlPolicy.Command.PAUSE)
+                    }
+
+                    override fun onStop() {
+                        mediaControlCallback?.onCommand(GmMediaControlPolicy.Command.STOP)
+                    }
+
+                    override fun onSkipToNext() {
+                        mediaControlCallback?.onCommand(GmMediaControlPolicy.Command.NEXT)
+                    }
+
+                    override fun onSkipToPrevious() {
+                        mediaControlCallback?.onCommand(GmMediaControlPolicy.Command.PREVIOUS)
+                    }
 
                     override fun onMediaButtonEvent(mediaButtonEvent: android.content.Intent): Boolean {
                         val ke = mediaButtonEvent.getParcelableExtra<android.view.KeyEvent>(android.content.Intent.EXTRA_KEY_EVENT)
@@ -131,6 +147,8 @@ class OalMediaSessionManager private constructor(private val context: Context) {
             cachedArtHash = 0
             cachedBitmap = null
             lastPushedPlaying = null
+            lastPushedState = PlaybackStateCompat.STATE_NONE
+            lastPushedPosition = 0L
             Log.i(TAG, "MediaSession released")
         }
         instance = null
@@ -150,6 +168,8 @@ class OalMediaSessionManager private constructor(private val context: Context) {
             cachedArtHash = 0
             cachedBitmap = null
             lastPushedPlaying = false
+            lastPushedState = PlaybackStateCompat.STATE_NONE
+            lastPushedPosition = 0L
             session.setMetadata(
                 MediaMetadataCompat.Builder()
                     .putString(MediaMetadataCompat.METADATA_KEY_TITLE, "OpenAutoLink")
@@ -162,6 +182,17 @@ class OalMediaSessionManager private constructor(private val context: Context) {
     }
 
     fun getSessionToken(): MediaSessionCompat.Token? = mediaSession?.sessionToken
+
+    fun setExperimentalControlsEnabled(enabled: Boolean) {
+        synchronized(sessionLock) {
+            if (experimentalControlsEnabled == enabled) return
+            experimentalControlsEnabled = enabled
+            mediaSession?.setPlaybackState(
+                buildPlaybackState(lastPushedState, lastPushedPosition),
+            )
+            Log.i(TAG, "Experimental transport controls enabled=$enabled")
+        }
+    }
 
     /**
      * Update now-playing metadata from bridge media_metadata control message.
@@ -235,6 +266,8 @@ class OalMediaSessionManager private constructor(private val context: Context) {
             // for consumers that DO listen to onMetadataChanged.
             val playing = lastPushedPlaying ?: false
             val st = if (playing) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED
+            lastPushedState = st
+            lastPushedPosition = 0L
             session.setPlaybackState(buildPlaybackState(st, 0L))
         }
     }
@@ -250,21 +283,23 @@ class OalMediaSessionManager private constructor(private val context: Context) {
             // when PlaybackState changes. Skipping the push leaves the cluster stuck on
             // the previous track's title/art until nav takes over and is cancelled.
             lastPushedPlaying = playing
+            lastPushedPosition = positionMs
 
             val state = if (playing) PlaybackStateCompat.STATE_PLAYING else PlaybackStateCompat.STATE_PAUSED
+            lastPushedState = state
             session.setPlaybackState(buildPlaybackState(state, positionMs))
         }
     }
 
     private fun buildPlaybackState(state: Int, position: Long): PlaybackStateCompat {
+        var actions = PlaybackStateCompat.ACTION_PLAY or
+            PlaybackStateCompat.ACTION_PAUSE or
+            PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
+            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
+            PlaybackStateCompat.ACTION_PLAY_PAUSE
+        if (experimentalControlsEnabled) actions = actions or PlaybackStateCompat.ACTION_STOP
         return PlaybackStateCompat.Builder()
-            .setActions(
-                PlaybackStateCompat.ACTION_PLAY or
-                    PlaybackStateCompat.ACTION_PAUSE or
-                    PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
-                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-                    PlaybackStateCompat.ACTION_PLAY_PAUSE
-            )
+            .setActions(actions)
             .setState(state, position, if (state == PlaybackStateCompat.STATE_PLAYING) 1.0f else 0f)
             .build()
     }

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -82,6 +82,9 @@ class SessionManager(
          * goodbye is never worth delaying shutdown for.
          */
         private const val BYEBYE_TIMEOUT_MS = 400
+        private const val STREAM_MUTE_CHANGED_ACTION = "android.media.STREAM_MUTE_CHANGED_ACTION"
+        private const val EXTRA_VOLUME_STREAM_TYPE = "android.media.EXTRA_VOLUME_STREAM_TYPE"
+        private const val EXTRA_STREAM_VOLUME_MUTED = "android.media.EXTRA_STREAM_VOLUME_MUTED"
 
         // aasdk SensorType ordinals (app/src/main/proto/oal/sensors.proto).
         // Used to answer the phone's SensorStartRequest with current state.
@@ -883,6 +886,9 @@ class SessionManager(
 
     /** SCREEN_OFF/_ON receiver registration tracker. */
     private var screenReceiver: android.content.BroadcastReceiver? = null
+    /** Mirrors AAOS STREAM_MUSIC mute state into AA audio focus. */
+    private var muteStateReceiver: android.content.BroadcastReceiver? = null
+    @Volatile private var lastKnownHuMuted: Boolean? = null
 
     private fun currentUiNightMode(): Boolean? {
         val nightMask = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
@@ -1727,6 +1733,7 @@ class SessionManager(
         // Without this, a parked car never sends driving status and the phone
         // stays FULLY_RESTRICTED (no Maps keyboard). Issue #61.
         session.onSensorSubscribedListener = { type -> onPhoneSubscribedSensor(type) }
+        syncHuMuteStateToPhone("session_start")
         // Reset the mirrored reconnect counter at session boundary. The
         // per-session collector below will republish updates as they fire.
         _reconnectAttempt.value = 0
@@ -1961,6 +1968,7 @@ class SessionManager(
         com.openautolink.app.transport.bluetooth.AaWirelessBtControl.releaseActivePhone()
 
         unregisterScreenReceiver()
+        unregisterMuteStateReceiver()
         unregisterDebugReceiver()
         if (cancelObserveJob) observeJob?.cancelAndJoin()
         observeJob = null
@@ -2608,6 +2616,66 @@ class SessionManager(
             try { ctx.unregisterReceiver(it) } catch (_: Exception) {}
         }
         screenReceiver = null
+    }
+
+    private fun registerMuteStateReceiver() {
+        if (muteStateReceiver != null) return
+        val ctx = context ?: return
+        val manager = audioManager ?: return
+        val receiver = object : android.content.BroadcastReceiver() {
+            override fun onReceive(c: android.content.Context?, intent: android.content.Intent?) {
+                if (intent?.action != STREAM_MUTE_CHANGED_ACTION) return
+                val stream = intent.getIntExtra(EXTRA_VOLUME_STREAM_TYPE, -1)
+                if (stream != AudioManager.STREAM_MUSIC) return
+                val muted = if (intent.hasExtra(EXTRA_STREAM_VOLUME_MUTED)) {
+                    intent.getBooleanExtra(EXTRA_STREAM_VOLUME_MUTED, false)
+                } else {
+                    runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
+                        .getOrDefault(false)
+                }
+                applyHuMuteState(muted, "broadcast")
+            }
+        }
+        val filter = android.content.IntentFilter(STREAM_MUTE_CHANGED_ACTION)
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                ctx.registerReceiver(receiver, filter, android.content.Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                ctx.registerReceiver(receiver, filter)
+            }
+            muteStateReceiver = receiver
+            OalLog.i(TAG, "Mute-state receiver registered")
+            syncHuMuteStateToPhone("receiver_registered")
+        } catch (e: Exception) {
+            OalLog.w(TAG, "Mute-state receiver registration failed: ${e.message}")
+        }
+    }
+
+    private fun unregisterMuteStateReceiver() {
+        val ctx = context ?: return
+        muteStateReceiver?.let {
+            try { ctx.unregisterReceiver(it) } catch (_: Exception) {}
+        }
+        muteStateReceiver = null
+        lastKnownHuMuted = null
+    }
+
+    private fun syncHuMuteStateToPhone(reason: String) {
+        val manager = audioManager ?: return
+        val muted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
+            .getOrElse {
+                OalLog.w(TAG, "Failed to read HU mute state ($reason): ${it.message}")
+                return
+            }
+        applyHuMuteState(muted, reason)
+    }
+
+    private fun applyHuMuteState(muted: Boolean, reason: String) {
+        if (lastKnownHuMuted == muted) return
+        lastKnownHuMuted = muted
+        OalLog.i(TAG, "HU mute changed: muted=$muted source=$reason")
+        aasdkSession?.setHeadUnitMuted(muted)
     }
 
     // ------------------------------------------------------------------

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -25,6 +25,7 @@ import com.openautolink.app.input.IgnitionMonitor
 import com.openautolink.app.input.ImuForwarder
 import com.openautolink.app.input.VehicleDataForwarder
 import com.openautolink.app.input.VehicleDataForwarderImpl
+import com.openautolink.app.media.GmMediaControlPolicy
 import com.openautolink.app.media.OalMediaBrowserService
 import com.openautolink.app.media.OalMediaSessionManager
 import com.openautolink.app.navigation.ManeuverState
@@ -56,6 +57,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -82,9 +84,10 @@ class SessionManager(
          * goodbye is never worth delaying shutdown for.
          */
         private const val BYEBYE_TIMEOUT_MS = 400
+        private const val MASTER_MUTE_CHANGED_ACTION = "android.media.MASTER_MUTE_CHANGED_ACTION"
         private const val STREAM_MUTE_CHANGED_ACTION = "android.media.STREAM_MUTE_CHANGED_ACTION"
+        private const val EXTRA_MASTER_VOLUME_MUTED = "android.media.EXTRA_MASTER_VOLUME_MUTED"
         private const val EXTRA_VOLUME_STREAM_TYPE = "android.media.EXTRA_VOLUME_STREAM_TYPE"
-        private const val EXTRA_STREAM_VOLUME_MUTED = "android.media.EXTRA_STREAM_VOLUME_MUTED"
 
         // aasdk SensorType ordinals (app/src/main/proto/oal/sensors.proto).
         // Used to answer the phone's SensorStartRequest with current state.
@@ -886,9 +889,13 @@ class SessionManager(
 
     /** SCREEN_OFF/_ON receiver registration tracker. */
     private var screenReceiver: android.content.BroadcastReceiver? = null
-    /** Mirrors AAOS STREAM_MUSIC mute state into AA audio focus. */
+    /** Process-scope state for the temporary GM media-control field trial. */
+    @Volatile private var experimentalGmMediaControlsEnabled = false
+    @Volatile private var experimentalGmMediaControlsObserverStarted = false
+    private val experimentalMediaControlLock = Any()
     private var muteStateReceiver: android.content.BroadcastReceiver? = null
-    @Volatile private var lastKnownHuMuted: Boolean? = null
+    @Volatile private var lastKnownMasterMuted = false
+    @Volatile private var lastDeliveredHuMuted: Boolean? = null
 
     private fun currentUiNightMode(): Boolean? {
         val nightMask = context?.resources?.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK)
@@ -1253,6 +1260,7 @@ class SessionManager(
                 media.updatePlaybackState(p.playing, p.positionMs)
             }
         }
+        observeExperimentalGmMediaControls()
 
         // Cluster service is gated by user preference (default ON). When disabled,
         // the CarAppService component is disabled so Templates Host won't bind it.
@@ -1644,7 +1652,23 @@ class SessionManager(
                 "autoNeg=$videoAutoNegotiate selected=${resW}x${resH}",
         )
 
+        val storedExperimentalControls = AppPreferences.getInstance(ctx)
+            .experimentalGmMediaControls.first()
+        if (storedExperimentalControls != experimentalGmMediaControlsEnabled) {
+            applyExperimentalGmMediaControls(storedExperimentalControls)
+        }
+
         val session = AasdkSession(scope, ctx)
+        session.desiredExperimentalMediaControlsEnabled = experimentalGmMediaControlsEnabled
+        if (experimentalGmMediaControlsEnabled) {
+            val streamMuted = runCatching {
+                audioManager?.isStreamMute(AudioManager.STREAM_MUSIC) ?: false
+            }.getOrDefault(false)
+            session.desiredHeadUnitMuted = GmMediaControlPolicy.effectiveMuted(
+                masterMuted = lastKnownMasterMuted,
+                streamMuted = streamMuted,
+            )
+        }
         session.transportMode = directTransport
         session.wppInterfaceName = wppInterfaceName
         // Effective AA content_insets:
@@ -1733,7 +1757,6 @@ class SessionManager(
         // Without this, a parked car never sends driving status and the phone
         // stays FULLY_RESTRICTED (no Maps keyboard). Issue #61.
         session.onSensorSubscribedListener = { type -> onPhoneSubscribedSensor(type) }
-        syncHuMuteStateToPhone("session_start")
         // Reset the mirrored reconnect counter at session boundary. The
         // per-session collector below will republish updates as they fire.
         _reconnectAttempt.value = 0
@@ -1743,33 +1766,40 @@ class SessionManager(
             session.connectionState.collect { connState ->
                 val reportedState = connState.toSessionState()
                 val attempt = _reconnectAttempt.value
-                synchronized(sessionStateLock) {
-                    if (aasdkSession !== session) return@synchronized
-                    val currentState = _sessionState.value
-                    val startStreamingServices = shouldStartStreamingServices(
-                        currentState,
-                        reportedState,
-                    )
-                    reconcileTransportSessionState(currentState, reportedState).also {
-                        _sessionState.value = it
-                        _statusMessage.value = when (it) {
-                            SessionState.IDLE ->
-                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                                else when (directTransport) {
-                                    "usb" -> "USB: ${UsbConnectionManager.status.value}"
-                                    else -> "Searching for phone…"
-                                }
-                            SessionState.CONNECTING ->
-                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                                else "Phone connecting..."
-                            SessionState.CONNECTED -> "Handshake..."
-                            SessionState.STREAMING -> "Streaming"
-                            SessionState.ERROR ->
-                                if (attempt > 0) "Reconnecting (attempt $attempt)…"
-                                else "Error"
+                val isCurrent = synchronized(sessionStateLock) {
+                    if (aasdkSession !== session) {
+                        false
+                    } else {
+                        val currentState = _sessionState.value
+                        val startStreamingServices = shouldStartStreamingServices(
+                            currentState,
+                            reportedState,
+                        )
+                        reconcileTransportSessionState(currentState, reportedState).also {
+                            _sessionState.value = it
+                            _statusMessage.value = when (it) {
+                                SessionState.IDLE ->
+                                    if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                    else when (directTransport) {
+                                        "usb" -> "USB: ${UsbConnectionManager.status.value}"
+                                        else -> "Searching for phone…"
+                                    }
+                                SessionState.CONNECTING ->
+                                    if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                    else "Phone connecting..."
+                                SessionState.CONNECTED -> "Handshake..."
+                                SessionState.STREAMING -> "Streaming"
+                                SessionState.ERROR ->
+                                    if (attempt > 0) "Reconnecting (attempt $attempt)…"
+                                    else "Error"
+                            }
                         }
+                        if (startStreamingServices) startStreamingServicesLocked(session)
+                        true
                     }
-                    if (startStreamingServices) startStreamingServicesLocked(session)
+                }
+                if (isCurrent && reportedState == SessionState.STREAMING) {
+                    syncExperimentalHuMuteState("session-streaming")
                 }
             }
         }
@@ -1837,6 +1867,10 @@ class SessionManager(
             OalLog.i(TAG, "Rejecting native start while this session is retiring")
             return false
         }
+
+        // A replacement native generation must receive a fresh effective mute
+        // state after its control and input channels reach STREAMING.
+        lastDeliveredHuMuted = null
 
         ensureVideoDecoder()
         ensureAudioPlayer()
@@ -1968,7 +2002,6 @@ class SessionManager(
         com.openautolink.app.transport.bluetooth.AaWirelessBtControl.releaseActivePhone()
 
         unregisterScreenReceiver()
-        unregisterMuteStateReceiver()
         unregisterDebugReceiver()
         if (cancelObserveJob) observeJob?.cancelAndJoin()
         observeJob = null
@@ -2618,64 +2651,206 @@ class SessionManager(
         screenReceiver = null
     }
 
+    private fun observeExperimentalGmMediaControls() {
+        if (experimentalGmMediaControlsObserverStarted) return
+        val ctx = context ?: return
+        experimentalGmMediaControlsObserverStarted = true
+        val preferences = AppPreferences.getInstance(ctx)
+        scope.launch {
+            preferences.experimentalGmMediaControls.distinctUntilChanged().collect { enabled ->
+                applyExperimentalGmMediaControls(enabled)
+            }
+        }
+    }
+
+    private fun applyExperimentalGmMediaControls(enabled: Boolean) {
+        synchronized(experimentalMediaControlLock) {
+            val wasEnabled = experimentalGmMediaControlsEnabled
+            if (!enabled) {
+                val currentSession = synchronized(sessionStateLock) { aasdkSession }
+                val shouldRestoreGain = lastDeliveredHuMuted == true ||
+                    currentSession?.desiredHeadUnitMuted == true
+                experimentalGmMediaControlsEnabled = false
+                currentSession?.setExperimentalMediaControlsEnabled(false)
+                if (wasEnabled && shouldRestoreGain) {
+                    // Clear both the live native state and the wrapper's retained
+                    // state, including a mute that was primed before channels opened.
+                    val restored = currentSession?.setHeadUnitMuted(false) ?: false
+                    OalLog.i(
+                        TAG,
+                        "AA audio focus sync outcome=${if (restored) "queued" else "rejected"}: " +
+                            "state=GAIN source=toggle-disabled",
+                    )
+                }
+                _mediaSessionManager?.setExperimentalControlsEnabled(false)
+                _mediaSessionManager?.mediaControlCallback = null
+                unregisterMuteStateReceiver()
+                lastDeliveredHuMuted = null
+                OalLog.i(TAG, "Experimental GM media controls disabled; legacy key-remap path unchanged")
+                return
+            }
+
+            experimentalGmMediaControlsEnabled = true
+            _mediaSessionManager?.mediaControlCallback = object : OalMediaSessionManager.MediaControlCallback {
+                override fun onCommand(command: GmMediaControlPolicy.Command) {
+                    routeMediaSessionCommand(command)
+                }
+            }
+            synchronized(sessionStateLock) { aasdkSession }
+                ?.setExperimentalMediaControlsEnabled(true)
+            _mediaSessionManager?.setExperimentalControlsEnabled(true)
+            registerMuteStateReceiver()
+            primeExperimentalUnmutedState()
+            syncExperimentalHuMuteState(if (wasEnabled) "settings-refresh" else "toggle-enabled")
+            OalLog.i(TAG, "Experimental GM media controls enabled; legacy key-remap path unchanged")
+        }
+    }
+
+    private fun routeMediaSessionCommand(command: GmMediaControlPolicy.Command) {
+        val keyCode = GmMediaControlPolicy.keyCodeFor(
+            command,
+            enabled = experimentalGmMediaControlsEnabled,
+        )
+        if (keyCode == null) {
+            OalLog.i(TAG, "MediaSession command outcome=rejected: command=$command reason=disabled")
+            return
+        }
+
+        val lifecycle = lifecycleGeneration
+        val target = synchronized(sessionStateLock) {
+            aasdkSession?.let { it to it.currentNativeSessionGeneration() }
+        }
+        if (target == null || target.second == 0L) {
+            OalLog.i(
+                TAG,
+                "MediaSession command outcome=rejected: command=$command keycode=$keyCode " +
+                    "lifecycle=$lifecycle reason=no-native-session",
+            )
+            return
+        }
+        val (targetSession, nativeGeneration) = target
+        OalLog.i(
+            TAG,
+            "MediaSession command attempted: command=$command keycode=$keyCode " +
+                "lifecycle=$lifecycle nativeGeneration=$nativeGeneration",
+        )
+        scope.launch {
+            val stillCurrent = synchronized(sessionStateLock) {
+                experimentalGmMediaControlsEnabled &&
+                    aasdkSession === targetSession && lifecycle == lifecycleGeneration
+            }
+            val queued = stillCurrent &&
+                targetSession.sendKeyPress(keyCode, nativeGeneration)
+            OalLog.i(
+                TAG,
+                "MediaSession command outcome=${if (queued) "queued" else "rejected"}: " +
+                    "command=$command keycode=$keyCode lifecycle=$lifecycle " +
+                    "nativeGeneration=$nativeGeneration",
+            )
+        }
+    }
+
     private fun registerMuteStateReceiver() {
         if (muteStateReceiver != null) return
         val ctx = context ?: return
-        val manager = audioManager ?: return
         val receiver = object : android.content.BroadcastReceiver() {
             override fun onReceive(c: android.content.Context?, intent: android.content.Intent?) {
-                if (intent?.action != STREAM_MUTE_CHANGED_ACTION) return
-                val stream = intent.getIntExtra(EXTRA_VOLUME_STREAM_TYPE, -1)
-                if (stream != AudioManager.STREAM_MUSIC) return
-                val muted = if (intent.hasExtra(EXTRA_STREAM_VOLUME_MUTED)) {
-                    intent.getBooleanExtra(EXTRA_STREAM_VOLUME_MUTED, false)
-                } else {
-                    runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
-                        .getOrDefault(false)
+                when (intent?.action) {
+                    MASTER_MUTE_CHANGED_ACTION -> {
+                        lastKnownMasterMuted = intent.getBooleanExtra(
+                            EXTRA_MASTER_VOLUME_MUTED,
+                            lastKnownMasterMuted,
+                        )
+                        scope.launch { syncExperimentalHuMuteState("master-broadcast") }
+                    }
+                    STREAM_MUTE_CHANGED_ACTION -> {
+                        if (intent.getIntExtra(EXTRA_VOLUME_STREAM_TYPE, -1) == AudioManager.STREAM_MUSIC) {
+                            scope.launch { syncExperimentalHuMuteState("stream-broadcast") }
+                        }
+                    }
                 }
-                applyHuMuteState(muted, "broadcast")
             }
         }
-        val filter = android.content.IntentFilter(STREAM_MUTE_CHANGED_ACTION)
+        val filter = android.content.IntentFilter().apply {
+            addAction(MASTER_MUTE_CHANGED_ACTION)
+            addAction(STREAM_MUTE_CHANGED_ACTION)
+        }
         try {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            val stickyMaster = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                 ctx.registerReceiver(receiver, filter, android.content.Context.RECEIVER_NOT_EXPORTED)
             } else {
                 @Suppress("UnspecifiedRegisterReceiverFlag")
                 ctx.registerReceiver(receiver, filter)
             }
+            if (stickyMaster?.action == MASTER_MUTE_CHANGED_ACTION &&
+                stickyMaster.hasExtra(EXTRA_MASTER_VOLUME_MUTED)
+            ) {
+                lastKnownMasterMuted = stickyMaster.getBooleanExtra(EXTRA_MASTER_VOLUME_MUTED, false)
+            }
             muteStateReceiver = receiver
-            OalLog.i(TAG, "Mute-state receiver registered")
-            syncHuMuteStateToPhone("receiver_registered")
+            OalLog.i(TAG, "GM master/stream mute receiver registered")
         } catch (e: Exception) {
-            OalLog.w(TAG, "Mute-state receiver registration failed: ${e.message}")
+            OalLog.w(TAG, "GM master/stream mute receiver registration failed: ${e.message}")
         }
     }
 
     private fun unregisterMuteStateReceiver() {
-        val ctx = context ?: return
-        muteStateReceiver?.let {
-            try { ctx.unregisterReceiver(it) } catch (_: Exception) {}
-        }
+        val receiver = muteStateReceiver
         muteStateReceiver = null
-        lastKnownHuMuted = null
-    }
-
-    private fun syncHuMuteStateToPhone(reason: String) {
-        val manager = audioManager ?: return
-        val muted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
-            .getOrElse {
-                OalLog.w(TAG, "Failed to read HU mute state ($reason): ${it.message}")
-                return
+        if (receiver != null) {
+            try {
+                context?.unregisterReceiver(receiver)
+            } catch (e: Exception) {
+                OalLog.w(TAG, "GM master/stream mute receiver unregister failed: ${e.message}")
             }
-        applyHuMuteState(muted, reason)
+        }
     }
 
-    private fun applyHuMuteState(muted: Boolean, reason: String) {
-        if (lastKnownHuMuted == muted) return
-        lastKnownHuMuted = muted
-        OalLog.i(TAG, "HU mute changed: muted=$muted source=$reason")
-        aasdkSession?.setHeadUnitMuted(muted)
+    private fun primeExperimentalUnmutedState() {
+        val manager = audioManager ?: return
+        val streamMuted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
+            .getOrDefault(false)
+        if (GmMediaControlPolicy.effectiveMuted(lastKnownMasterMuted, streamMuted)) return
+        val primed = synchronized(sessionStateLock) { aasdkSession }
+            ?.primeHeadUnitMuted(false) ?: false
+        OalLog.i(
+            TAG,
+            "AA audio focus sync outcome=${if (primed) "primed" else "deferred"}: " +
+                "state=GAIN source=experimental-initial-unmuted",
+        )
+    }
+
+    private fun syncExperimentalHuMuteState(reason: String) {
+        synchronized(experimentalMediaControlLock) {
+            val manager = audioManager ?: return
+            val masterMuted = lastKnownMasterMuted
+            val streamMuted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
+                .getOrElse {
+                    OalLog.w(TAG, "Failed to read HU media-stream mute ($reason): ${it.message}")
+                    return
+                }
+            val targetMuted = GmMediaControlPolicy.nextMuteState(
+                enabled = experimentalGmMediaControlsEnabled,
+                masterMuted = masterMuted,
+                streamMuted = streamMuted,
+                lastDeliveredMuted = lastDeliveredHuMuted,
+            ) ?: return
+
+            OalLog.i(
+                TAG,
+                "HU mute state changed: master=$masterMuted stream=$streamMuted " +
+                    "effective=$targetMuted source=$reason",
+            )
+            val queued = synchronized(sessionStateLock) {
+                aasdkSession?.setHeadUnitMuted(targetMuted) ?: false
+            }
+            if (queued) lastDeliveredHuMuted = targetMuted
+            OalLog.i(
+                TAG,
+                "AA audio focus sync outcome=${if (queued) "queued" else "rejected"}: " +
+                    "state=${if (targetMuted) "LOSS" else "GAIN"} source=$reason",
+            )
+        }
     }
 
     // ------------------------------------------------------------------

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
@@ -24,7 +24,7 @@ object AasdkNative {
 
     /** Create a new native aasdk session. Must be called before start. */
     @JvmStatic
-    external fun nativeCreateSession()
+    external fun nativeCreateSession(): Long
 
     /**
      * Start the AA session over the given transport pipe.
@@ -68,6 +68,16 @@ object AasdkNative {
 
     @JvmStatic
     external fun nativeSendKeyEvent(keyCode: Int, isDown: Boolean)
+
+    /** Queue one complete down/up media-key press on the current native session. */
+    @JvmStatic
+    external fun nativeSendKeyPress(keyCode: Int, expectedNativeGeneration: Long): Boolean
+
+    @JvmStatic
+    external fun nativeSetExperimentalMediaControlsEnabled(
+        enabled: Boolean,
+        expectedNativeGeneration: Long,
+    ): Boolean
 
     @JvmStatic
     external fun nativeSendGpsLocation(
@@ -139,7 +149,16 @@ object AasdkNative {
      * Native maps this to unsolicited audio-focus loss/gain for the phone.
      */
     @JvmStatic
-    external fun nativeSetHuMuted(muted: Boolean)
+    external fun nativeSetHeadUnitMuted(
+        muted: Boolean,
+        expectedNativeGeneration: Long,
+    ): Boolean
+
+    @JvmStatic
+    external fun nativePrimeHeadUnitMuted(
+        muted: Boolean,
+        expectedNativeGeneration: Long,
+    ): Boolean
 
     @JvmStatic
     external fun nativeIsStreaming(): Boolean

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
@@ -134,6 +134,13 @@ object AasdkNative {
     @JvmStatic
     external fun nativeRequestKeyframe()
 
+    /**
+     * Notify native aasdk when the head unit media stream mute state changes.
+     * Native maps this to unsolicited audio-focus loss/gain for the phone.
+     */
+    @JvmStatic
+    external fun nativeSetHuMuted(muted: Boolean)
+
     @JvmStatic
     external fun nativeIsStreaming(): Boolean
 }

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -373,6 +373,15 @@ class AasdkSession(
     @Volatile
     var onNativeSessionStarting: (() -> Boolean)? = null
 
+    /** Desired HU mute state, retained across native transport replacement. */
+    @Volatile
+    var desiredHeadUnitMuted: Boolean? = null
+    @Volatile
+    var desiredExperimentalMediaControlsEnabled = false
+    private val nativeSessionGeneration = java.util.concurrent.atomic.AtomicLong(0L)
+
+    fun currentNativeSessionGeneration(): Long = nativeSessionGeneration.get()
+
     /** Tracks the TCP target across every start path, including WPP restart. */
     private val companionDialState = CompanionDialState()
 
@@ -549,7 +558,14 @@ class AasdkSession(
             transportPipe = pipe
 
             try {
-                AasdkNative.nativeCreateSession()
+                nativeSessionGeneration.set(AasdkNative.nativeCreateSession())
+                AasdkNative.nativeSetExperimentalMediaControlsEnabled(
+                    desiredExperimentalMediaControlsEnabled,
+                    nativeSessionGeneration.get(),
+                )
+                desiredHeadUnitMuted?.let {
+                    AasdkNative.nativePrimeHeadUnitMuted(it, nativeSessionGeneration.get())
+                }
                 AasdkNative.nativeStartSession(pipe, this, sdrConfig)
             } catch (e: Exception) {
                 OalLog.e(TAG, "Native session start failed (USB): ${e.message}")
@@ -637,7 +653,14 @@ class AasdkSession(
         transportPipe = AasdkTransportPipe(input, output)
 
         try {
-            AasdkNative.nativeCreateSession()
+            nativeSessionGeneration.set(AasdkNative.nativeCreateSession())
+            AasdkNative.nativeSetExperimentalMediaControlsEnabled(
+                desiredExperimentalMediaControlsEnabled,
+                nativeSessionGeneration.get(),
+            )
+            desiredHeadUnitMuted?.let {
+                AasdkNative.nativePrimeHeadUnitMuted(it, nativeSessionGeneration.get())
+            }
             AasdkNative.nativeStartSession(transportPipe!!, this, sdrConfig)
         } catch (e: Exception) {
             OalLog.e(TAG, "Native session start failed: ${e.message}")
@@ -761,6 +784,17 @@ class AasdkSession(
         AasdkNative.nativeSendKeyEvent(keyCode, isDown)
     }
 
+    fun sendKeyPress(keyCode: Int, expectedNativeGeneration: Long): Boolean =
+        AasdkNative.nativeSendKeyPress(keyCode, expectedNativeGeneration)
+
+    fun setExperimentalMediaControlsEnabled(enabled: Boolean): Boolean =
+        synchronized(connectionStartLock) {
+            desiredExperimentalMediaControlsEnabled = enabled
+            val generation = nativeSessionGeneration.get()
+            generation != 0L &&
+                AasdkNative.nativeSetExperimentalMediaControlsEnabled(enabled, generation)
+        }
+
     fun sendGpsLocation(lat: Double, lon: Double, alt: Double,
                         speed: Float, bearing: Float, timestampMs: Long) {
         AasdkNative.nativeSendGpsLocation(lat, lon, alt, speed, bearing, timestampMs)
@@ -805,8 +839,16 @@ class AasdkSession(
      * Mirrors AAOS stream mute state into AA so phone apps can react
      * (e.g., pause/resume on mute/unmute).
      */
-    fun setHeadUnitMuted(muted: Boolean) {
-        AasdkNative.nativeSetHuMuted(muted)
+    fun setHeadUnitMuted(muted: Boolean): Boolean {
+        desiredHeadUnitMuted = muted
+        val generation = nativeSessionGeneration.get()
+        return generation != 0L && AasdkNative.nativeSetHeadUnitMuted(muted, generation)
+    }
+
+    fun primeHeadUnitMuted(muted: Boolean): Boolean {
+        desiredHeadUnitMuted = muted
+        val generation = nativeSessionGeneration.get()
+        return generation != 0L && AasdkNative.nativePrimeHeadUnitMuted(muted, generation)
     }
 
     /**

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -802,6 +802,14 @@ class AasdkSession(
     }
 
     /**
+     * Mirrors AAOS stream mute state into AA so phone apps can react
+     * (e.g., pause/resume on mute/unmute).
+     */
+    fun setHeadUnitMuted(muted: Boolean) {
+        AasdkNative.nativeSetHuMuted(muted)
+    }
+
+    /**
      * Invoked when the phone subscribes to a sensor type, so the owner
      * (SessionManager) can push current vehicle state immediately instead of
      * waiting for a VHAL change event that a parked car never produces.

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -2444,6 +2444,41 @@ private fun AudioTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        // Temporary field-test switch. Once vehicle evidence is conclusive this
+        // setting can be removed and the proven behavior made unconditional.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Experimental GM media controls",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text = "Route GM's native media controls and master/stream mute state " +
+                        "to Android Auto. Existing steering-wheel key remaps stay active. " +
+                        "Takes effect immediately.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(
+                checked = uiState.experimentalGmMediaControls,
+                onCheckedChange = { viewModel.updateExperimentalGmMediaControls(it) },
+                modifier = Modifier.testTag("experimentalGmMediaControlsToggle"),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        HorizontalDivider(modifier = Modifier.fillMaxWidth(0.7f))
+
+        Spacer(modifier = Modifier.height(24.dp))
+
         // --- Per-Purpose Volume Offsets ---
         SectionHeader("Volume Offsets")
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -48,6 +48,8 @@ data class SettingsUiState(
     val gpsForwarding: Boolean = AppPreferences.DEFAULT_GPS_FORWARDING,
     val alwaysInPark: Boolean = AppPreferences.DEFAULT_ALWAYS_IN_PARK,
     val clusterNavigation: Boolean = AppPreferences.DEFAULT_CLUSTER_NAVIGATION,
+    val experimentalGmMediaControls: Boolean =
+        AppPreferences.DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS,
     val overlayStatsButton: Boolean = AppPreferences.DEFAULT_OVERLAY_STATS_BUTTON,
     val overlayPhoneSwitchButton: Boolean = AppPreferences.DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON,
     val overlayReconnectButton: Boolean = AppPreferences.DEFAULT_OVERLAY_RECONNECT_BUTTON,
@@ -144,6 +146,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.simulateIgnitionButton,
         preferences.overlayPhoneSwitchButton,
         preferences.overlayReconnectButton,
+        preferences.experimentalGmMediaControls,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -196,6 +199,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             simulateIgnitionButton = values[47] as Boolean,
             overlayPhoneSwitchButton = values[48] as Boolean,
             overlayReconnectButton = values[49] as Boolean,
+            experimentalGmMediaControls = values[50] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -456,6 +460,10 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateClusterNavigation(enabled: Boolean) {
         viewModelScope.launch { preferences.setClusterNavigation(enabled) }
+    }
+
+    fun updateExperimentalGmMediaControls(enabled: Boolean) {
+        viewModelScope.launch { preferences.setExperimentalGmMediaControls(enabled) }
     }
 
     fun updateOverlayStatsButton(visible: Boolean) {

--- a/app/src/test/java/com/openautolink/app/media/GmMediaControlPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/media/GmMediaControlPolicyTest.kt
@@ -1,0 +1,124 @@
+package com.openautolink.app.media
+
+import android.view.KeyEvent
+import com.openautolink.app.data.AppPreferences
+import com.openautolink.app.ui.settings.SettingsUiState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GmMediaControlPolicyTest {
+
+    @Test
+    fun `experiment defaults off in storage and Settings state`() {
+        assertFalse(AppPreferences.DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS)
+        assertFalse(SettingsUiState().experimentalGmMediaControls)
+    }
+
+    @Test
+    fun `disabled experiment does not translate MediaSession commands`() {
+        assertNull(
+            GmMediaControlPolicy.keyCodeFor(
+                GmMediaControlPolicy.Command.PLAY,
+                enabled = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `enabled experiment uses the discrete key mapping from GM GAL`() {
+        assertEquals(
+            KeyEvent.KEYCODE_MEDIA_PLAY,
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PLAY, enabled = true),
+        )
+        assertEquals(
+            KeyEvent.KEYCODE_MEDIA_PAUSE,
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PAUSE, enabled = true),
+        )
+        assertEquals(
+            KeyEvent.KEYCODE_MEDIA_PAUSE,
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.STOP, enabled = true),
+        )
+        assertEquals(
+            KeyEvent.KEYCODE_MEDIA_NEXT,
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.NEXT, enabled = true),
+        )
+        assertEquals(
+            KeyEvent.KEYCODE_MEDIA_PREVIOUS,
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PREVIOUS, enabled = true),
+        )
+    }
+
+    @Test
+    fun `master or music-stream mute makes the effective HU state muted`() {
+        assertFalse(GmMediaControlPolicy.effectiveMuted(masterMuted = false, streamMuted = false))
+        assertTrue(GmMediaControlPolicy.effectiveMuted(masterMuted = true, streamMuted = false))
+        assertTrue(GmMediaControlPolicy.effectiveMuted(masterMuted = false, streamMuted = true))
+        assertTrue(GmMediaControlPolicy.effectiveMuted(masterMuted = true, streamMuted = true))
+    }
+
+    @Test
+    fun `mute synchronization emits only enabled state transitions`() {
+        assertNull(
+            GmMediaControlPolicy.nextMuteState(
+                enabled = false,
+                masterMuted = true,
+                streamMuted = false,
+                lastDeliveredMuted = false,
+            ),
+        )
+        assertEquals(
+            true,
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = true,
+                streamMuted = false,
+                lastDeliveredMuted = false,
+            ),
+        )
+        assertNull(
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = true,
+                streamMuted = true,
+                lastDeliveredMuted = true,
+            ),
+        )
+        assertEquals(
+            false,
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = false,
+                streamMuted = false,
+                lastDeliveredMuted = true,
+            ),
+        )
+        assertNull(
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = false,
+                streamMuted = false,
+                lastDeliveredMuted = null,
+            ),
+        )
+        assertEquals(
+            true,
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = true,
+                streamMuted = false,
+                lastDeliveredMuted = null,
+            ),
+        )
+        assertNull(
+            GmMediaControlPolicy.nextMuteState(
+                enabled = true,
+                masterMuted = true,
+                streamMuted = false,
+                lastDeliveredMuted = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/openautolink/app/media/GmMediaControlWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/media/GmMediaControlWiringContractTest.kt
@@ -1,0 +1,112 @@
+package com.openautolink.app.media
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class GmMediaControlWiringContractTest {
+
+    @Test
+    fun `experimental control mode is off by default and reachable from Settings`() {
+        val preferences = source("app/src/main/java/com/openautolink/app/data/AppPreferences.kt")
+        val settingsVm = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
+        val settingsUi = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt")
+
+        assertTrue(preferences.contains("EXPERIMENTAL_GM_MEDIA_CONTROLS"))
+        assertTrue(preferences.contains("DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS = false"))
+        assertTrue(preferences.contains("val experimentalGmMediaControls: Flow<Boolean>"))
+        assertTrue(preferences.contains("suspend fun setExperimentalGmMediaControls"))
+        assertTrue(settingsVm.contains("experimentalGmMediaControls"))
+        assertTrue(settingsVm.contains("updateExperimentalGmMediaControls"))
+        assertTrue(settingsUi.contains("Experimental GM media controls"))
+        assertTrue(settingsUi.contains("experimentalGmMediaControlsToggle"))
+    }
+
+    @Test
+    fun `enabled MediaSession controls and both GM mute channels reach the current AA session`() {
+        val media = source("app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt")
+        val manager = source("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+        val aasdk = source("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt")
+        val nativeApi = source("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt")
+        val jni = source("app/src/main/cpp/aasdk_jni.cpp")
+        val nativeImpl = source("app/src/main/cpp/jni_session.cpp")
+
+        assertTrue(media.contains("override fun onStop()"))
+        assertTrue(media.contains("GmMediaControlPolicy.Command.STOP"))
+        assertTrue(media.contains("PlaybackStateCompat.ACTION_STOP"))
+        assertTrue(media.contains("if (experimentalControlsEnabled) actions = actions or PlaybackStateCompat.ACTION_STOP"))
+        assertTrue(media.contains("buildPlaybackState(lastPushedState, lastPushedPosition)"))
+        assertTrue(manager.contains("setExperimentalControlsEnabled(false)"))
+        assertTrue(manager.contains("setExperimentalControlsEnabled(true)"))
+        assertTrue(manager.contains("preferences.experimentalGmMediaControls.distinctUntilChanged()"))
+        assertTrue(manager.contains("MASTER_MUTE_CHANGED_ACTION"))
+        assertTrue(manager.contains("STREAM_MUTE_CHANGED_ACTION"))
+        assertTrue(manager.contains("EXTRA_MASTER_VOLUME_MUTED"))
+        assertTrue(manager.contains("manager.isStreamMute(AudioManager.STREAM_MUSIC)"))
+        assertTrue(manager.contains("routeMediaSessionCommand"))
+        assertTrue(manager.contains("syncExperimentalHuMuteState"))
+        assertTrue(manager.contains("primeExperimentalUnmutedState"))
+        val receiverBlock = manager
+            .substringAfter("private fun registerMuteStateReceiver()")
+            .substringBefore("private fun unregisterMuteStateReceiver()")
+        assertTrue(receiverBlock.contains("scope.launch { syncExperimentalHuMuteState"))
+        assertTrue(aasdk.contains("fun sendKeyPress"))
+        assertTrue(aasdk.contains("currentNativeSessionGeneration"))
+        assertTrue(aasdk.contains("fun setHeadUnitMuted"))
+        val nativeGateSetter = aasdk
+            .substringAfter("fun setExperimentalMediaControlsEnabled")
+            .substringBefore("fun sendGpsLocation")
+        assertTrue(nativeGateSetter.contains("synchronized(connectionStartLock)"))
+        assertTrue(nativeApi.contains("nativeSendKeyPress"))
+        assertTrue(nativeApi.contains("nativeSetHeadUnitMuted"))
+        assertTrue(nativeApi.contains("nativePrimeHeadUnitMuted"))
+        assertTrue(nativeApi.contains("nativeSetExperimentalMediaControlsEnabled"))
+        assertTrue(jni.contains("AasdkNative_nativeSendKeyPress"))
+        assertTrue(jni.contains("AasdkNative_nativeSetHeadUnitMuted"))
+        assertTrue(jni.contains("gSessionGeneration.load() != expectedGeneration"))
+        val keyPressBody = nativeImpl
+            .substringAfter("bool JniSession::sendKeyPress")
+            .substringBefore("void JniSession::sendGpsLocation")
+        assertTrue(keyPressBody.contains("for (bool down : {true, false})"))
+        assertTrue(keyPressBody.contains("edges == 2"))
+        assertTrue(keyPressBody.contains("experimentalMediaControlsEnabled_"))
+        val muteSetterBody = nativeImpl
+            .substringAfter("bool JniSession::setHeadUnitMuted")
+            .substringBefore("bool JniSession::flushHeadUnitAudioFocusState")
+        assertTrue(muteSetterBody.contains("ioService_->post"))
+        assertFalse(muteSetterBody.contains("controlChannel_"))
+        assertFalse(muteSetterBody.contains("strand_"))
+        val setupFocusBody = nativeImpl
+            .substringAfter("void JniSession::sendUnsolicitedAudioFocusGain")
+            .substringBefore("bool JniSession::setHeadUnitMuted")
+        assertTrue(setupFocusBody.contains("if (!experimentalMediaControlsEnabled_.load())"))
+        assertTrue(setupFocusBody.contains("AUDIO_FOCUS_STATE_GAIN"))
+        assertTrue(nativeImpl.contains("Key press send complete:"))
+        assertTrue(nativeImpl.contains("AA audio focus sync outcome=sent:"))
+    }
+
+    @Test
+    fun `existing custom key remapping remains independent of experimental MediaSession controls`() {
+        val steering = source("app/src/main/java/com/openautolink/app/input/SteeringWheelController.kt")
+        val customBranch = steering
+            .substringAfter("val customMapped = customKeyMap[keycode]")
+            .substringBefore("return when")
+
+        assertTrue(customBranch.contains("sendButtonToAA(customMapped"))
+        assertFalse(steering.contains("experimentalGmMediaControls"))
+        assertFalse(steering.contains("GmMediaControlPolicy"))
+    }
+
+    private fun source(path: String): String = projectFile(path).readText()
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        error("Cannot locate project file: $path")
+    }
+}


### PR DESCRIPTION
## Summary

- carry Matt Nelson's mute-sync work onto current `main` with authorship preserved
- add an off-by-default **Experimental GM media controls** toggle under Settings → Audio
- route GM native MediaSession Play/Pause/Stop/Next/Previous controls to the current Android Auto input session
- combine GM master mute and `STREAM_MUSIC` mute into unsolicited Android Auto focus Loss/Gain while the experiment is enabled
- retain exact wrapper/native-generation fencing and a native enable gate so reconnects or rapid disable cannot deliver stale commands
- preserve the existing Activity/`SteeringWheelController` custom key-remap path unchanged
- add positive attempted/queued/sent/failed diagnostic markers for the next vehicle log

## Toggle behavior

**Off (default):** existing behavior is preserved. MediaSession callbacks are disconnected, experimental Stop is not advertised, and audio setup retains its existing unsolicited Gain behavior.

**On:** GM media-screen controls and master/stream mute are bridged to Android Auto. Existing custom steering-wheel remaps remain active on their separate input path.

## Verification

- strict test-first policy and wiring tests, including remap independence
- full `:app:testDebugUnitTest`: 477 tests, 0 failures/errors/skips
- `:app:externalNativeBuildDebug`: arm64-v8a and x86_64 passed
- `:app:assembleDebug` passed
- final source tree hash matched before/after verification
- built APK contains both JNI ABIs and all new runtime outcome markers
- independent lifecycle/native/settings reviews completed; all blocking findings resolved before commit

## Vehicle test

Enable **Settings → Audio → Experimental GM media controls**, then test:

1. native GM media-screen Play/Pause/Next/Previous;
2. steering-wheel mute/end-call button;
3. display power button;
4. existing custom F-key remaps;
5. mute → unmute and power-off-view → restore.

The decisive uploaded-log markers are:

```text
Experimental GM media controls enabled; legacy key-remap path unchanged
MediaSession command attempted:
MediaSession command outcome=queued:
Key press send complete:
HU mute state changed:
AA audio focus sync outcome=sent:
```

This is a field-test attempt and does not close #113 until vehicle behavior and the next uploaded log confirm the outcome.

Closes no issue; relates to #113.
