### PR TITLE
fix(cluster): reject stale bootstrap generations

### DIFF
--- a/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapTaskState.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapTaskState.kt
@@ -14,7 +14,8 @@ internal class ClusterBootstrapTaskState<T : Any> {
 
     @Synchronized
     fun protect(generation: Long, owner: T) {
-        if (this.generation != generation) {
+        if (generation < this.generation) return
+        if (generation > this.generation) {
             backgroundRequestedGeneration = Long.MIN_VALUE
         }
         this.generation = generation

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapTaskStateTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapTaskStateTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ClusterBootstrapTaskStateTest {
@@ -36,6 +37,22 @@ class ClusterBootstrapTaskStateTest {
         state.protect(8, replacement)
 
         assertNull(state.pendingTargetFor(replacement))
+        assertNull(state.requestBackground(7))
+    }
+
+    @Test
+    fun staleGenerationCannotReplaceCurrentOwnerOrClearPendingRequest() {
+        val state = ClusterBootstrapTaskState<Any>()
+        val current = Any()
+        val stale = Any()
+        state.protect(8, current)
+        val currentTarget = state.requestBackground(8)!!
+
+        state.protect(7, stale)
+
+        assertSame(current, state.pendingTargetFor(current)!!.owner)
+        assertTrue(state.isCurrent(currentTarget))
+        assertNull(state.pendingTargetFor(stale))
         assertNull(state.requestBackground(7))
     }
 


### PR DESCRIPTION
## Summary

- reject older `CarAppActivity` binding generations in `ClusterBootstrapTaskState.protect()`
- preserve the current generation's owner and pending move-to-back request when a stale Activity is recreated late
- retain existing behavior for same-generation Activity replacement and strictly newer generations
- add a regression test reproducing the stale generation 7 → active generation 8 takeover

## Why

A delayed Activity from an older binding generation could call `protect()` after a newer generation was active. The old implementation treated every different generation as newer, replaced the current owner, and cleared the active background request. That could leave the current bootstrap task in front.

Binding generations are monotonic. Older generations must be ignored rather than installed.

## TDD evidence

Before the fix, `staleGenerationCannotReplaceCurrentOwnerOrClearPendingRequest` failed with an NPE because the stale Activity displaced the current owner. After the monotonic guard, the focused suite passes.

## Verification

- focused `ClusterBootstrapTaskStateTest`: pass
- `:app:testDebugUnitTest :app:assembleDebug --rerun-tasks --no-daemon --max-workers=2`: pass
- **485 tests, 0 failures, 0 errors, 0 skipped**
- debug APK contains both **arm64-v8a** and **x86_64**
- APK SHA-256: `7c1489ef361ef1b900a8a971081dbbf58dac8ebda6d4d9d2ef09d1dfd4fe0994`
- staged-diff security and whitespace scans: clean

## Honest status

This closes the source-level stale-generation race identified after PR #117. The overall windowless cluster behavior remains an attempt pending vehicle verification.

Follow-up to #117 and #118.
