### PR TITLE
fix(video): configure per-codec seed thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ GM's recent AAOS EVs share much of the same infotainment platform. A problem rep
 - **Wide-display adaptation** — configurable DPI, safe areas, margins, and scaling
 - **Modern video support** — H.264, H.265, and VP9; manual tiers include 1440p (2560×1440) and 4K (3840×2160), plus portrait equivalents
 - **Verified H.265 startup** — H.265 startup is verified clean over USB and wireless with GAL 6's 120-frame GOP
+- **Per-codec seed filtering** — Settings → Video exposes startup-placeholder cutoffs; defaults are H.264 10,000 bytes, H.265 4,096 bytes, and VP9 disabled (0), with changes applied by Save & Reconnect
 - **Built-in diagnostics** — transport status, network tools, VHAL browser, and optional log export
 
 OpenAutoLink forwards the vehicle's real battery and range data into Android Auto. Google Maps uses the standard vehicle energy model for battery-aware navigation and destination estimates. See [EV range estimates](docs/ev-range.md).

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -9,6 +9,8 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.openautolink.app.transport.aasdk.GalProtocolPolicy
+import com.openautolink.app.video.SeedIdrPolicy
+import com.openautolink.app.video.SeedIdrThresholds
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -33,6 +35,9 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
         val VIDEO_AUTO_NEGOTIATE = booleanPreferencesKey("video_auto_negotiate")
         val VIDEO_CODEC = stringPreferencesKey("video_codec")
+        val VIDEO_SEED_THRESHOLD_H264 = intPreferencesKey("video_seed_threshold_h264")
+        val VIDEO_SEED_THRESHOLD_H265 = intPreferencesKey("video_seed_threshold_h265")
+        val VIDEO_SEED_THRESHOLD_VP9 = intPreferencesKey("video_seed_threshold_vp9")
         val VIDEO_FPS = intPreferencesKey("video_fps")
         // v2 deliberately starts every existing install on verified GAL 6.0.
         // Choices made after this migration persist normally under the new key.
@@ -248,6 +253,9 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
         const val DEFAULT_VIDEO_AUTO_NEGOTIATE = true
         const val DEFAULT_VIDEO_CODEC = "h264"
+        const val DEFAULT_VIDEO_SEED_THRESHOLD_H264 = SeedIdrThresholds.DEFAULT_H264_BYTES
+        const val DEFAULT_VIDEO_SEED_THRESHOLD_H265 = SeedIdrThresholds.DEFAULT_H265_BYTES
+        const val DEFAULT_VIDEO_SEED_THRESHOLD_VP9 = SeedIdrThresholds.DEFAULT_VP9_BYTES
         const val DEFAULT_VIDEO_FPS = 60
         const val DEFAULT_GAL_VERSION = "6.0"
         const val DEFAULT_DISPLAY_MODE = "fullscreen_immersive"
@@ -388,6 +396,20 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val videoCodec: Flow<String> = dataStore.data.map { prefs ->
         prefs[VIDEO_CODEC] ?: DEFAULT_VIDEO_CODEC
+    }
+
+    val seedIdrThresholds: Flow<SeedIdrThresholds> = dataStore.data.map { prefs ->
+        SeedIdrThresholds(
+            h264Bytes = SeedIdrPolicy.sanitizeThreshold(
+                prefs[VIDEO_SEED_THRESHOLD_H264] ?: DEFAULT_VIDEO_SEED_THRESHOLD_H264,
+            ),
+            h265Bytes = SeedIdrPolicy.sanitizeThreshold(
+                prefs[VIDEO_SEED_THRESHOLD_H265] ?: DEFAULT_VIDEO_SEED_THRESHOLD_H265,
+            ),
+            vp9Bytes = SeedIdrPolicy.sanitizeThreshold(
+                prefs[VIDEO_SEED_THRESHOLD_VP9] ?: DEFAULT_VIDEO_SEED_THRESHOLD_VP9,
+            ),
+        )
     }
 
     val videoFps: Flow<Int> = dataStore.data.map { prefs ->
@@ -723,6 +745,18 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setVideoCodec(codec: String) {
         dataStore.edit { it[VIDEO_CODEC] = codec }
+    }
+
+    suspend fun setVideoSeedThresholdH264(bytes: Int) {
+        dataStore.edit { it[VIDEO_SEED_THRESHOLD_H264] = SeedIdrPolicy.sanitizeThreshold(bytes) }
+    }
+
+    suspend fun setVideoSeedThresholdH265(bytes: Int) {
+        dataStore.edit { it[VIDEO_SEED_THRESHOLD_H265] = SeedIdrPolicy.sanitizeThreshold(bytes) }
+    }
+
+    suspend fun setVideoSeedThresholdVp9(bytes: Int) {
+        dataStore.edit { it[VIDEO_SEED_THRESHOLD_VP9] = SeedIdrPolicy.sanitizeThreshold(bytes) }
     }
 
     suspend fun setVideoFps(fps: Int) {

--- a/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
+++ b/app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt
@@ -206,6 +206,7 @@ class SettingsReceiver : BroadcastReceiver() {
                     manualIpAddress = if (prefs.manualIpEnabled.first())
                         prefs.manualIpAddress.first().takeIf { it.isNotBlank() } else null,
                     galVersion = prefs.galVersion.first(),
+                    seedIdrThresholds = prefs.seedIdrThresholds.first(),
                 )
                 OalLog.i("SettingsRcv", "RECONNECT: triggered")
             } catch (e: Exception) {

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -44,6 +44,7 @@ import com.openautolink.app.video.DecoderState
 import com.openautolink.app.video.AutoDpiPolicy
 import com.openautolink.app.video.AutoVideoTouchPolicy
 import com.openautolink.app.video.MediaCodecDecoder
+import com.openautolink.app.video.SeedIdrThresholds
 import com.openautolink.app.video.VideoDecoder
 import com.openautolink.app.video.VideoStats
 import kotlinx.coroutines.CoroutineScope
@@ -294,6 +295,9 @@ class SessionManager(
     private var lastScalingMode: String = AppPreferences.DEFAULT_VIDEO_SCALING_MODE
 
     @Volatile
+    private var lastSeedIdrThresholds = SeedIdrThresholds()
+
+    @Volatile
     private var lastVolumeOffsetMedia: Int = 0
 
     @Volatile
@@ -448,11 +452,13 @@ class SessionManager(
     private fun createVideoDecoder(
         codecPreference: String,
         scalingMode: String,
+        seedIdrThresholds: SeedIdrThresholds,
     ): MediaCodecDecoder {
         val decoderGeneration = videoDecoderGeneration.incrementAndGet()
         return MediaCodecDecoder(
             codecPreference = codecPreference,
             scalingMode = scalingMode,
+            seedIdrThresholds = seedIdrThresholds,
             onSessionRestartNeeded = { reason ->
                 val targetSession = aasdkSession
                 OalLog.w(TAG, "Decoder cannot recover the output surface in-place — $reason")
@@ -484,7 +490,11 @@ class SessionManager(
             return
         }
         OalLog.i(TAG, "No video decoder for this session — creating one")
-        _videoDecoder = createVideoDecoder(lastCodecPreference, lastScalingMode)
+        _videoDecoder = createVideoDecoder(
+            lastCodecPreference,
+            lastScalingMode,
+            seedIdrThresholds = lastSeedIdrThresholds,
+        )
         lastKnownSurface?.let { (surface, w, h) ->
             if (surface.isValid) {
                 OalLog.i(TAG, "Attaching the last known surface to the new decoder")
@@ -1106,6 +1116,7 @@ class SessionManager(
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
         wppRearmSource: String? = null,
+        seedIdrThresholds: SeedIdrThresholds = SeedIdrThresholds(),
     ) {
         val requestGeneration = lifecycleGeneration
         val transportStartGeneration = currentTransportStartGeneration()
@@ -1138,12 +1149,17 @@ class SessionManager(
         // needs one without re-running this setup.
         lastCodecPreference = codecPreference
         lastScalingMode = scalingMode
+        lastSeedIdrThresholds = seedIdrThresholds
         // Remembered for the same reason: an audio player rebuilt on a transport
         // restart must keep the user's volume offsets.
         lastVolumeOffsetMedia = volumeOffsetMedia
         lastVolumeOffsetNavigation = volumeOffsetNavigation
         lastVolumeOffsetAssistant = volumeOffsetAssistant
-        _videoDecoder = createVideoDecoder(codecPreference, scalingMode)
+        _videoDecoder = createVideoDecoder(
+            codecPreference,
+            scalingMode,
+            seedIdrThresholds = seedIdrThresholds,
+        )
         // Re-attach the surface the UI last reported, if there is one.
         //
         // Holding it here rather than only in the ViewModel removes the ordering
@@ -2113,6 +2129,7 @@ class SessionManager(
         safeAreaRight: Int = 0,
         gpsForwarding: Boolean = true,
         galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
+        seedIdrThresholds: SeedIdrThresholds = SeedIdrThresholds(),
     ) {
         // "Save & Reconnect" from Settings doesn't know the resolved Car
         // Hotspot IP — fall back to the last value we successfully used so
@@ -2133,6 +2150,7 @@ class SessionManager(
                 volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                 effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
                 gpsForwarding, galVersion,
+                seedIdrThresholds = seedIdrThresholds,
             )
             return
         }
@@ -2227,6 +2245,7 @@ class SessionManager(
                     volumeOffsetMedia, volumeOffsetNavigation, volumeOffsetAssistant,
                     effectiveManualIp, safeAreaTop, safeAreaBottom, safeAreaLeft, safeAreaRight,
                     gpsForwarding, galVersion, transportStartGeneration,
+                    seedIdrThresholds,
                 )
             } catch (e: Exception) {
                 OalLog.e(TAG, "reconnect() failed: ${e.message}")
@@ -2260,6 +2279,7 @@ class SessionManager(
         gpsForwarding: Boolean,
         galVersion: String,
         transportStartGeneration: Long,
+        seedIdrThresholds: SeedIdrThresholds,
     ) {
         observeJob = null
         decoderWatchJob = null
@@ -2278,7 +2298,12 @@ class SessionManager(
 
         // 3. Flush video decoder (codec/scaling may have changed)
         _videoDecoder?.release()
-        _videoDecoder = createVideoDecoder(codecPreference, scalingMode)
+        lastSeedIdrThresholds = seedIdrThresholds
+        _videoDecoder = createVideoDecoder(
+            codecPreference,
+            scalingMode,
+            seedIdrThresholds = seedIdrThresholds,
+        )
         _telemetryCollector?.videoDecoder = _videoDecoder
 
         // 4. Update audio volume offsets in-place (no release/recreate)

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -82,7 +82,7 @@ class AasdkSession(
     private val _videoFrames = MutableSharedFlow<VideoFrame>(extraBufferCapacity = 30)
     val videoFrames: SharedFlow<VideoFrame> = _videoFrames.asSharedFlow()
 
-    /** Negotiated video codec type from phone. 3=H.264, 5=H.264_BP, 7=H.265 */
+    /** Negotiated video codec type from phone. 3=H.264, 5=VP9, 7=H.265 */
     private val _negotiatedCodecType = MutableStateFlow(0)
     val negotiatedCodecType: StateFlow<Int> = _negotiatedCodecType.asStateFlow()
 

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSessionCallback.kt
@@ -28,7 +28,7 @@ interface AasdkSessionCallback {
 
     /**
      * Phone negotiated a video codec during channel setup.
-     * @param codecType aasdk MediaCodecType: 3=H.264, 5=H.264_BP, 7=H.265
+     * @param codecType aasdk MediaCodecType: 3=H.264, 5=VP9, 7=H.265
      */
     fun onVideoCodecConfigured(codecType: Int)
 

--- a/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt
@@ -639,6 +639,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
         wppRearmSource: String? = null,
     ) {
             val codec = preferences.videoCodec.first()
+            val seedIdrThresholds = preferences.seedIdrThresholds.first()
             val micSrc = preferences.micSource.first()
             val scalingMode = preferences.videoScalingMode.first()
             val hotspotSsid = preferences.hotspotSsid.first()
@@ -869,6 +870,7 @@ class ProjectionViewModel(application: Application) : AndroidViewModel(applicati
                 gpsForwarding = gpsForwarding,
                 galVersion = galVersion,
                 wppRearmSource = wppRearmSource,
+                seedIdrThresholds = seedIdrThresholds,
             )
     }
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -1449,6 +1449,68 @@ private fun VideoTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        SectionHeader("Seed keyframe thresholds")
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = "Keyframes smaller than the selected codec's threshold are treated as " +
+                "startup placeholders and decoded silently for 2.5 seconds. Set 0 to disable " +
+                "the guard for that codec. Defaults come from uploaded vehicle logs: H.264 " +
+                "10,000 bytes, H.265 4,096 bytes, VP9 disabled. Requires Save & Reconnect.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.fillMaxWidth(0.7f).padding(bottom = 12.dp),
+        )
+
+        data class SeedThresholdOption(
+            val testTag: String,
+            val label: String,
+            val value: Int,
+            val onChange: (Int) -> Unit,
+        )
+
+        listOf(
+            SeedThresholdOption(
+                "seedThreshold_h264",
+                "H.264 seed cutoff (bytes)",
+                uiState.videoSeedThresholdH264,
+                viewModel::updateVideoSeedThresholdH264,
+            ),
+            SeedThresholdOption(
+                "seedThreshold_h265",
+                "H.265 / HEVC seed cutoff (bytes)",
+                uiState.videoSeedThresholdH265,
+                viewModel::updateVideoSeedThresholdH265,
+            ),
+            SeedThresholdOption(
+                "seedThreshold_vp9",
+                "VP9 seed cutoff (bytes)",
+                uiState.videoSeedThresholdVp9,
+                viewModel::updateVideoSeedThresholdVp9,
+            ),
+        ).forEach { option ->
+            LocalEchoTextField(
+                value = option.value.toString(),
+                onValueChange = { raw ->
+                    option.onChange(raw.filter(Char::isDigit).take(7).toIntOrNull() ?: 0)
+                },
+                label = { Text(option.label) },
+                supportingText = { Text("0 disables this codec's seed filter") },
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .padding(vertical = 4.dp)
+                    .testTag(option.testTag),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        HorizontalDivider(modifier = Modifier.fillMaxWidth(0.7f))
+
+        Spacer(modifier = Modifier.height(24.dp))
+
         // --- DPI ---
         SectionHeader("AA Display Density (DPI)")
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -27,6 +27,9 @@ data class SettingsUiState(
     val wppChannelMhz: String = "",
     val videoAutoNegotiate: Boolean = AppPreferences.DEFAULT_VIDEO_AUTO_NEGOTIATE,
     val videoCodec: String = AppPreferences.DEFAULT_VIDEO_CODEC,
+    val videoSeedThresholdH264: Int = AppPreferences.DEFAULT_VIDEO_SEED_THRESHOLD_H264,
+    val videoSeedThresholdH265: Int = AppPreferences.DEFAULT_VIDEO_SEED_THRESHOLD_H265,
+    val videoSeedThresholdVp9: Int = AppPreferences.DEFAULT_VIDEO_SEED_THRESHOLD_VP9,
     val videoFps: Int = AppPreferences.DEFAULT_VIDEO_FPS,
     val galVersion: String = AppPreferences.DEFAULT_GAL_VERSION,
     val displayMode: String = AppPreferences.DEFAULT_DISPLAY_MODE,
@@ -220,6 +223,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _wppChannelMhzOverride = MutableStateFlow("")
     private val _directTransportOverride = MutableStateFlow(AppPreferences.DEFAULT_DIRECT_TRANSPORT)
 
+    private val seedIdrThresholds = preferences.seedIdrThresholds.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5000),
+        com.openautolink.app.video.SeedIdrThresholds(),
+    )
+
     init {
         viewModelScope.launch {
             preferences.hotspotSsid.collect { _hotspotSsidOverride.value = it }
@@ -252,6 +261,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         _wppApInterfaceOverride,
         _wppChannelMhzOverride,
         galVersion,
+        seedIdrThresholds,
     ) { arr ->
         val state = arr[0] as SettingsUiState
         state.copy(
@@ -260,6 +270,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             wppApInterface = arr[5] as String,
             wppChannelMhz = arr[6] as String,
             galVersion = arr[7] as String,
+            videoSeedThresholdH264 = (arr[8] as com.openautolink.app.video.SeedIdrThresholds).h264Bytes,
+            videoSeedThresholdH265 = (arr[8] as com.openautolink.app.video.SeedIdrThresholds).h265Bytes,
+            videoSeedThresholdVp9 = (arr[8] as com.openautolink.app.video.SeedIdrThresholds).vp9Bytes,
         )
     }.stateIn(
         viewModelScope,
@@ -376,6 +389,18 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     }
     fun updateVideoCodec(codec: String) {
         viewModelScope.launch { preferences.setVideoCodec(codec) }
+    }
+
+    fun updateVideoSeedThresholdH264(bytes: Int) {
+        viewModelScope.launch { preferences.setVideoSeedThresholdH264(bytes) }
+    }
+
+    fun updateVideoSeedThresholdH265(bytes: Int) {
+        viewModelScope.launch { preferences.setVideoSeedThresholdH265(bytes) }
+    }
+
+    fun updateVideoSeedThresholdVp9(bytes: Int) {
+        viewModelScope.launch { preferences.setVideoSeedThresholdVp9(bytes) }
     }
 
     fun updateVideoAutoNegotiate(enabled: Boolean) {
@@ -607,6 +632,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             val sm = com.openautolink.app.session.SessionManager.instanceOrNull() ?: return@launch
             val codec = preferences.videoCodec.first()
+            val seedIdrThresholds = preferences.seedIdrThresholds.first()
             val micSrc = preferences.micSource.first()
             val scalingMode = preferences.videoScalingMode.first()
             val hotspotSsid = preferences.hotspotSsid.first()
@@ -675,6 +701,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 safeAreaRight = saRight,
                 gpsForwarding = gpsForwarding,
                 galVersion = galVersion,
+                seedIdrThresholds = seedIdrThresholds,
             )
         }
     }

--- a/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
+++ b/app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong
 class MediaCodecDecoder(
     private val codecPreference: String = "h264",
     private val scalingMode: String = "letterbox", // "letterbox" or "crop"
+    private val seedIdrThresholds: SeedIdrThresholds = SeedIdrThresholds(),
     private val onSessionRestartNeeded: (String) -> Unit = {},
 ) : VideoDecoder {
 
@@ -47,30 +48,21 @@ class MediaCodecDecoder(
         private const val INPUT_TIMEOUT_BEHIND_US = 5000L // 5ms — shorter when catching up
         private const val OUTPUT_TIMEOUT_US = 1000L // 1ms timeout for output drain
         private const val STATS_INTERVAL_MS = 500L
-        // Minimum IDR size to be considered a real picture (not encoder startup seed
-        // and not gearhead's startup splash).
-        //
-        // HISTORY (#18): this was 4096 with a comment claiming "seed IDRs are ~900
-        // bytes". That was measured against an early seed IDR and is WRONG for the
-        // case that actually matters: gearhead sends an ~8176-byte black/green
-        // startup-splash keyframe at session start (confirmed in the deep-sleep
-        // black-video investigation, 2026-07-18). 8176 > 4096, so the splash took
-        // the REAL-IDR branch — we unblanked on a non-picture and then rendered
-        // P-frames anchored to it until the phone's next scheduled IDR.
-        //
-        // On WIRELESS that next IDR is 60 SECONDS away: gearhead hard-codes
-        // VideoEncoderParams__key_frame_interval_wireless = 60 (teardown
-        // p000/acgw.java mo3361l; the 2s "ackless" alternative in mo3360k is dead
-        // code — p000/vlz.java's constructor assigns ackless=false unconditionally).
-        // That is the exact source of #18's "green for the first 60 seconds".
-        //
-        // Real content IDRs measure 100-210KB. 50000 sits well above the 8176B
-        // splash and well below the smallest observed real IDR.
-        private const val MIN_REAL_IDR_BYTES = 50_000
+        // Seed cutoffs are codec-specific and user-configurable. The archive has
+        // an 8,176-byte H.264 startup splash, 898-1,075-byte H.265 placeholders,
+        // and legitimate H.265 content IDRs down to 43,026 bytes. One global
+        // 50,000-byte cutoff therefore blanked Clark's healthy stream for 2.5s.
         // After accepting a seed IDR, silently decode P-frames for this long before
         // rendering. Gives the decoder time to accumulate picture content from P-frames
         // so the first visible frame is mostly complete rather than green.
         private const val SEED_WARMUP_MS = 2500L
+    }
+
+    init {
+        val message = "Seed IDR thresholds: h264=${seedIdrThresholds.h264Bytes} " +
+            "h265=${seedIdrThresholds.h265Bytes} vp9=${seedIdrThresholds.vp9Bytes}"
+        Log.i(TAG, message)
+        DiagnosticLog.i("video", message)
     }
 
     private val _decoderState = MutableStateFlow(DecoderState.IDLE)
@@ -126,9 +118,10 @@ class MediaCodecDecoder(
     /** Emit the #18 diagnostic line for an IDR, naming the branch that consumed it. */
     private fun logIdrDiag(branch: String, frame: VideoFrame) {
         if (!isH265Stream()) return
+        val thresholdBytes = SeedIdrPolicy.thresholdBytes(detectedCodec, seedIdrThresholds)
         val sinceLast = if (lastRealIdrMs > 0) System.currentTimeMillis() - lastRealIdrMs else -1L
         val msg = "H265-IDR branch=$branch size=${frame.data.size}B " +
-                "threshold=$MIN_REAL_IDR_BYTES pSinceLastIdr=${pFramesSinceIdr.get()} " +
+                "threshold=$thresholdBytes pSinceLastIdr=${pFramesSinceIdr.get()} " +
                 "msSinceLastIdr=$sinceLast real=$realIdrCount sub=$subThresholdIdrCount " +
                 "renderGate=$renderingEnabled outFmt=$outputFormatReceived"
         Log.i(TAG, msg)
@@ -139,14 +132,10 @@ class MediaCodecDecoder(
     /**
      * Set the negotiated codec type from the AA protocol (video setup response).
      * Must be called before video frames arrive.
-     * @param aaCodecType aasdk MediaCodecType: 3=H.264, 5=H.264_BP, 7=H.265
+     * @param aaCodecType aasdk MediaCodecType: 3=H.264, 5=VP9, 7=H.265
      */
     fun setNegotiatedCodec(aaCodecType: Int) {
-        val newCodec = when (aaCodecType) {
-            7 -> "h265"
-            3, 5 -> "h264"
-            else -> return
-        }
+        val newCodec = SeedIdrPolicy.codecForAaType(aaCodecType) ?: return
         if (newCodec != detectedCodec) {
             val newMime = CodecSelector.codecToMime(newCodec)
             Log.i(TAG, "Negotiated codec from AA protocol: $newCodec ($newMime) — was $detectedCodec ($mimeType)")
@@ -418,7 +407,10 @@ class MediaCodecDecoder(
         if (inputPaused) {
             // Still cache config and the newest IDR — they are what lets the
             // fallback reconfigure path work if the swap is refused.
-            if (frame.isKeyframe && frame.data.size >= MIN_REAL_IDR_BYTES) {
+            val seedThresholdBytes = SeedIdrPolicy.thresholdBytes(detectedCodec, seedIdrThresholds)
+            if (frame.isKeyframe &&
+                (seedThresholdBytes == 0 || frame.data.size >= seedThresholdBytes)
+            ) {
                 cachedIdrFrame = frame
             }
             framesDropped.incrementAndGet()
@@ -606,10 +598,11 @@ class MediaCodecDecoder(
         // but suppress rendering for SEED_WARMUP_MS. After warmup, enough P-frame blocks
         // have accumulated that the picture is mostly complete. A real IDR (when it arrives
         // at the phone's natural GOP interval) will clean up any remaining artifacts.
-        if (frame.data.size < MIN_REAL_IDR_BYTES) {
+        val seedThresholdBytes = SeedIdrPolicy.thresholdBytes(detectedCodec, seedIdrThresholds)
+        if (seedThresholdBytes > 0 && frame.data.size < seedThresholdBytes) {
             subThresholdIdrCount++
             logIdrDiag("sub-threshold(seed-or-splash)", frame)
-            Log.w(TAG, "Seed IDR detected (${frame.data.size} bytes < $MIN_REAL_IDR_BYTES) — silent decode for ${SEED_WARMUP_MS}ms before rendering")
+            Log.w(TAG, "Seed IDR detected (${frame.data.size} bytes < $seedThresholdBytes for $detectedCodec) — silent decode for ${SEED_WARMUP_MS}ms before rendering")
             DiagnosticLog.w("video", "Seed IDR: ${frame.data.size}B, warmup ${SEED_WARMUP_MS}ms")
             queueFrame(frame)  // Feed to decoder — establishes reference for P-frames
             receivedIdr = true  // Allow P-frames to flow to decoder

--- a/app/src/main/java/com/openautolink/app/video/SeedIdrPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/video/SeedIdrPolicy.kt
@@ -1,0 +1,42 @@
+package com.openautolink.app.video
+
+/** Per-codec cutoff below which a keyframe is treated as a startup placeholder. */
+data class SeedIdrThresholds(
+    val h264Bytes: Int = DEFAULT_H264_BYTES,
+    val h265Bytes: Int = DEFAULT_H265_BYTES,
+    val vp9Bytes: Int = DEFAULT_VP9_BYTES,
+) {
+    companion object {
+        const val DEFAULT_H264_BYTES = 10_000
+        const val DEFAULT_H265_BYTES = 4_096
+        const val DEFAULT_VP9_BYTES = 0
+    }
+}
+
+object SeedIdrPolicy {
+    const val MAX_THRESHOLD_BYTES = 1_000_000
+
+    /** AA protocol MediaCodecType values supported by the current decoder UI. */
+    fun codecForAaType(aaCodecType: Int): String? = when (aaCodecType) {
+        3 -> "h264"
+        5 -> "vp9"
+        7 -> "h265"
+        else -> null
+    }
+
+    fun sanitizeThreshold(bytes: Int): Int = bytes.coerceIn(0, MAX_THRESHOLD_BYTES)
+
+    fun thresholdBytes(codec: String, thresholds: SeedIdrThresholds): Int =
+        sanitizeThreshold(
+            when (codec.lowercase()) {
+                "h265", "hevc" -> thresholds.h265Bytes
+                "vp9" -> thresholds.vp9Bytes
+                else -> thresholds.h264Bytes
+            },
+        )
+
+    fun isSeed(codec: String, frameBytes: Int, thresholds: SeedIdrThresholds): Boolean {
+        val threshold = thresholdBytes(codec, thresholds)
+        return threshold > 0 && frameBytes < threshold
+    }
+}

--- a/app/src/test/java/com/openautolink/app/video/SeedIdrPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/video/SeedIdrPolicyTest.kt
@@ -1,0 +1,58 @@
+package com.openautolink.app.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SeedIdrPolicyTest {
+
+    @Test
+    fun `archive-derived defaults separate startup placeholders from real keyframes`() {
+        val thresholds = SeedIdrThresholds()
+
+        assertEquals(10_000, thresholds.h264Bytes)
+        assertEquals(4_096, thresholds.h265Bytes)
+        assertEquals(0, thresholds.vp9Bytes)
+
+        assertTrue(SeedIdrPolicy.isSeed("h264", 8_176, thresholds))
+        assertFalse(SeedIdrPolicy.isSeed("h264", 10_000, thresholds))
+
+        assertTrue(SeedIdrPolicy.isSeed("h265", 1_075, thresholds))
+        assertTrue(SeedIdrPolicy.isSeed("hevc", 898, thresholds))
+        assertFalse(SeedIdrPolicy.isSeed("h265", 43_026, thresholds))
+
+        assertFalse(SeedIdrPolicy.isSeed("vp9", 1, thresholds))
+    }
+
+    @Test
+    fun `per-codec overrides are independent and nonnegative`() {
+        val thresholds = SeedIdrThresholds(
+            h264Bytes = 12_000,
+            h265Bytes = 2_000,
+            vp9Bytes = 500,
+        )
+
+        assertEquals(12_000, SeedIdrPolicy.thresholdBytes("avc", thresholds))
+        assertEquals(2_000, SeedIdrPolicy.thresholdBytes("hevc", thresholds))
+        assertEquals(500, SeedIdrPolicy.thresholdBytes("vp9", thresholds))
+        assertEquals(12_000, SeedIdrPolicy.thresholdBytes("unknown", thresholds))
+
+        assertEquals("h264", SeedIdrPolicy.codecForAaType(3))
+        assertEquals("vp9", SeedIdrPolicy.codecForAaType(5))
+        assertEquals("h265", SeedIdrPolicy.codecForAaType(7))
+        assertEquals(null, SeedIdrPolicy.codecForAaType(6))
+        assertEquals(
+            500,
+            SeedIdrPolicy.thresholdBytes(
+                SeedIdrPolicy.codecForAaType(5)!!,
+                thresholds,
+            ),
+        )
+
+        assertTrue(SeedIdrPolicy.isSeed("vp9", 499, thresholds))
+        assertFalse(SeedIdrPolicy.isSeed("vp9", 500, thresholds))
+        assertEquals(0, SeedIdrPolicy.sanitizeThreshold(-1))
+        assertEquals(1_000_000, SeedIdrPolicy.sanitizeThreshold(1_500_000))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/video/SeedIdrWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/video/SeedIdrWiringContractTest.kt
@@ -1,0 +1,71 @@
+package com.openautolink.app.video
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SeedIdrWiringContractTest {
+
+    @Test
+    fun `per-codec thresholds are persisted and reachable from Video settings`() {
+        val preferences = source("app/src/main/java/com/openautolink/app/data/AppPreferences.kt")
+        val settingsVm = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
+        val settingsUi = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt")
+
+        listOf("VIDEO_SEED_THRESHOLD_H264", "VIDEO_SEED_THRESHOLD_H265", "VIDEO_SEED_THRESHOLD_VP9")
+            .forEach { assertTrue(preferences.contains(it)) }
+        assertTrue(preferences.contains("val seedIdrThresholds: Flow<SeedIdrThresholds>"))
+        assertTrue(preferences.contains("setVideoSeedThresholdH264"))
+        assertTrue(preferences.contains("setVideoSeedThresholdH265"))
+        assertTrue(preferences.contains("setVideoSeedThresholdVp9"))
+
+        assertTrue(settingsVm.contains("videoSeedThresholdH264"))
+        assertTrue(settingsVm.contains("videoSeedThresholdH265"))
+        assertTrue(settingsVm.contains("videoSeedThresholdVp9"))
+        assertTrue(settingsVm.contains("updateVideoSeedThresholdH264"))
+        assertTrue(settingsVm.contains("updateVideoSeedThresholdH265"))
+        assertTrue(settingsVm.contains("updateVideoSeedThresholdVp9"))
+
+        assertTrue(settingsUi.contains("Seed keyframe thresholds"))
+        assertTrue(settingsUi.contains("seedThreshold_h264"))
+        assertTrue(settingsUi.contains("seedThreshold_h265"))
+        assertTrue(settingsUi.contains("seedThreshold_vp9"))
+    }
+
+    @Test
+    fun `saved thresholds reach every decoder creation path`() {
+        val projectionVm = source("app/src/main/java/com/openautolink/app/ui/projection/ProjectionViewModel.kt")
+        val settingsVm = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
+        val settingsReceiver = source("app/src/main/java/com/openautolink/app/diagnostics/SettingsReceiver.kt")
+        val manager = source("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
+        val decoder = source("app/src/main/java/com/openautolink/app/video/MediaCodecDecoder.kt")
+
+        assertTrue(projectionVm.contains("val seedIdrThresholds = preferences.seedIdrThresholds.first()"))
+        assertTrue(projectionVm.contains("seedIdrThresholds = seedIdrThresholds"))
+        assertTrue(settingsVm.contains("val seedIdrThresholds = preferences.seedIdrThresholds.first()"))
+        assertTrue(settingsVm.contains("seedIdrThresholds = seedIdrThresholds"))
+        assertTrue(settingsReceiver.contains("seedIdrThresholds = prefs.seedIdrThresholds.first()"))
+
+        assertTrue(manager.contains("private var lastSeedIdrThresholds = SeedIdrThresholds()"))
+        assertTrue(manager.contains("seedIdrThresholds = lastSeedIdrThresholds"))
+        assertTrue(manager.contains("seedIdrThresholds = seedIdrThresholds"))
+        assertTrue(decoder.contains("private val seedIdrThresholds: SeedIdrThresholds"))
+        assertTrue(decoder.contains("val newCodec = SeedIdrPolicy.codecForAaType(aaCodecType) ?: return"))
+        assertTrue(decoder.contains("Seed IDR thresholds: h264="))
+        assertTrue(decoder.contains("SeedIdrPolicy.thresholdBytes(detectedCodec, seedIdrThresholds)"))
+        assertFalse(decoder.contains("MIN_REAL_IDR_BYTES"))
+    }
+
+    private fun source(path: String): String = projectFile(path).readText()
+
+    private fun projectFile(path: String): File {
+        var dir = File(System.getProperty("user.dir") ?: error("user.dir unavailable"))
+        repeat(8) {
+            val candidate = File(dir, path)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile ?: return@repeat
+        }
+        error("Cannot locate project file: $path")
+    }
+}


### PR DESCRIPTION
## Summary
- replace the global 50,000-byte seed-keyframe cutoff with configurable per-codec thresholds
- default H.264 to 10,000 bytes, H.265/HEVC to 4,096 bytes, and VP9 to disabled
- expose all three settings under Video and carry them through cold start and every reconnect path
- correct AA codec type 5 mapping to VP9

## Evidence
Clark's Galaxy S20 FE produced legitimate H.265 IDRs from 43,026 to 48,671 bytes. The old cutoff hid video for about 2.5 seconds while video and audio continued. Across 244 archived car logs, real H.264 startup splashes were 8,176/8,974 bytes and true H.265 placeholders were below 4,096 bytes.

## Verification
- 497 unit tests passed; 0 failures/errors/skips
- uncached debug APK build completed, including both native ABIs
- APK v2 signature verified
- DEX contains the new settings and runtime threshold marker
- independent fail-closed review passed after correcting codec type 5 mapping

Runtime verification remains pending: the next car log should show `Seed IDR thresholds: h264=10000 h265=4096 vp9=0`, and Clark's 43-49KB HEVC IDRs should take the real-IDR branch without the 2.5-second wait.
