### PR TITLE
diag(companion): log runtime resource health

### DIFF
--- a/companion/src/main/java/com/openautolink/companion/diagnostics/CompanionRuntimeHealthMonitor.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/CompanionRuntimeHealthMonitor.kt
@@ -1,0 +1,137 @@
+package com.openautolink.companion.diagnostics
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Debug
+import android.os.Process
+import android.os.SystemClock
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Low-frequency process health telemetry for drive logs. Sampling runs on a
+ * child of the service IO scope and never blocks socket/bridge callbacks.
+ */
+class CompanionRuntimeHealthMonitor(
+    context: Context,
+    parentScope: CoroutineScope,
+) {
+    private val appContext = context.applicationContext
+    private val tracker = RuntimeHealthTracker()
+    private val monitorJob = SupervisorJob(parentScope.coroutineContext[Job])
+    private val monitorScope = CoroutineScope(parentScope.coroutineContext + monitorJob)
+    private val lifecycleLock = Any()
+    private var periodicJob: Job? = null
+
+    @Volatile
+    private var stopped = false
+
+    fun start() {
+        synchronized(lifecycleLock) {
+            if (periodicJob?.isActive == true || !monitorJob.isActive) return
+            stopped = false
+            periodicJob = monitorScope.launch {
+                emitSample("service_start")
+                while (isActive) {
+                    delay(SAMPLE_INTERVAL_MS)
+                    emitSample("periodic")
+                }
+            }
+        }
+    }
+
+    /** Queue a pressure-triggered sample without doing file/proc work on the callback thread. */
+    fun record(reason: String) {
+        synchronized(lifecycleLock) {
+            if (stopped || !monitorJob.isActive) return
+            monitorScope.launch { emitSample(reason) }
+        }
+    }
+
+    fun stop() {
+        synchronized(lifecycleLock) {
+            stopped = true
+            monitorJob.cancel()
+            periodicJob = null
+        }
+    }
+
+    private fun emitSample(reason: String) {
+        val report = try {
+            tracker.record(reason, sample())
+        } catch (error: Exception) {
+            synchronized(lifecycleLock) {
+                if (stopped) return
+                CompanionLog.w(
+                    TAG,
+                    "COMPANION HEALTH sampling_failed reason=$reason " +
+                        "error=${error.javaClass.simpleName}",
+                )
+            }
+            return
+        }
+
+        synchronized(lifecycleLock) {
+            if (stopped) return
+            if (report.shouldLogWarning(reason)) {
+                CompanionLog.w(TAG, report.line)
+            } else {
+                CompanionLog.i(TAG, report.line)
+            }
+        }
+    }
+
+    private fun sample(): RuntimeHealthSample {
+        val runtime = Runtime.getRuntime()
+        val processMemory = Debug.MemoryInfo()
+        Debug.getMemoryInfo(processMemory)
+        val systemMemory = ActivityManager.MemoryInfo().also { memoryInfo ->
+            appContext.getSystemService(ActivityManager::class.java).getMemoryInfo(memoryInfo)
+        }
+        val procStatus = readProcStatus()
+        return RuntimeHealthSample(
+            elapsedMs = SystemClock.elapsedRealtime(),
+            processCpuMs = Process.getElapsedCpuTime(),
+            javaUsedBytes = runtime.totalMemory() - runtime.freeMemory(),
+            javaMaxBytes = runtime.maxMemory(),
+            nativeUsedBytes = Debug.getNativeHeapAllocatedSize(),
+            pssKb = processMemory.totalPss.toLong(),
+            rssKb = procStatus.rssKb,
+            threadCount = procStatus.threadCount,
+            openFdCount = File("/proc/self/fd").list()?.size ?: -1,
+            systemAvailBytes = systemMemory.availMem,
+            systemThresholdBytes = systemMemory.threshold,
+            systemLowMemory = systemMemory.lowMemory,
+        )
+    }
+
+    private fun readProcStatus(): ProcStatus {
+        var rssKb = -1L
+        var threadCount = -1
+        File("/proc/self/status").forEachLine { line ->
+            when {
+                line.startsWith("VmRSS:") -> rssKb = firstLong(line)
+                line.startsWith("Threads:") -> threadCount = firstLong(line).toInt()
+            }
+        }
+        return ProcStatus(rssKb = rssKb, threadCount = threadCount)
+    }
+
+    private fun firstLong(line: String): Long =
+        line.substringAfter(':').trim().substringBefore(' ').toLongOrNull() ?: -1L
+
+    private data class ProcStatus(
+        val rssKb: Long,
+        val threadCount: Int,
+    )
+
+    companion object {
+        private const val TAG = "OAL_Health"
+        internal const val SAMPLE_INTERVAL_MS = 60_000L
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/ProcessExitSummary.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/ProcessExitSummary.kt
@@ -25,6 +25,11 @@ internal object ProcessExitSummary {
             "ageMs=$ageMs pssKb=$pssKb rssKb=$rssKb description=$safeDescription"
     }
 
+    fun isMemoryPressureReason(reason: Int): Boolean = reason == 3
+
+    /** Includes Android's broader CPU/wakeup/resource termination category. */
+    fun isResourcePressureReason(reason: Int): Boolean = reason == 3 || reason == 9
+
     private fun reasonName(reason: Int): String = when (reason) {
         0 -> "UNKNOWN"
         1 -> "EXIT_SELF"

--- a/companion/src/main/java/com/openautolink/companion/diagnostics/RuntimeHealthTracker.kt
+++ b/companion/src/main/java/com/openautolink/companion/diagnostics/RuntimeHealthTracker.kt
@@ -1,0 +1,120 @@
+package com.openautolink.companion.diagnostics
+
+import java.util.Locale
+
+/** One low-frequency snapshot of this process's resource use. */
+data class RuntimeHealthSample(
+    val elapsedMs: Long,
+    val processCpuMs: Long,
+    val javaUsedBytes: Long,
+    val javaMaxBytes: Long,
+    val nativeUsedBytes: Long,
+    val pssKb: Long,
+    val rssKb: Long,
+    val threadCount: Int,
+    val openFdCount: Int,
+    val systemAvailBytes: Long,
+    val systemThresholdBytes: Long,
+    val systemLowMemory: Boolean,
+)
+
+data class RuntimeHealthReport(
+    val line: String,
+    val pressure: String,
+    val isPressureWarning: Boolean,
+) {
+    fun shouldLogWarning(reason: String): Boolean =
+        isPressureWarning || reason == "low_memory_callback" || reason.startsWith("trim_memory_")
+}
+
+/**
+ * Formats bounded, identifier-free resource snapshots and derives trends from
+ * the immediately previous sample. The tracker is synchronized because periodic
+ * and trim-memory samples can arrive from different threads.
+ */
+class RuntimeHealthTracker {
+    private var previous: RuntimeHealthSample? = null
+
+    @Synchronized
+    fun record(reason: String, sample: RuntimeHealthSample): RuntimeHealthReport {
+        val prior = previous
+        previous = sample
+
+        val javaPercent = percentage(sample.javaUsedBytes, sample.javaMaxBytes)
+        val pressure = when {
+            sample.systemLowMemory -> "system_low"
+            javaPercent >= HEAP_WARNING_PERCENT &&
+                sample.openFdCount >= FD_WARNING_THRESHOLD -> "heap_fd_high"
+            javaPercent >= HEAP_WARNING_PERCENT -> "heap_high"
+            sample.openFdCount >= FD_WARNING_THRESHOLD -> "fd_high"
+            else -> "normal"
+        }
+        val cpuPercent = prior?.let {
+            val elapsedDelta = sample.elapsedMs - it.elapsedMs
+            val cpuDelta = sample.processCpuMs - it.processCpuMs
+            if (elapsedDelta > 0L && cpuDelta >= 0L) {
+                String.format(Locale.US, "%.1f", cpuDelta * 100.0 / elapsedDelta)
+            } else {
+                "na"
+            }
+        } ?: "na"
+
+        val line = buildString(320) {
+            append("COMPANION HEALTH reason=").append(sanitizeReason(reason))
+            append(" pressure=").append(pressure)
+            append(" elapsedMs=").append(sample.elapsedMs)
+            append(" javaMiB=").append(toMiB(sample.javaUsedBytes))
+                .append('/').append(toMiB(sample.javaMaxBytes))
+            append(" javaPct=").append(javaPercent)
+            append(" nativeMiB=").append(toMiBOrUnavailable(sample.nativeUsedBytes))
+            append(" pssMiB=").append(toKiBMiBOrUnavailable(sample.pssKb))
+            append(" rssMiB=").append(toKiBMiBOrUnavailable(sample.rssKb))
+            append(" threads=").append(countOrUnavailable(sample.threadCount))
+            append(" fds=").append(countOrUnavailable(sample.openFdCount))
+            append(" systemAvailMiB=").append(toMiBOrUnavailable(sample.systemAvailBytes))
+            append(" systemThresholdMiB=").append(toMiBOrUnavailable(sample.systemThresholdBytes))
+            append(" systemLow=").append(sample.systemLowMemory)
+            append(" cpuPct=").append(cpuPercent)
+            append(" dPssKiB=").append(delta(prior?.pssKb, sample.pssKb))
+            append(" dRssKiB=").append(delta(prior?.rssKb, sample.rssKb))
+            append(" dFds=").append(delta(prior?.openFdCount?.toLong(), sample.openFdCount.toLong()))
+        }
+        return RuntimeHealthReport(
+            line = line,
+            pressure = pressure,
+            isPressureWarning = pressure != "normal",
+        )
+    }
+
+    private fun percentage(value: Long, maximum: Long): Int =
+        if (maximum <= 0L) 0 else ((value.coerceAtLeast(0L) * 100L) / maximum).toInt()
+
+    private fun toMiB(bytes: Long): Long = bytes.coerceAtLeast(0L) / BYTES_PER_MIB
+
+    private fun toMiBOrUnavailable(bytes: Long): String =
+        if (bytes < 0L) "na" else (bytes / BYTES_PER_MIB).toString()
+
+    private fun toKiBMiBOrUnavailable(kibibytes: Long): String =
+        if (kibibytes < 0L) "na" else (kibibytes / KIB_PER_MIB).toString()
+
+    private fun countOrUnavailable(count: Int): String = if (count < 0) "na" else count.toString()
+
+    private fun delta(previous: Long?, current: Long): String =
+        previous?.takeIf { it >= 0L }
+            ?.takeIf { current >= 0L }
+            ?.let { (current - it).toString() }
+            ?: "na"
+
+    private fun sanitizeReason(reason: String): String =
+        reason.take(MAX_REASON_LENGTH).map { c ->
+            if (c.isLetterOrDigit() || c == '_' || c == '-') c else '_'
+        }.joinToString("").ifBlank { "unknown" }
+
+    companion object {
+        const val HEAP_WARNING_PERCENT = 80
+        const val FD_WARNING_THRESHOLD = 512
+        private const val MAX_REASON_LENGTH = 48
+        private const val BYTES_PER_MIB = 1024L * 1024L
+        private const val KIB_PER_MIB = 1024L
+    }
+}

--- a/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
+++ b/companion/src/main/java/com/openautolink/companion/service/CompanionService.kt
@@ -16,6 +16,7 @@ import com.openautolink.companion.MainActivity
 import com.openautolink.companion.R
 import com.openautolink.companion.diagnostics.CompanionFileLogger
 import com.openautolink.companion.diagnostics.CompanionLog
+import com.openautolink.companion.diagnostics.CompanionRuntimeHealthMonitor
 import com.openautolink.companion.diagnostics.PhoneWppDiagnostics
 import com.openautolink.companion.diagnostics.PhoneWppStage
 import com.openautolink.companion.diagnostics.ProcessExitSummary
@@ -50,6 +51,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
     private var fileLogger: CompanionFileLogger? = null
     private var fileLogIdleTimeoutJob: kotlinx.coroutines.Job? = null
     private var wppNetworkObserver: WppNetworkObserver? = null
+    private var runtimeHealthMonitor: CompanionRuntimeHealthMonitor? = null
     /** True once a connection has been observed during the current logging session. */
     @Volatile private var loggingSessionEverConnected: Boolean = false
 
@@ -80,6 +82,13 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
         // Do this after persistent logging starts: CompanionFileLogger clears the
         // logcat ring when it begins, so logging first would erase the evidence.
         logPreviousProcessExit()
+        runtimeHealthMonitor = CompanionRuntimeHealthMonitor(
+            applicationContext,
+            serviceScope,
+        ).also { it.start() }
+        if (_fileLoggingActive.value) {
+            runtimeHealthMonitor?.record("logging_start")
+        }
     }
 
     /** Start file logging if the persisted "always log" pref is enabled. */
@@ -198,7 +207,13 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
                 nowMs = System.currentTimeMillis(),
                 description = previous.description,
             )
-            CompanionLog.w(TAG, "Previous companion process exit: $summary")
+            if (ProcessExitSummary.isMemoryPressureReason(previous.reason)) {
+                CompanionLog.w(TAG, "COMPANION MEMORY EXIT $summary")
+            } else if (ProcessExitSummary.isResourcePressureReason(previous.reason)) {
+                CompanionLog.w(TAG, "COMPANION RESOURCE EXIT $summary")
+            } else {
+                CompanionLog.w(TAG, "Previous companion process exit: $summary")
+            }
         } catch (e: Exception) {
             CompanionLog.w(
                 TAG,
@@ -303,6 +318,17 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
 
     // ── Wake lock ──────────────────────────────────────────────────────
 
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        runtimeHealthMonitor?.record("trim_memory_$level")
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onLowMemory() {
+        super.onLowMemory()
+        runtimeHealthMonitor?.record("low_memory_callback")
+    }
+
     private fun acquireWakeLock() {
         // Release existing lock before acquiring a new one to reset the timeout
         releaseWakeLock()
@@ -393,6 +419,8 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             multicastLock?.release()
             CompanionLog.d(TAG, "MulticastLock released")
         }
+        runtimeHealthMonitor?.stop()
+        runtimeHealthMonitor = null
         serviceScope.cancel()
         _instance = null
         super.onDestroy()
@@ -441,6 +469,7 @@ class CompanionService : Service(), TcpAdvertiser.StateListener {
             CompanionLog.fileLogger = logger
             _fileLoggingActive.value = true
             _fileLoggingPath.value = path
+            runtimeHealthMonitor?.record("logging_start")
             loggingSessionEverConnected = _isConnected.value
             CompanionLog.i(TAG, "File logging enabled: $path")
             // 10-minute idle timeout: if the AA proxy never connects while

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/RuntimeHealthIntegrationContractTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/RuntimeHealthIntegrationContractTest.kt
@@ -1,0 +1,79 @@
+package com.openautolink.companion.diagnostics
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuntimeHealthIntegrationContractTest {
+
+    @Test
+    fun `service owns runtime health monitoring for its complete lifecycle`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        val onCreate = source.substringAfter("override fun onCreate()")
+            .substringBefore("override fun onStartCommand")
+        val onDestroy = source.substringAfter("override fun onDestroy()")
+            .substringBefore("private fun joinWppAttempt")
+
+        assertTrue(onCreate.indexOf("logPreviousProcessExit()") >= 0)
+        assertTrue(onCreate.indexOf("runtimeHealthMonitor") > onCreate.indexOf("logPreviousProcessExit()"))
+        assertTrue(onCreate.contains("if (_fileLoggingActive.value)"))
+        assertTrue(onCreate.lastIndexOf("record(\"logging_start\")") > onCreate.indexOf("runtimeHealthMonitor"))
+        assertTrue(source.contains("override fun onTrimMemory(level: Int)"))
+        assertTrue(source.contains("record(\"trim_memory_${'$'}level\")"))
+        assertTrue(source.contains("override fun onLowMemory()"))
+        assertTrue(source.contains("record(\"low_memory_callback\")"))
+        assertTrue(onDestroy.indexOf("runtimeHealthMonitor?.stop()") >= 0)
+        assertTrue(onDestroy.indexOf("runtimeHealthMonitor?.stop()") < onDestroy.indexOf("serviceScope.cancel()"))
+
+        val startLogging = source.substringAfter("fun startFileLogging()")
+            .substringBefore("fun stopFileLogging()")
+        assertTrue(startLogging.indexOf("_fileLoggingActive.value = true") >= 0)
+        assertTrue(
+            startLogging.indexOf("record(\"logging_start\")") >
+                startLogging.indexOf("_fileLoggingActive.value = true"),
+        )
+    }
+
+    @Test
+    fun `sampler is low frequency bounded and avoids thread stack allocation`() {
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/diagnostics/CompanionRuntimeHealthMonitor.kt",
+        ).readText()
+
+        assertTrue(source.contains("SAMPLE_INTERVAL_MS = 60_000L"))
+        assertTrue(source.contains("/proc/self/status"))
+        assertTrue(source.contains("/proc/self/fd"))
+        assertTrue(source.contains("Debug.getMemoryInfo"))
+        assertTrue(source.contains("SupervisorJob"))
+        assertTrue(source.contains("monitorJob.cancel()"))
+        assertTrue(source.contains("catch (error: Exception)"))
+        assertFalse(source.contains("runCatching"))
+        assertFalse(source.contains("Thread.getAllStackTraces"))
+        assertFalse(source.contains("while (true)"))
+    }
+
+    @Test
+    fun `previous low memory and resource exits receive a stable memory marker`() {
+        assertTrue(ProcessExitSummary.isMemoryPressureReason(3))
+        assertFalse(ProcessExitSummary.isMemoryPressureReason(9))
+        assertFalse(ProcessExitSummary.isMemoryPressureReason(4))
+        assertTrue(ProcessExitSummary.isResourcePressureReason(3))
+        assertTrue(ProcessExitSummary.isResourcePressureReason(9))
+        assertFalse(ProcessExitSummary.isResourcePressureReason(4))
+
+        val source = projectFile(
+            "companion/src/main/java/com/openautolink/companion/service/CompanionService.kt",
+        ).readText()
+        assertTrue(source.contains("COMPANION MEMORY EXIT"))
+        assertTrue(source.contains("COMPANION RESOURCE EXIT"))
+    }
+
+    private fun projectFile(path: String): File {
+        val candidates = listOf(File(path), File("../$path"), File("../../$path"))
+        return candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate project file: $path")
+    }
+}

--- a/companion/src/test/java/com/openautolink/companion/diagnostics/RuntimeHealthTrackerTest.kt
+++ b/companion/src/test/java/com/openautolink/companion/diagnostics/RuntimeHealthTrackerTest.kt
@@ -1,0 +1,172 @@
+package com.openautolink.companion.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RuntimeHealthTrackerTest {
+
+    @Test
+    fun `first sample reports absolute process health without invented deltas`() {
+        val tracker = RuntimeHealthTracker()
+
+        val report = tracker.record(
+            reason = "service_start",
+            sample = sample(
+                elapsedMs = 1_000L,
+                cpuMs = 250L,
+                javaUsedBytes = 32L * MIB,
+                javaMaxBytes = 256L * MIB,
+                nativeUsedBytes = 12L * MIB,
+                pssKb = 64L * 1024L,
+                rssKb = 80L * 1024L,
+                threads = 18,
+                fds = 42,
+            ),
+        )
+
+        assertTrue(report.line.startsWith("COMPANION HEALTH reason=service_start pressure=normal"))
+        assertTrue(report.line.contains("javaMiB=32/256 javaPct=12"))
+        assertTrue(report.line.contains("nativeMiB=12 pssMiB=64 rssMiB=80"))
+        assertTrue(report.line.contains("threads=18 fds=42"))
+        assertTrue(report.line.contains("cpuPct=na dPssKiB=na dRssKiB=na dFds=na"))
+        assertFalse(report.isPressureWarning)
+    }
+
+    @Test
+    fun `later sample reports memory fd and process cpu trends`() {
+        val tracker = RuntimeHealthTracker()
+        tracker.record(
+            "service_start",
+            sample(
+                elapsedMs = 1_000L,
+                cpuMs = 100L,
+                pssKb = 40_000L,
+                rssKb = 50_000L,
+                fds = 30,
+            ),
+        )
+
+        val report = tracker.record(
+            "periodic",
+            sample(
+                elapsedMs = 61_000L,
+                cpuMs = 1_300L,
+                pssKb = 43_000L,
+                rssKb = 54_000L,
+                fds = 34,
+            ),
+        )
+
+        assertTrue(report.line.contains("cpuPct=2.0"))
+        assertTrue(report.line.contains("dPssKiB=3000 dRssKiB=4000 dFds=4"))
+    }
+
+    @Test
+    fun `high heap or fd pressure elevates the report to warning`() {
+        val heapPressure = RuntimeHealthTracker().record(
+            "periodic",
+            sample(
+                javaUsedBytes = 220L * MIB,
+                javaMaxBytes = 256L * MIB,
+            ),
+        )
+        val fdPressure = RuntimeHealthTracker().record(
+            "periodic",
+            sample(fds = RuntimeHealthTracker.FD_WARNING_THRESHOLD),
+        )
+
+        assertEquals("heap_high", heapPressure.pressure)
+        assertTrue(heapPressure.isPressureWarning)
+        assertEquals("fd_high", fdPressure.pressure)
+        assertTrue(fdPressure.isPressureWarning)
+    }
+
+    @Test
+    fun `trim callbacks retain their exact level in the stable marker`() {
+        val report = RuntimeHealthTracker().record(
+            reason = "trim_memory_80",
+            sample = sample(),
+        )
+
+        assertTrue(report.line.startsWith("COMPANION HEALTH reason=trim_memory_80"))
+    }
+
+    @Test
+    fun `system memory pressure is explicit in every report`() {
+        val report = RuntimeHealthTracker().record(
+            reason = "periodic",
+            sample = sample(
+                systemAvailBytes = 768L * MIB,
+                systemThresholdBytes = 1024L * MIB,
+                systemLowMemory = true,
+            ),
+        )
+
+        assertEquals("system_low", report.pressure)
+        assertTrue(report.isPressureWarning)
+        assertTrue(report.line.contains("systemAvailMiB=768 systemThresholdMiB=1024 systemLow=true"))
+    }
+
+    @Test
+    fun `unavailable process metrics stay unavailable instead of becoming zero`() {
+        val report = RuntimeHealthTracker().record(
+            reason = "periodic",
+            sample = sample(
+                nativeUsedBytes = -1L,
+                pssKb = -1L,
+                rssKb = -1L,
+                threads = -1,
+                fds = -1,
+                systemAvailBytes = -1L,
+                systemThresholdBytes = -1L,
+            ),
+        )
+
+        assertTrue(report.line.contains("nativeMiB=na pssMiB=na rssMiB=na"))
+        assertTrue(report.line.contains("threads=na fds=na"))
+        assertTrue(report.line.contains("systemAvailMiB=na systemThresholdMiB=na"))
+    }
+
+    @Test
+    fun `normal baselines are info while pressure callbacks are warnings`() {
+        val normal = RuntimeHealthTracker().record("service_start", sample())
+        val trim = RuntimeHealthTracker().record("trim_memory_80", sample())
+
+        assertFalse(normal.shouldLogWarning("service_start"))
+        assertTrue(trim.shouldLogWarning("trim_memory_80"))
+    }
+
+    private fun sample(
+        elapsedMs: Long = 1_000L,
+        cpuMs: Long = 100L,
+        javaUsedBytes: Long = 32L * MIB,
+        javaMaxBytes: Long = 256L * MIB,
+        nativeUsedBytes: Long = 12L * MIB,
+        pssKb: Long = 64L * 1024L,
+        rssKb: Long = 80L * 1024L,
+        threads: Int = 18,
+        fds: Int = 42,
+        systemAvailBytes: Long = 4L * 1024L * MIB,
+        systemThresholdBytes: Long = 512L * MIB,
+        systemLowMemory: Boolean = false,
+    ) = RuntimeHealthSample(
+        elapsedMs = elapsedMs,
+        processCpuMs = cpuMs,
+        javaUsedBytes = javaUsedBytes,
+        javaMaxBytes = javaMaxBytes,
+        nativeUsedBytes = nativeUsedBytes,
+        pssKb = pssKb,
+        rssKb = rssKb,
+        threadCount = threads,
+        openFdCount = fds,
+        systemAvailBytes = systemAvailBytes,
+        systemThresholdBytes = systemThresholdBytes,
+        systemLowMemory = systemLowMemory,
+    )
+
+    companion object {
+        private const val MIB = 1024L * 1024L
+    }
+}


### PR DESCRIPTION
## Summary

- add low-overhead companion process health snapshots every 60 seconds
- record Java/native heap, PSS/RSS, thread count, open FDs, system memory, process CPU, and sample-to-sample growth
- capture immediate service and file-logging baselines plus Android trim/low-memory callbacks
- distinguish prior low-memory and excessive-resource process exits
- keep all sampling off the AA bridge path and owned by a cancellable child scope

This is a logging-only evidence build. It does not change projection, transport, proxy, or recovery behavior.

## Verification

- strict RED/GREEN cycles for tracker and lifecycle contracts
- host Temurin 17 + Android SDK: 84 companion tests, 0 failures/errors/skips
- host `:companion:assembleDebug` and `:companion:compileReleaseKotlin` with `--rerun-tasks`: successful
- current debug DEX contains `COMPANION HEALTH`, `COMPANION MEMORY EXIT`, `COMPANION RESOURCE EXIT`, `logging_start`, and `trim_memory_`
- prior `v0.1.489` companion APK contains none of those markers (negative control)
- lint still reports two pre-existing `MissingPermission` errors in unchanged `TcpAdvertiser.kt` and `WifiJobService.kt`; this diff introduces no lint finding

## Runtime proof still required

A drive log must contain `COMPANION HEALTH reason=logging_start` followed by periodic samples. The sample trend will provide evidence for or against retained-memory, FD, thread, or CPU growth. Build and artifact containment do not prove runtime stability.
