### PR TITLE
fix(cluster): restore required relay action strip

### DIFF
--- a/app/src/main/java/com/openautolink/app/OalApplication.kt
+++ b/app/src/main/java/com/openautolink/app/OalApplication.kt
@@ -33,6 +33,10 @@ class OalApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // Install before any session infrastructure can launch AndroidX CarAppActivity.
+        // onActivityPreCreated applies zero-alpha/non-focusable protection before
+        // BaseCarAppActivity creates the Templates Host surface.
+        com.openautolink.app.cluster.ClusterBootstrapWindowProtector.install(this)
         loadPreviousCrash()
         loadPreviousNativeCrash()
         installCrashHandler()

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterBindingRegistry.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterBindingRegistry.kt
@@ -29,6 +29,7 @@ internal class ClusterBindingRegistry {
     private var activeGeneration: Long? = null
     private val liveSessionIds = linkedSetOf<Long>()
     private var primarySessionId: Long? = null
+    private var readySessionId: Long? = null
 
     @Synchronized
     fun openManager(): ManagerLease {
@@ -36,6 +37,7 @@ internal class ClusterBindingRegistry {
         activeGeneration = generation
         liveSessionIds.clear()
         primarySessionId = null
+        readySessionId = null
         return ManagerLease(generation)
     }
 
@@ -45,6 +47,7 @@ internal class ClusterBindingRegistry {
         activeGeneration = null
         liveSessionIds.clear()
         primarySessionId = null
+        readySessionId = null
         return true
     }
 
@@ -63,6 +66,19 @@ internal class ClusterBindingRegistry {
             return false
         }
         primarySessionId = lease.sessionId
+        readySessionId = null
+        return true
+    }
+
+    @Synchronized
+    fun markReady(lease: SessionLease): Boolean {
+        if (activeGeneration != lease.generation ||
+            primarySessionId != lease.sessionId ||
+            lease.sessionId !in liveSessionIds
+        ) {
+            return false
+        }
+        readySessionId = lease.sessionId
         return true
     }
 
@@ -71,6 +87,7 @@ internal class ClusterBindingRegistry {
         if (activeGeneration != lease.generation) return
         liveSessionIds -= lease.sessionId
         if (primarySessionId == lease.sessionId) primarySessionId = null
+        if (readySessionId == lease.sessionId) readySessionId = null
     }
 
     @Synchronized
@@ -80,6 +97,12 @@ internal class ClusterBindingRegistry {
     @Synchronized
     fun hasLiveSession(lease: ManagerLease): Boolean =
         activeGeneration == lease.generation && primarySessionId in liveSessionIds
+
+    @Synchronized
+    fun hasReadySession(lease: ManagerLease): Boolean =
+        activeGeneration == lease.generation &&
+            readySessionId == primarySessionId &&
+            readySessionId in liveSessionIds
 
     @Synchronized
     fun isSessionCurrent(lease: SessionLease): Boolean =
@@ -151,6 +174,9 @@ internal object ClusterBindingState {
     fun markPrimary(lease: ClusterBindingRegistry.SessionLease): Boolean =
         registry.markPrimary(lease)
 
+    fun markReady(lease: ClusterBindingRegistry.SessionLease): Boolean =
+        registry.markReady(lease)
+
     fun unregisterSession(lease: ClusterBindingRegistry.SessionLease) =
         registry.unregisterSession(lease)
 
@@ -159,6 +185,9 @@ internal object ClusterBindingState {
 
     fun hasLiveSession(lease: ClusterBindingRegistry.ManagerLease): Boolean =
         registry.hasLiveSession(lease)
+
+    fun hasReadySession(lease: ClusterBindingRegistry.ManagerLease): Boolean =
+        registry.hasReadySession(lease)
 
     fun isSessionCurrent(lease: ClusterBindingRegistry.SessionLease): Boolean =
         registry.isSessionCurrent(lease)

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapTaskState.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapTaskState.kt
@@ -1,0 +1,47 @@
+package com.openautolink.app.cluster
+
+/** Generation-owned state for the invisible CarAppActivity task. */
+internal class ClusterBootstrapTaskState<T : Any> {
+
+    data class Target<T : Any>(
+        val generation: Long,
+        val owner: T,
+    )
+
+    private var generation = Long.MIN_VALUE
+    private var owner: T? = null
+    private var backgroundRequestedGeneration = Long.MIN_VALUE
+
+    @Synchronized
+    fun protect(generation: Long, owner: T) {
+        if (generation < this.generation) return
+        if (generation > this.generation) {
+            backgroundRequestedGeneration = Long.MIN_VALUE
+        }
+        this.generation = generation
+        this.owner = owner
+    }
+
+    @Synchronized
+    fun requestBackground(generation: Long): Target<T>? {
+        if (this.generation != generation) return null
+        backgroundRequestedGeneration = generation
+        return owner?.let { Target(generation, it) }
+    }
+
+    @Synchronized
+    fun pendingTargetFor(owner: T): Target<T>? {
+        if (this.owner !== owner || backgroundRequestedGeneration != generation) return null
+        return Target(generation, owner)
+    }
+
+    @Synchronized
+    fun isCurrent(target: Target<T>): Boolean =
+        generation == target.generation && owner === target.owner &&
+            backgroundRequestedGeneration == target.generation
+
+    @Synchronized
+    fun destroy(owner: T) {
+        if (this.owner === owner) this.owner = null
+    }
+}

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapWindowProtector.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapWindowProtector.kt
@@ -1,0 +1,96 @@
+package com.openautolink.app.cluster
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import android.view.WindowManager
+import com.openautolink.app.diagnostics.DiagnosticLog
+
+/**
+ * Makes AndroidX's main-display bootstrap activity non-visible and non-interactive
+ * before [androidx.car.app.activity.BaseCarAppActivity] creates its host surface.
+ * Once the cluster session is usable, its own task is moved behind the existing
+ * foreground task without destroying the Activity or its renderer connection.
+ */
+internal object ClusterBootstrapWindowProtector : Application.ActivityLifecycleCallbacks {
+
+    private const val CAR_APP_ACTIVITY = "androidx.car.app.activity.CarAppActivity"
+    private val taskState = ClusterBootstrapTaskState<Activity>()
+
+    fun install(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (activity.javaClass.name != CAR_APP_ACTIVITY) return
+
+        val generation = activity.intent.getLongExtra(
+            CLUSTER_BINDING_GENERATION_EXTRA,
+            Long.MIN_VALUE,
+        )
+        taskState.protect(generation, activity)
+
+        val window = activity.window
+        window.addFlags(
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+        )
+        window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+        val attributes = window.attributes
+        attributes.alpha = 0f
+        window.attributes = attributes
+        DiagnosticLog.i(
+            "cluster",
+            "Cluster bootstrap window protected generation=$generation alpha=0 focusable=false touchable=false",
+        )
+    }
+
+    fun moveTaskToBack(generation: Long) {
+        val target = taskState.requestBackground(generation)
+        if (target == null) {
+            DiagnosticLog.w(
+                "cluster",
+                "Cluster bootstrap task background outcome=stale-or-missing generation=$generation",
+            )
+            return
+        }
+        postMoveTaskToBack(target)
+    }
+
+    private fun postMoveTaskToBack(target: ClusterBootstrapTaskState.Target<Activity>) {
+        val activity = target.owner
+        activity.window.decorView.post {
+            if (!taskState.isCurrent(target) || activity.isFinishing || activity.isDestroyed) {
+                return@post
+            }
+
+            try {
+                val moved = activity.moveTaskToBack(true)
+                DiagnosticLog.i(
+                    "cluster",
+                    "Cluster bootstrap task background outcome=${if (moved) "moved" else "rejected"} generation=${target.generation}",
+                )
+            } catch (e: Exception) {
+                DiagnosticLog.w(
+                    "cluster",
+                    "Cluster bootstrap task background outcome=failed generation=${target.generation} error=${e.message}",
+                )
+            }
+        }
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+    override fun onActivityStarted(activity: Activity) = Unit
+
+    override fun onActivityResumed(activity: Activity) {
+        taskState.pendingTargetFor(activity)?.let { postMoveTaskToBack(it) }
+    }
+
+    override fun onActivityPaused(activity: Activity) = Unit
+    override fun onActivityStopped(activity: Activity) = Unit
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) {
+        taskState.destroy(activity)
+    }
+}

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
@@ -12,8 +12,6 @@ import androidx.car.app.model.Template
 import androidx.car.app.navigation.NavigationManager
 import androidx.car.app.navigation.NavigationManagerCallback
 import androidx.car.app.navigation.model.Destination
-import androidx.car.app.navigation.model.MessageInfo
-import androidx.car.app.navigation.model.NavigationTemplate
 import androidx.car.app.navigation.model.Step
 import androidx.car.app.navigation.model.TravelEstimate
 import androidx.car.app.navigation.model.Trip
@@ -395,11 +393,6 @@ class ClusterMainSession : Session() {
     }
 
     private class RelayScreen(carContext: CarContext) : Screen(carContext) {
-        override fun onGetTemplate(): Template =
-            NavigationTemplate.Builder()
-                .setNavigationInfo(
-                    MessageInfo.Builder("\u200B").build()
-                )
-                .build()
+        override fun onGetTemplate(): Template = ClusterRelayTemplateFactory.build()
     }
 }

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt
@@ -7,8 +7,6 @@ import com.openautolink.app.diagnostics.DiagnosticLog
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.Session
-import androidx.car.app.model.Action
-import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.CarText
 import androidx.car.app.model.Template
 import androidx.car.app.navigation.NavigationManager
@@ -39,7 +37,10 @@ import java.time.ZonedDateTime
  *
  * GM has an internal cluster manager (OnStarTurnByTurnManager) that consumes
  * NavigationManager data and renders turn-by-turn on the instrument cluster.
- * The [RelayScreen] is never visible — GM's system ignores it.
+ * [RelayScreen] exists only to satisfy the main-display host contract while the
+ * bootstrap activity is transparent. Once the primary session owns a
+ * [NavigationManager], the activity stays alive as the renderer owner but its
+ * task is moved behind the existing foreground task.
  *
  * Primary/secondary multiplexing handles Templates Host creating multiple sessions:
  * - AAOS emulator: creates DISPLAY_TYPE_MAIN + DISPLAY_TYPE_CLUSTER (two sessions)
@@ -69,13 +70,16 @@ class ClusterMainSession : Session() {
          */
         fun endActiveNavigation() {
             val session = primarySessions.currentOwner() ?: return
-            try {
-                session.navigationManager?.navigationEnded()
-                session.isNavigating = false
-                Log.i(TAG, "navigationEnded() forced on user exit")
-                DiagnosticLog.i("cluster", "navigationEnded() forced on user exit")
-            } catch (e: Exception) {
-                Log.w(TAG, "endActiveNavigation() failed: ${e.message}")
+            if (session.navigationLifecycle.onRouteTerminated() ==
+                ClusterNavigationLifecyclePolicy.Action.END
+            ) {
+                try {
+                    session.navigationManager?.navigationEnded()
+                    Log.i(TAG, "navigationEnded() forced on user exit")
+                    DiagnosticLog.i("cluster", "navigationEnded() forced on user exit")
+                } catch (e: Exception) {
+                    Log.w(TAG, "endActiveNavigation() failed: ${e.message}")
+                }
             }
         }
 
@@ -88,8 +92,7 @@ class ClusterMainSession : Session() {
 
     private var navigationManager: NavigationManager? = null
     private var scope: CoroutineScope? = null
-    private var isNavigating = false
-    private var hasSeenActiveNav = false
+    private val navigationLifecycle = ClusterNavigationLifecyclePolicy()
     private var arrivalTimeoutJob: Job? = null
     private var bindingLease: ClusterBindingRegistry.SessionLease? = null
     private var tripOutcomeLogged = false
@@ -164,32 +167,19 @@ class ClusterMainSession : Session() {
             override fun onStopNavigation() {
                 if (!isCurrentPrimary()) return
                 Log.i(TAG, "onStopNavigation callback from Templates Host")
-                // Do NOT set isNavigating = false — GM's Templates Host may call this
-                // spuriously. We only end navigation on explicit nav_state_clear or
-                // arrival timeout. Re-calling navigationStarted() to re-assert nav.
-                try {
-                    navigationManager?.navigationStarted()
-                    Log.i(TAG, "Re-asserted navigationStarted() after onStopNavigation")
-                } catch (e: Exception) {
-                    Log.w(TAG, "Failed to re-assert navigationStarted(): ${e.message}")
-                    isNavigating = false
-                }
+                arrivalTimeoutJob?.cancel()
+                arrivalTimeoutJob = null
+                navigationLifecycle.onHostStop()
+                DiagnosticLog.i(
+                    "cluster",
+                    "Host stopped navigation; suppressing current route until clear",
+                )
             }
 
             override fun onAutoDriveEnabled() {
                 Log.d(TAG, "Auto drive enabled")
             }
         })
-
-        // Call navigationStarted() IMMEDIATELY — this is the trigger that causes
-        // Templates Host to create ClusterTurnCardActivity on the cluster display.
-        try {
-            navigationManager?.navigationStarted()
-            isNavigating = true
-            Log.i(TAG, "navigationStarted() called")
-        } catch (e: Exception) {
-            Log.w(TAG, "navigationStarted() failed: ${e.message}")
-        }
 
         val sessionScope = CoroutineScope(Dispatchers.Main)
         scope = sessionScope
@@ -198,18 +188,34 @@ class ClusterMainSession : Session() {
             collectNavigationState()
         }
 
+        if (navigationManager != null) {
+            if (ClusterBindingState.markReady(lease)) {
+                DiagnosticLog.i(
+                    "cluster",
+                    "Cluster session ready generation=${lease.generation}; collector and NavigationManager callback installed",
+                )
+                ClusterBootstrapWindowProtector.moveTaskToBack(lease.generation)
+            } else {
+                DiagnosticLog.w(
+                    "cluster",
+                    "Cluster session ready rejected for retired generation=${lease.generation}",
+                )
+            }
+        }
+
         return RelayScreen(carContext)
     }
 
     private fun retirePrimary(reason: String, endNavigation: Boolean) {
-        if (endNavigation && isNavigating) {
+        if (endNavigation && navigationLifecycle.onRouteTerminated() ==
+            ClusterNavigationLifecyclePolicy.Action.END
+        ) {
             try {
                 navigationManager?.navigationEnded()
             } catch (e: Exception) {
                 Log.e(TAG, "navigationEnded() failed during $reason: ${e.message}")
             }
         }
-        isNavigating = false
         arrivalTimeoutJob?.cancel()
         arrivalTimeoutJob = null
         scope?.cancel()
@@ -244,17 +250,28 @@ class ClusterMainSession : Session() {
         val navManager = navigationManager ?: return
 
         if (maneuver != null) {
-            hasSeenActiveNav = true
-
-            if (!isNavigating) {
-                try {
-                    navManager.navigationStarted()
-                    isNavigating = true
-                    Log.i(TAG, "navigationStarted() (re-start)")
-                } catch (e: Exception) {
-                    Log.e(TAG, "navigationStarted() failed: ${e.message}")
-                    return
+            when (navigationLifecycle.onRouteAvailable()) {
+                ClusterNavigationLifecyclePolicy.Action.NONE -> return
+                ClusterNavigationLifecyclePolicy.Action.START_AND_UPDATE -> {
+                    try {
+                        navManager.navigationStarted()
+                        Log.i(TAG, "navigationStarted() — first maneuver in route epoch")
+                        DiagnosticLog.i(
+                            "cluster",
+                            "Navigation ownership outcome=started generation=${bindingLease?.generation}",
+                        )
+                    } catch (e: Exception) {
+                        navigationLifecycle.onNavigationStartFailed()
+                        Log.e(TAG, "navigationStarted() failed: ${e.message}")
+                        DiagnosticLog.e(
+                            "cluster",
+                            "Navigation ownership outcome=start-failed generation=${bindingLease?.generation} error=${e.message}",
+                        )
+                        return
+                    }
                 }
+                ClusterNavigationLifecyclePolicy.Action.UPDATE -> Unit
+                ClusterNavigationLifecyclePolicy.Action.END -> return
             }
 
             try {
@@ -283,10 +300,11 @@ class ClusterMainSession : Session() {
                 if (arrivalTimeoutJob?.isActive != true) {
                     arrivalTimeoutJob = scope?.launch {
                         delay(ARRIVAL_TIMEOUT_MS)
-                        if (isNavigating) {
+                        if (navigationLifecycle.onRouteTerminated() ==
+                            ClusterNavigationLifecyclePolicy.Action.END
+                        ) {
                             Log.i(TAG, "Arrival timeout — ending navigation")
                             try { navManager.navigationEnded() } catch (_: Exception) {}
-                            isNavigating = false
                         }
                     }
                 }
@@ -294,16 +312,19 @@ class ClusterMainSession : Session() {
                 arrivalTimeoutJob?.cancel()
                 arrivalTimeoutJob = null
             }
-        } else if (isNavigating && hasSeenActiveNav) {
+        } else {
             arrivalTimeoutJob?.cancel()
             arrivalTimeoutJob = null
-            Log.i(TAG, "navigationEnded() — nav cleared")
-            try {
-                navManager.navigationEnded()
-            } catch (e: Exception) {
-                Log.e(TAG, "navigationEnded() failed: ${e.message}")
+            if (navigationLifecycle.onRouteCleared() ==
+                ClusterNavigationLifecyclePolicy.Action.END
+            ) {
+                Log.i(TAG, "navigationEnded() — nav cleared")
+                try {
+                    navManager.navigationEnded()
+                } catch (e: Exception) {
+                    Log.e(TAG, "navigationEnded() failed: ${e.message}")
+                }
             }
-            isNavigating = false
         }
     }
 
@@ -377,12 +398,7 @@ class ClusterMainSession : Session() {
         override fun onGetTemplate(): Template =
             NavigationTemplate.Builder()
                 .setNavigationInfo(
-                    MessageInfo.Builder("OpenAutoLink — Cluster Navigation")
-                        .setText("Cluster navigation service active.")
-                        .build()
-                )
-                .setActionStrip(
-                    ActionStrip.Builder().addAction(Action.APP_ICON).build()
+                    MessageInfo.Builder("\u200B").build()
                 )
                 .build()
     }

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt
@@ -28,7 +28,6 @@ class ClusterManager(private val context: Context) {
         private const val CAR_APP_ACTIVITY_CLASS = "androidx.car.app.activity.CarAppActivity"
         private const val RELAUNCH_DELAY_MS = 2000L
         private const val RETRY_DELAY_MS = 4000L
-        private const val BRING_BACK_DELAY_MS = 1000L
         private const val PERMISSIONS_RETRY_DELAY_MS = 3000L
         private const val HEALTH_CHECK_DELAY_MS = 5000L
         private const val MAX_HEALTH_RETRIES = 3
@@ -92,7 +91,8 @@ class ClusterManager(private val context: Context) {
      * Guarded by this manager's generation-owned binding lease. Sessions from an
      * older manager can never block a fresh launch.
      *
-     * Brings the main activity back to front after binding completes (1s delay).
+     * The process-scope lifecycle protector keeps this required renderer owner
+     * transparent and non-interactive for the lifetime of the cluster session.
      */
     fun launchClusterBinding() {
         synchronized(ClusterBindingLifecycle.lock) {
@@ -140,29 +140,8 @@ class ClusterManager(private val context: Context) {
                 Log.i(TAG, "Launched CarAppActivity for Templates Host binding")
                 DiagnosticLog.i("cluster", "Launched CarAppActivity for Templates Host binding")
 
-                // Schedule health check — if session doesn't come alive, retry
+                // Schedule health check — if session doesn't become usable, retry.
                 scheduleHealthCheck(launchLease)
-
-                // Bring main activity back — binding is IPC-based, doesn't need foreground
-                handler.postDelayed({
-                    synchronized(ClusterBindingLifecycle.lock) {
-                        if (!enabled || !ClusterBindingState.isManagerCurrent(launchLease)) {
-                            return@synchronized
-                        }
-                        try {
-                            val mainActivity = Class.forName("${context.packageName}.MainActivity")
-                            val bringBack = Intent(context, mainActivity).apply {
-                                flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or
-                                        Intent.FLAG_ACTIVITY_NEW_TASK or
-                                        Intent.FLAG_ACTIVITY_NO_ANIMATION
-                            }
-                            context.startActivity(bringBack)
-                            Log.i(TAG, "Brought main activity back to foreground")
-                        } catch (e: Exception) {
-                            Log.w(TAG, "Failed to bring main activity back: ${e.message}")
-                        }
-                    }
-                }, BRING_BACK_DELAY_MS)
             } catch (e: Exception) {
                 // Cluster service blocked or not available — graceful degradation
                 Log.w(TAG, "Failed to launch CarAppActivity: ${e.message}")
@@ -172,9 +151,10 @@ class ClusterManager(private val context: Context) {
         }
     }
 
+
     /**
      * Schedule a health check after launching CarAppActivity.
-     * If the cluster session hasn't come alive after HEALTH_CHECK_DELAY_MS,
+     * If the cluster session isn't ready after [HEALTH_CHECK_DELAY_MS],
      * tear down the stale task and retry the full binding chain.
      */
     private fun scheduleHealthCheck(launchLease: ClusterBindingRegistry.ManagerLease) {
@@ -182,8 +162,8 @@ class ClusterManager(private val context: Context) {
             synchronized(ClusterBindingLifecycle.lock) {
                 if (!enabled) return@synchronized
                 if (!ClusterBindingState.isManagerCurrent(launchLease)) return@synchronized
-                if (ClusterBindingState.hasLiveSession(launchLease)) {
-                    Log.i(TAG, "Health check: cluster session alive")
+                if (ClusterBindingState.hasReadySession(launchLease)) {
+                    Log.i(TAG, "Health check: cluster session ready")
                     healthRetryCount = 0
                     relaunching = false
                     return@synchronized
@@ -196,8 +176,8 @@ class ClusterManager(private val context: Context) {
                     relaunching = false
                     return@synchronized
                 }
-                Log.w(TAG, "Health check: session not alive — retry $healthRetryCount/$MAX_HEALTH_RETRIES")
-                DiagnosticLog.w("cluster", "Cluster session not alive — retrying ($healthRetryCount/$MAX_HEALTH_RETRIES)")
+                Log.w(TAG, "Health check: session not ready — retry $healthRetryCount/$MAX_HEALTH_RETRIES")
+                DiagnosticLog.w("cluster", "Cluster session not ready — retrying ($healthRetryCount/$MAX_HEALTH_RETRIES)")
                 restartClusterBinding()
             }
         }, HEALTH_CHECK_DELAY_MS)
@@ -242,7 +222,7 @@ class ClusterManager(private val context: Context) {
     fun ensureAlive() {
         synchronized(ClusterBindingLifecycle.lock) {
             if (!enabled) return@synchronized
-            if (ClusterBindingState.hasLiveSession(bindingLease)) return@synchronized
+            if (ClusterBindingState.hasReadySession(bindingLease)) return@synchronized
             if (relaunching) return@synchronized
 
             Log.w(TAG, "Cluster session not alive — relaunching binding")
@@ -294,7 +274,7 @@ class ClusterManager(private val context: Context) {
             task.finishAndRemoveTask()
             DiagnosticLog.i(
                 "cluster",
-                "Cluster task teardown outcome=finished reason=$reason generation=${lease.generation}",
+                "Cluster task teardown outcome=requested reason=$reason generation=${lease.generation}",
             )
         } catch (e: Exception) {
             Log.w(TAG, "Failed to finish CarAppActivity task: ${e.message}")

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationLifecyclePolicy.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterNavigationLifecyclePolicy.kt
@@ -1,0 +1,57 @@
+package com.openautolink.app.cluster
+
+/** Pure state machine for ownership of the host's single active navigation slot. */
+internal class ClusterNavigationLifecyclePolicy {
+
+    enum class Action {
+        NONE,
+        START_AND_UPDATE,
+        UPDATE,
+        END,
+    }
+
+    private var state = State.IDLE
+
+    fun onRouteAvailable(): Action = when (state) {
+        State.IDLE -> {
+            state = State.NAVIGATING
+            Action.START_AND_UPDATE
+        }
+        State.NAVIGATING -> Action.UPDATE
+        State.SUPPRESSED_UNTIL_CLEAR -> Action.NONE
+    }
+
+    fun onRouteCleared(): Action = when (state) {
+        State.IDLE -> Action.NONE
+        State.NAVIGATING -> {
+            state = State.IDLE
+            Action.END
+        }
+        State.SUPPRESSED_UNTIL_CLEAR -> {
+            state = State.IDLE
+            Action.NONE
+        }
+    }
+
+    fun onHostStop() {
+        if (state == State.NAVIGATING) state = State.SUPPRESSED_UNTIL_CLEAR
+    }
+
+    fun onNavigationStartFailed() {
+        if (state == State.NAVIGATING) state = State.IDLE
+    }
+
+    fun onRouteTerminated(): Action = when (state) {
+        State.NAVIGATING -> {
+            state = State.SUPPRESSED_UNTIL_CLEAR
+            Action.END
+        }
+        State.IDLE, State.SUPPRESSED_UNTIL_CLEAR -> Action.NONE
+    }
+
+    private enum class State {
+        IDLE,
+        NAVIGATING,
+        SUPPRESSED_UNTIL_CLEAR,
+    }
+}

--- a/app/src/main/java/com/openautolink/app/cluster/ClusterRelayTemplateFactory.kt
+++ b/app/src/main/java/com/openautolink/app/cluster/ClusterRelayTemplateFactory.kt
@@ -1,0 +1,19 @@
+package com.openautolink.app.cluster
+
+import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
+import androidx.car.app.navigation.model.MessageInfo
+import androidx.car.app.navigation.model.NavigationTemplate
+
+/** Builds the invisible relay template while preserving host-required structure. */
+internal object ClusterRelayTemplateFactory {
+    fun build(): NavigationTemplate =
+        NavigationTemplate.Builder()
+            .setNavigationInfo(MessageInfo.Builder("\u200B").build())
+            .setActionStrip(
+                ActionStrip.Builder()
+                    .addAction(Action.APP_ICON)
+                    .build(),
+            )
+            .build()
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterBindingRegistryTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterBindingRegistryTest.kt
@@ -79,6 +79,33 @@ class ClusterBindingRegistryTest {
     }
 
     @Test
+    fun onlyCurrentPrimaryCanMarkBindingReady() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val primary = registry.registerSession()!!
+        val secondary = registry.registerSession()!!
+        registry.markPrimary(primary)
+
+        assertFalse(registry.markReady(secondary))
+        assertFalse(registry.hasReadySession(manager))
+        assertTrue(registry.markReady(primary))
+        assertTrue(registry.hasReadySession(manager))
+    }
+
+    @Test
+    fun removingReadyPrimaryClearsBindingReadiness() {
+        val registry = ClusterBindingRegistry()
+        val manager = registry.openManager()
+        val primary = registry.registerSession()!!
+        registry.markPrimary(primary)
+        registry.markReady(primary)
+
+        registry.unregisterSession(primary)
+
+        assertFalse(registry.hasReadySession(manager))
+    }
+
+    @Test
     fun lifecycleLockSerializesSessionInitializationAgainstRetirement() {
         val registry = ClusterBindingRegistry()
         val manager = registry.openManager()

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapTaskStateTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapTaskStateTest.kt
@@ -1,0 +1,72 @@
+package com.openautolink.app.cluster
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClusterBootstrapTaskStateTest {
+
+    @Test
+    fun sameGenerationReplacementPreservesPendingBackgroundRequest() {
+        val state = ClusterBootstrapTaskState<Any>()
+        val first = Any()
+        val replacement = Any()
+        state.protect(7, first)
+        val staleTarget = state.requestBackground(7)!!
+
+        state.protect(7, replacement)
+
+        val replacementTarget = state.pendingTargetFor(replacement)
+        assertNotNull(replacementTarget)
+        assertSame(replacement, replacementTarget!!.owner)
+        assertFalse(state.isCurrent(staleTarget))
+        assertSame(replacement, state.requestBackground(7)!!.owner)
+    }
+
+    @Test
+    fun replacementGenerationDropsOldBackgroundRequest() {
+        val state = ClusterBootstrapTaskState<Any>()
+        val first = Any()
+        val replacement = Any()
+        state.protect(7, first)
+        state.requestBackground(7)
+
+        state.protect(8, replacement)
+
+        assertNull(state.pendingTargetFor(replacement))
+        assertNull(state.requestBackground(7))
+    }
+
+    @Test
+    fun staleGenerationCannotReplaceCurrentOwnerOrClearPendingRequest() {
+        val state = ClusterBootstrapTaskState<Any>()
+        val current = Any()
+        val stale = Any()
+        state.protect(8, current)
+        val currentTarget = state.requestBackground(8)!!
+
+        state.protect(7, stale)
+
+        assertSame(current, state.pendingTargetFor(current)!!.owner)
+        assertTrue(state.isCurrent(currentTarget))
+        assertNull(state.pendingTargetFor(stale))
+        assertNull(state.requestBackground(7))
+    }
+
+    @Test
+    fun destroyedActivityCanBeRecreatedWithinPendingGeneration() {
+        val state = ClusterBootstrapTaskState<Any>()
+        val first = Any()
+        val replacement = Any()
+        state.protect(7, first)
+        state.requestBackground(7)
+        state.destroy(first)
+
+        state.protect(7, replacement)
+
+        assertNotNull(state.pendingTargetFor(replacement))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapWindowWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterBootstrapWindowWiringContractTest.kt
@@ -1,0 +1,67 @@
+package com.openautolink.app.cluster
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClusterBootstrapWindowWiringContractTest {
+
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+        return File(requireNotNull(root), relative).readText()
+    }
+
+    @Test
+    fun bootstrapWindowIsProtectedBeforeCarAppActivityCreatesItsSurface() {
+        val application = projectFile(
+            "app/src/main/java/com/openautolink/app/OalApplication.kt",
+        )
+        val protector = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapWindowProtector.kt",
+        )
+        val taskState = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterBootstrapTaskState.kt",
+        )
+
+        val install = application.indexOf("ClusterBootstrapWindowProtector.install(this)")
+        val sessionInfrastructure = application.indexOf("IgnitionMonitor.start(this)")
+        assertTrue("protector must install before session infrastructure", install in 0 until sessionInfrastructure)
+        assertTrue(protector.contains("private const val CAR_APP_ACTIVITY = \"androidx.car.app.activity.CarAppActivity\""))
+        assertTrue(protector.contains("if (activity.javaClass.name != CAR_APP_ACTIVITY) return"))
+        assertTrue(protector.contains("onActivityPreCreated"))
+        assertTrue(protector.contains("WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE"))
+        assertTrue(protector.contains("WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE"))
+        assertTrue(protector.contains("attributes.alpha = 0f"))
+        assertTrue(protector.contains("Cluster bootstrap window protected"))
+        assertTrue(protector.contains("window.decorView.post"))
+        assertTrue(protector.contains("ClusterBootstrapTaskState<Activity>()"))
+        assertTrue(protector.contains("moveTaskToBack(true)"))
+        assertTrue(protector.contains("Cluster bootstrap task background outcome="))
+        assertTrue(taskState.contains("if (this.generation != generation)"))
+        assertTrue(taskState.contains("backgroundRequestedGeneration == target.generation"))
+    }
+
+    @Test
+    fun readyPrimaryStaysInvisibleWithoutForegroundBounceOrUnsafeTaskRetirement() {
+        val manager = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt",
+        )
+        val session = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
+        )
+
+        val collectorStart = session.indexOf("sessionScope.launch")
+        val ready = session.indexOf("ClusterBindingState.markReady(lease)")
+        val background = session.indexOf("ClusterBootstrapWindowProtector.moveTaskToBack(lease.generation)")
+        assertTrue("collector must be installed before readiness", collectorStart in 0 until ready)
+        assertTrue("task must move behind the foreground only after readiness", ready in 0 until background)
+        assertTrue(manager.contains("ClusterBindingState.hasReadySession(launchLease)"))
+        assertFalse(manager.contains("scheduleBootstrapRetirement"))
+        assertFalse(manager.contains("finishClusterTask(launchLease, \"session-ready\")"))
+        assertFalse(manager.contains("Brought main activity back to foreground"))
+        assertFalse(manager.contains("Intent.FLAG_ACTIVITY_REORDER_TO_FRONT"))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterMainSessionWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterMainSessionWiringContractTest.kt
@@ -1,0 +1,44 @@
+package com.openautolink.app.cluster
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClusterMainSessionWiringContractTest {
+
+    private fun projectFile(relative: String): String {
+        val start = File(requireNotNull(System.getProperty("user.dir")))
+        val root = generateSequence(start) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+        return File(requireNotNull(root), relative).readText()
+    }
+
+    @Test
+    fun navigationOwnershipIsRouteGatedAndHonorsHostStop() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
+        )
+        val stopStart = source.indexOf("override fun onStopNavigation()")
+        val stopEnd = source.indexOf("override fun onAutoDriveEnabled()", stopStart)
+        assertTrue("onStopNavigation callback missing", stopStart >= 0 && stopEnd > stopStart)
+        val stopCallback = source.substring(stopStart, stopEnd)
+
+        assertTrue(source.contains("ClusterNavigationLifecyclePolicy()"))
+        assertTrue(source.contains("navigationLifecycle.onRouteAvailable()"))
+        assertTrue(source.contains("navigationLifecycle.onRouteCleared()"))
+        assertTrue(stopCallback.contains("navigationLifecycle.onHostStop()"))
+        assertFalse(stopCallback.contains("navigationStarted()"))
+        assertFalse(source.contains("Call navigationStarted() IMMEDIATELY"))
+    }
+
+    @Test
+    fun bootstrapTemplateDoesNotExposeIssue116Placeholder() {
+        val source = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
+        )
+
+        assertFalse(source.contains("OpenAutoLink — Cluster Navigation"))
+        assertFalse(source.contains("Cluster navigation service active."))
+    }
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterManagerWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterManagerWiringContractTest.kt
@@ -15,22 +15,26 @@ class ClusterManagerWiringContractTest {
     }
 
     @Test
-    fun delayedForegroundRestoreIsOwnedByLaunchingGeneration() {
+    fun healthCheckIsReadyAndGenerationOwned() {
         val source = projectFile(
             "app/src/main/java/com/openautolink/app/cluster/ClusterManager.kt"
         )
-        val start = source.indexOf("// Bring main activity back")
-        val end = source.indexOf("}, BRING_BACK_DELAY_MS)", start)
-        assertTrue("bring-back callback missing", start >= 0 && end > start)
+        val start = source.indexOf("private fun scheduleHealthCheck(")
+        val end = source.indexOf("fun restartClusterBinding()", start)
+        assertTrue("health-check callback missing", start >= 0 && end > start)
 
         val callback = source.substring(start, end)
         assertTrue(
-            "bring-back callback must share the lifecycle lock",
+            "health-check callback must share the lifecycle lock",
             callback.contains("synchronized(ClusterBindingLifecycle.lock)"),
         )
         assertTrue(
-            "bring-back callback must reject a retired launch generation",
+            "health-check callback must reject a retired launch generation",
             callback.contains("ClusterBindingState.isManagerCurrent(launchLease)"),
+        )
+        assertTrue(
+            "health-check must require a usable primary session",
+            callback.contains("ClusterBindingState.hasReadySession(launchLease)"),
         )
     }
 }

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterNavigationLifecyclePolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterNavigationLifecyclePolicyTest.kt
@@ -1,0 +1,95 @@
+package com.openautolink.app.cluster
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClusterNavigationLifecyclePolicyTest {
+
+    @Test
+    fun firstRouteStartsNavigationAndPublishesTrip() {
+        val policy = ClusterNavigationLifecyclePolicy()
+
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.START_AND_UPDATE,
+            policy.onRouteAvailable(),
+        )
+    }
+
+    @Test
+    fun activeRouteUpdatesWithoutRestartingNavigation() {
+        val policy = ClusterNavigationLifecyclePolicy()
+        policy.onRouteAvailable()
+
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.UPDATE,
+            policy.onRouteAvailable(),
+        )
+    }
+
+    @Test
+    fun clearingActiveRouteEndsNavigation() {
+        val policy = ClusterNavigationLifecyclePolicy()
+        policy.onRouteAvailable()
+
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.END,
+            policy.onRouteCleared(),
+        )
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.NONE,
+            policy.onRouteCleared(),
+        )
+    }
+
+    @Test
+    fun hostStopSuppressesCurrentRouteUntilItClears() {
+        val policy = ClusterNavigationLifecyclePolicy()
+        policy.onRouteAvailable()
+
+        policy.onHostStop()
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.NONE,
+            policy.onRouteAvailable(),
+        )
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.NONE,
+            policy.onRouteCleared(),
+        )
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.START_AND_UPDATE,
+            policy.onRouteAvailable(),
+        )
+    }
+
+    @Test
+    fun arrivalEndsOnceAndSuppressesTerminalRouteUntilClear() {
+        val policy = ClusterNavigationLifecyclePolicy()
+        policy.onRouteAvailable()
+
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.END,
+            policy.onRouteTerminated(),
+        )
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.NONE,
+            policy.onRouteAvailable(),
+        )
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.NONE,
+            policy.onRouteTerminated(),
+        )
+    }
+
+    @Test
+    fun failedNavigationStartAllowsNextUpdateToRetryStart() {
+        val policy = ClusterNavigationLifecyclePolicy()
+        policy.onRouteAvailable()
+
+        policy.onNavigationStartFailed()
+
+        assertEquals(
+            ClusterNavigationLifecyclePolicy.Action.START_AND_UPDATE,
+            policy.onRouteAvailable(),
+        )
+    }
+}

--- a/app/src/test/java/com/openautolink/app/cluster/ClusterRelayTemplateFactoryTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterRelayTemplateFactoryTest.kt
@@ -1,0 +1,14 @@
+package com.openautolink.app.cluster
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class ClusterRelayTemplateFactoryTest {
+
+    @Test
+    fun windowlessRelayTemplateKeepsRequiredActionStrip() {
+        val template = ClusterRelayTemplateFactory.build()
+
+        assertNotNull(template.actionStrip)
+    }
+}


### PR DESCRIPTION
## Root cause

The uploaded car logs contain **15 distinct 0.1.491 process crashes** between 11:08:03 and 11:11:40. Every process reaches Templates Host connection and primary `ClusterMainSession` creation, then dies on the main thread with:

```text
java.lang.IllegalStateException: Action strip for this template must be set
```

PR #117 changed `RelayScreen` from a valid `NavigationTemplate` with `ActionStrip.APP_ICON` to a zero-width `MessageInfo` with no action strip. AndroidX 1.7 accepts the builder call site but validates the template when Templates Host requests it, which caused the delayed UI crash loop.

## Fix

- restore the reviewed windowless cluster implementation after the emergency #125 isolation rollback;
- build the invisible relay template through `ClusterRelayTemplateFactory`;
- retain the zero-width message while restoring the host-required `ActionStrip` with `Action.APP_ICON`;
- route every `RelayScreen.onGetTemplate()` call through that tested factory.

No visible cluster placeholder is restored. GM media controls, codec-specific seed thresholds, companion runtime diagnostics, and all unrelated current-main work remain unchanged.

## TDD and verification

- RED: `ClusterRelayTemplateFactoryTest` failed to compile because the required production factory did not exist.
- GREEN: the executable test calls the real AndroidX `NavigationTemplate.Builder.build()` path and asserts a non-null action strip.
- Focused factory test: pass.
- Full `:app:testDebugUnitTest :app:assembleDebug --rerun-tasks`: **498 tests**, 0 failures/errors/skips.
- Debug APK: arm64-v8a + x86_64; contains cluster protector, task-background, GM-media, and seed-threshold markers; old visible placeholder strings absent.
- Minified `:app:bundleRelease --rerun-tasks`: pass, including R8, lint, both ABIs, and packaging.
- Independent source review: approve; no blocker.

## Honest status

The deterministic crash mechanism is proven and the invalid template is corrected. The windowless behavior itself remains a vehicle-test attempt until the next installed log shows `Cluster bootstrap window protected`, `Cluster session ready`, and `Cluster bootstrap task background outcome=moved`, without another action-strip crash and with real route guidance still working.

Fixes #116.
