### PR TITLE
test(cluster): cover extracted relay placeholder

### DIFF
--- a/app/src/test/java/com/openautolink/app/cluster/ClusterMainSessionWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/cluster/ClusterMainSessionWiringContractTest.kt
@@ -34,11 +34,21 @@ class ClusterMainSessionWiringContractTest {
 
     @Test
     fun bootstrapTemplateDoesNotExposeIssue116Placeholder() {
-        val source = projectFile(
+        val sessionSource = projectFile(
             "app/src/main/java/com/openautolink/app/cluster/ClusterMainSession.kt",
         )
+        val templateSource = projectFile(
+            "app/src/main/java/com/openautolink/app/cluster/ClusterRelayTemplateFactory.kt",
+        )
+        val visiblePlaceholderText = listOf(
+            "OpenAutoLink — Cluster Navigation",
+            "Cluster navigation service active.",
+        )
 
-        assertFalse(source.contains("OpenAutoLink — Cluster Navigation"))
-        assertFalse(source.contains("Cluster navigation service active."))
+        assertTrue(sessionSource.contains("ClusterRelayTemplateFactory.build()"))
+        visiblePlaceholderText.forEach { text ->
+            assertFalse(sessionSource.contains(text))
+            assertFalse(templateSource.contains(text))
+        }
     }
 }


### PR DESCRIPTION
## Summary

Close the non-blocking review gap from PR #126 by making the Issue #116 placeholder regression test inspect the extracted `ClusterRelayTemplateFactory`, not only `ClusterMainSession`.

The test now also asserts that `RelayScreen` delegates to the factory, so visible placeholder text cannot be reintroduced in either production file without failing CI.

## Verification

- Focused `ClusterMainSessionWiringContractTest`: passed
- Documentation/test-only; no runtime code or release change

Follow-up to #126.
