### PR TITLE
feat(media): make validated GM controls built in

### DIFF
--- a/app/src/main/cpp/aasdk_jni.cpp
+++ b/app/src/main/cpp/aasdk_jni.cpp
@@ -211,17 +211,6 @@ Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSendKeyPress(
     return session->sendKeyPress(keyCode) ? JNI_TRUE : JNI_FALSE;
 }
 
-JNIEXPORT jboolean JNICALL
-Java_com_openautolink_app_transport_aasdk_AasdkNative_nativeSetExperimentalMediaControlsEnabled(
-    JNIEnv* /*env*/, jclass /*clazz*/, jboolean enabled, jlong expectedGeneration)
-{
-    std::lock_guard<std::mutex> lock(gSessionMutex);
-    auto session = std::atomic_load(&gSession);
-    if (!session || gSessionGeneration.load() != expectedGeneration) return JNI_FALSE;
-    return session->setExperimentalMediaControlsEnabled(enabled == JNI_TRUE)
-        ? JNI_TRUE : JNI_FALSE;
-}
-
 /*
  * Class:     com_openautolink_app_transport_aasdk_AasdkNative
  * Method:    nativeSendGpsLocation

--- a/app/src/main/cpp/jni_session.cpp
+++ b/app/src/main/cpp/jni_session.cpp
@@ -981,16 +981,8 @@ void JniSession::onAudioFocusRequest(
 
 void JniSession::sendUnsolicitedAudioFocusGain()
 {
-    // Off mode is byte-for-behavior compatible with the established path: every
-    // audio setup emits an unsolicited GAIN, with no experimental dedupe.
-    if (!experimentalMediaControlsEnabled_.load()) {
-        sendUnsolicitedAudioFocusState(static_cast<int>(
-            aap_protobuf::service::control::message::AUDIO_FOCUS_STATE_GAIN));
-        return;
-    }
-
-    // In experimental mode, an explicitly primed unmuted state must not add a
-    // new unsolicited GAIN merely because the toggle was enabled.
+    // GM mute synchronization is built in. A primed unmuted state suppresses
+    // the redundant initial GAIN; a primed mute sends LOSS once control is ready.
     flushHeadUnitAudioFocusState(headUnitMuteExplicit_.load());
 }
 
@@ -1004,7 +996,8 @@ bool JniSession::setHeadUnitMuted(bool muted)
     headUnitMuteExplicit_.store(true);
     auto self = shared_from_this();
     ioService_->post([self]() {
-        self->flushHeadUnitAudioFocusState(false);
+        // Suppress a redundant first GAIN, but still send GAIN after a queued LOSS.
+        self->flushHeadUnitAudioFocusState(true);
     });
     nativeDiag(1, "audio", "HU mute state queued: muted=" +
                std::string(muted ? "true" : "false"));
@@ -1023,7 +1016,7 @@ bool JniSession::primeHeadUnitMuted(bool muted)
 
 bool JniSession::flushHeadUnitAudioFocusState(bool suppressInitialUnmuted)
 {
-    if (stopped_ || !controlChannel_ || !strand_) {
+    if (stopped_ || !streaming_ || !controlChannel_ || !strand_) {
         nativeDiag(1, "audio", "HU mute state primed: muted=" +
                    std::string(headUnitMuted_.load() ? "true" : "false"));
         return false;
@@ -1033,7 +1026,7 @@ bool JniSession::flushHeadUnitAudioFocusState(bool suppressInitialUnmuted)
     if (lastQueuedHeadUnitMute_ == desiredMute) return true;
     if (suppressInitialUnmuted && !muted && lastQueuedHeadUnitMute_ < 0) {
         nativeDiag(1, "audio", "AA audio focus sync outcome=suppressed: "
-                   "state=GAIN reason=experimental-initial-unmuted");
+                   "state=GAIN reason=built-in-initial-unmuted");
         return true;
     }
     auto focus = muted
@@ -2199,9 +2192,8 @@ void JniSession::sendKeyEvent(int keyCode, bool isDown)
 
 bool JniSession::sendKeyPress(int keyCode)
 {
-    if (!experimentalMediaControlsEnabled_ || !streaming_ || !inputChannel_ || stopped_) {
+    if (!streaming_ || !inputChannel_ || stopped_) {
         nativeDiag(2, "input", "Key press rejected: keycode=" + std::to_string(keyCode) +
-                   " experimental=" + (experimentalMediaControlsEnabled_ ? "true" : "false") +
                    " streaming=" + (streaming_ ? "true" : "false") +
                    " inputChannel=" + (inputChannel_ ? "ready" : "null") +
                    " stopped=" + (stopped_ ? "true" : "false"));
@@ -2210,8 +2202,7 @@ bool JniSession::sendKeyPress(int keyCode)
 
     auto self = shared_from_this();
     ioService_->post([self, keyCode]() {
-        if (!self->experimentalMediaControlsEnabled_ || self->stopped_ ||
-            !self->inputChannel_ || !self->strand_) {
+        if (self->stopped_ || !self->inputChannel_ || !self->strand_) {
             self->nativeDiag(2, "input", "Key press send rejected: keycode=" +
                              std::to_string(keyCode) + " reason=session-not-ready");
             return;
@@ -2247,15 +2238,6 @@ bool JniSession::sendKeyPress(int keyCode)
             self->inputChannel_->sendInputReport(report, std::move(promise));
         }
     });
-    return true;
-}
-
-bool JniSession::setExperimentalMediaControlsEnabled(bool enabled)
-{
-    if (stopped_) return false;
-    experimentalMediaControlsEnabled_.store(enabled);
-    nativeDiag(1, "input", "Experimental MediaSession native gate enabled=" +
-               std::string(enabled ? "true" : "false"));
     return true;
 }
 

--- a/app/src/main/cpp/jni_session.h
+++ b/app/src/main/cpp/jni_session.h
@@ -130,9 +130,6 @@ public:
     /** Queue a complete down/up media-key press as one native operation. */
     bool sendKeyPress(int keyCode);
 
-    /** Gate only the experimental MediaSession command path. */
-    bool setExperimentalMediaControlsEnabled(bool enabled);
-
     /** Send GPS location to phone. */
     void sendGpsLocation(double lat, double lon, double alt,
                          float speed, float bearing, long long timestampMs);
@@ -309,7 +306,6 @@ private:
     std::atomic<bool> sessionStoppedFired_{false};
     std::atomic<bool> headUnitMuted_{false};
     std::atomic<bool> headUnitMuteExplicit_{false};
-    std::atomic<bool> experimentalMediaControlsEnabled_{false};
     // IO-thread confined; reset only when an async send fails.
     int lastQueuedHeadUnitMute_ = -1;
     // Reason string passed to Kotlin onSessionStopped. Defaults to "stopped";

--- a/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
+++ b/app/src/main/java/com/openautolink/app/data/AppPreferences.kt
@@ -125,10 +125,6 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         // reports a usable gear. See issue #61.
         val ALWAYS_IN_PARK = booleanPreferencesKey("always_in_park")
         val CLUSTER_NAVIGATION = booleanPreferencesKey("cluster_navigation")
-        // Opt-in field trial for GM-native MediaSession controls and mute sync.
-        // Default off preserves the current activity/key-remap behavior.
-        val EXPERIMENTAL_GM_MEDIA_CONTROLS =
-            booleanPreferencesKey("experimental_gm_media_controls")
         val OVERLAY_STATS_BUTTON = booleanPreferencesKey("overlay_stats_button")
         val OVERLAY_PHONE_SWITCH_BUTTON = booleanPreferencesKey("overlay_phone_switch_button")
         val OVERLAY_RECONNECT_BUTTON = booleanPreferencesKey("overlay_reconnect_button")
@@ -321,7 +317,6 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
         const val DEFAULT_GPS_FORWARDING = true
         const val DEFAULT_ALWAYS_IN_PARK = false
         const val DEFAULT_CLUSTER_NAVIGATION = true
-        const val DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS = false
         const val DEFAULT_OVERLAY_STATS_BUTTON = true
         const val DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON = true
         const val DEFAULT_OVERLAY_RECONNECT_BUTTON = false
@@ -555,10 +550,6 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     val clusterNavigation: Flow<Boolean> = dataStore.data.map { prefs ->
         prefs[CLUSTER_NAVIGATION] ?: DEFAULT_CLUSTER_NAVIGATION
-    }
-
-    val experimentalGmMediaControls: Flow<Boolean> = dataStore.data.map { prefs ->
-        prefs[EXPERIMENTAL_GM_MEDIA_CONTROLS] ?: DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS
     }
 
     val overlayStatsButton: Flow<Boolean> = dataStore.data.map { prefs ->
@@ -828,10 +819,6 @@ class AppPreferences private constructor(private val dataStore: DataStore<Prefer
 
     suspend fun setClusterNavigation(enabled: Boolean) {
         dataStore.edit { it[CLUSTER_NAVIGATION] = enabled }
-    }
-
-    suspend fun setExperimentalGmMediaControls(enabled: Boolean) {
-        dataStore.edit { it[EXPERIMENTAL_GM_MEDIA_CONTROLS] = enabled }
     }
 
     suspend fun setOverlayStatsButton(visible: Boolean) {

--- a/app/src/main/java/com/openautolink/app/media/GmMediaControlPolicy.kt
+++ b/app/src/main/java/com/openautolink/app/media/GmMediaControlPolicy.kt
@@ -2,7 +2,7 @@ package com.openautolink.app.media
 
 import android.view.KeyEvent
 
-/** Pure policy for the opt-in GM MediaSession control experiment. */
+/** Pure policy for built-in GM MediaSession controls and mute synchronization. */
 object GmMediaControlPolicy {
     enum class Command {
         PLAY,
@@ -12,29 +12,31 @@ object GmMediaControlPolicy {
         PREVIOUS,
     }
 
-    fun keyCodeFor(command: Command, enabled: Boolean): Int? {
-        if (!enabled) return null
-        return when (command) {
-            Command.PLAY -> KeyEvent.KEYCODE_MEDIA_PLAY
-            Command.PAUSE,
-            Command.STOP -> KeyEvent.KEYCODE_MEDIA_PAUSE
-            Command.NEXT -> KeyEvent.KEYCODE_MEDIA_NEXT
-            Command.PREVIOUS -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
-        }
+    fun keyCodeFor(command: Command): Int = when (command) {
+        Command.PLAY -> KeyEvent.KEYCODE_MEDIA_PLAY
+        Command.PAUSE,
+        Command.STOP -> KeyEvent.KEYCODE_MEDIA_PAUSE
+        Command.NEXT -> KeyEvent.KEYCODE_MEDIA_NEXT
+        Command.PREVIOUS -> KeyEvent.KEYCODE_MEDIA_PREVIOUS
     }
 
     fun effectiveMuted(masterMuted: Boolean, streamMuted: Boolean): Boolean =
         masterMuted || streamMuted
 
     fun nextMuteState(
-        enabled: Boolean,
         masterMuted: Boolean,
         streamMuted: Boolean,
         lastDeliveredMuted: Boolean?,
+        retainedMuted: Boolean?,
     ): Boolean? {
-        if (!enabled) return null
         val effectiveMuted = effectiveMuted(masterMuted, streamMuted)
-        if (lastDeliveredMuted == null) return true.takeIf { effectiveMuted }
+        if (lastDeliveredMuted == null) {
+            return when {
+                effectiveMuted -> true
+                retainedMuted == true -> false
+                else -> null
+            }
+        }
         return effectiveMuted.takeIf { it != lastDeliveredMuted }
     }
 }

--- a/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt
@@ -64,7 +64,6 @@ class OalMediaSessionManager private constructor(private val context: Context) {
     private var lastPushedPlaying: Boolean? = null
     private var lastPushedState = PlaybackStateCompat.STATE_NONE
     private var lastPushedPosition = 0L
-    @Volatile private var experimentalControlsEnabled = false
 
     // Album art cache: avoid redundant BitmapFactory decodes
     private var cachedArtHash = 0
@@ -183,17 +182,6 @@ class OalMediaSessionManager private constructor(private val context: Context) {
 
     fun getSessionToken(): MediaSessionCompat.Token? = mediaSession?.sessionToken
 
-    fun setExperimentalControlsEnabled(enabled: Boolean) {
-        synchronized(sessionLock) {
-            if (experimentalControlsEnabled == enabled) return
-            experimentalControlsEnabled = enabled
-            mediaSession?.setPlaybackState(
-                buildPlaybackState(lastPushedState, lastPushedPosition),
-            )
-            Log.i(TAG, "Experimental transport controls enabled=$enabled")
-        }
-    }
-
     /**
      * Update now-playing metadata from bridge media_metadata control message.
      */
@@ -292,12 +280,12 @@ class OalMediaSessionManager private constructor(private val context: Context) {
     }
 
     private fun buildPlaybackState(state: Int, position: Long): PlaybackStateCompat {
-        var actions = PlaybackStateCompat.ACTION_PLAY or
+        val actions = PlaybackStateCompat.ACTION_PLAY or
             PlaybackStateCompat.ACTION_PAUSE or
+            PlaybackStateCompat.ACTION_STOP or
             PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
             PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
             PlaybackStateCompat.ACTION_PLAY_PAUSE
-        if (experimentalControlsEnabled) actions = actions or PlaybackStateCompat.ACTION_STOP
         return PlaybackStateCompat.Builder()
             .setActions(actions)
             .setState(state, position, if (state == PlaybackStateCompat.STATE_PLAYING) 1.0f else 0f)

--- a/app/src/main/java/com/openautolink/app/session/SessionManager.kt
+++ b/app/src/main/java/com/openautolink/app/session/SessionManager.kt
@@ -58,7 +58,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
@@ -899,10 +898,8 @@ class SessionManager(
 
     /** SCREEN_OFF/_ON receiver registration tracker. */
     private var screenReceiver: android.content.BroadcastReceiver? = null
-    /** Process-scope state for the temporary GM media-control field trial. */
-    @Volatile private var experimentalGmMediaControlsEnabled = false
-    @Volatile private var experimentalGmMediaControlsObserverStarted = false
-    private val experimentalMediaControlLock = Any()
+    /** Process-scope state for built-in GM media controls and mute synchronization. */
+    private val gmMediaControlLock = Any()
     private var muteStateReceiver: android.content.BroadcastReceiver? = null
     @Volatile private var lastKnownMasterMuted = false
     @Volatile private var lastDeliveredHuMuted: Boolean? = null
@@ -1276,7 +1273,7 @@ class SessionManager(
                 media.updatePlaybackState(p.playing, p.positionMs)
             }
         }
-        observeExperimentalGmMediaControls()
+        installGmMediaControls()
 
         // Cluster service is gated by user preference (default ON). When disabled,
         // the CarAppService component is disabled so Templates Host won't bind it.
@@ -1668,23 +1665,16 @@ class SessionManager(
                 "autoNeg=$videoAutoNegotiate selected=${resW}x${resH}",
         )
 
-        val storedExperimentalControls = AppPreferences.getInstance(ctx)
-            .experimentalGmMediaControls.first()
-        if (storedExperimentalControls != experimentalGmMediaControlsEnabled) {
-            applyExperimentalGmMediaControls(storedExperimentalControls)
-        }
-
         val session = AasdkSession(scope, ctx)
-        session.desiredExperimentalMediaControlsEnabled = experimentalGmMediaControlsEnabled
-        if (experimentalGmMediaControlsEnabled) {
-            val streamMuted = runCatching {
-                audioManager?.isStreamMute(AudioManager.STREAM_MUSIC) ?: false
-            }.getOrDefault(false)
-            session.desiredHeadUnitMuted = GmMediaControlPolicy.effectiveMuted(
+        val streamMuted = runCatching {
+            audioManager?.isStreamMute(AudioManager.STREAM_MUSIC) ?: false
+        }.getOrDefault(false)
+        session.primeHeadUnitMuted(
+            GmMediaControlPolicy.effectiveMuted(
                 masterMuted = lastKnownMasterMuted,
                 streamMuted = streamMuted,
-            )
-        }
+            ),
+        )
         session.transportMode = directTransport
         session.wppInterfaceName = wppInterfaceName
         // Effective AA content_insets:
@@ -1814,9 +1804,6 @@ class SessionManager(
                         true
                     }
                 }
-                if (isCurrent && reportedState == SessionState.STREAMING) {
-                    syncExperimentalHuMuteState("session-streaming")
-                }
             }
         }
 
@@ -1886,7 +1873,7 @@ class SessionManager(
 
         // A replacement native generation must receive a fresh effective mute
         // state after its control and input channels reach STREAMING.
-        lastDeliveredHuMuted = null
+        synchronized(gmMediaControlLock) { lastDeliveredHuMuted = null }
 
         ensureVideoDecoder()
         ensureAudioPlayer()
@@ -2676,70 +2663,22 @@ class SessionManager(
         screenReceiver = null
     }
 
-    private fun observeExperimentalGmMediaControls() {
-        if (experimentalGmMediaControlsObserverStarted) return
-        val ctx = context ?: return
-        experimentalGmMediaControlsObserverStarted = true
-        val preferences = AppPreferences.getInstance(ctx)
-        scope.launch {
-            preferences.experimentalGmMediaControls.distinctUntilChanged().collect { enabled ->
-                applyExperimentalGmMediaControls(enabled)
-            }
-        }
-    }
-
-    private fun applyExperimentalGmMediaControls(enabled: Boolean) {
-        synchronized(experimentalMediaControlLock) {
-            val wasEnabled = experimentalGmMediaControlsEnabled
-            if (!enabled) {
-                val currentSession = synchronized(sessionStateLock) { aasdkSession }
-                val shouldRestoreGain = lastDeliveredHuMuted == true ||
-                    currentSession?.desiredHeadUnitMuted == true
-                experimentalGmMediaControlsEnabled = false
-                currentSession?.setExperimentalMediaControlsEnabled(false)
-                if (wasEnabled && shouldRestoreGain) {
-                    // Clear both the live native state and the wrapper's retained
-                    // state, including a mute that was primed before channels opened.
-                    val restored = currentSession?.setHeadUnitMuted(false) ?: false
-                    OalLog.i(
-                        TAG,
-                        "AA audio focus sync outcome=${if (restored) "queued" else "rejected"}: " +
-                            "state=GAIN source=toggle-disabled",
-                    )
+    private fun installGmMediaControls() {
+        synchronized(gmMediaControlLock) {
+            _mediaSessionManager?.mediaControlCallback =
+                object : OalMediaSessionManager.MediaControlCallback {
+                    override fun onCommand(command: GmMediaControlPolicy.Command) {
+                        routeMediaSessionCommand(command)
+                    }
                 }
-                _mediaSessionManager?.setExperimentalControlsEnabled(false)
-                _mediaSessionManager?.mediaControlCallback = null
-                unregisterMuteStateReceiver()
-                lastDeliveredHuMuted = null
-                OalLog.i(TAG, "Experimental GM media controls disabled; legacy key-remap path unchanged")
-                return
-            }
-
-            experimentalGmMediaControlsEnabled = true
-            _mediaSessionManager?.mediaControlCallback = object : OalMediaSessionManager.MediaControlCallback {
-                override fun onCommand(command: GmMediaControlPolicy.Command) {
-                    routeMediaSessionCommand(command)
-                }
-            }
-            synchronized(sessionStateLock) { aasdkSession }
-                ?.setExperimentalMediaControlsEnabled(true)
-            _mediaSessionManager?.setExperimentalControlsEnabled(true)
             registerMuteStateReceiver()
-            primeExperimentalUnmutedState()
-            syncExperimentalHuMuteState(if (wasEnabled) "settings-refresh" else "toggle-enabled")
-            OalLog.i(TAG, "Experimental GM media controls enabled; legacy key-remap path unchanged")
+            syncGmMuteState("controls-installed")
+            OalLog.i(TAG, "GM media controls active; legacy key-remap path unchanged")
         }
     }
 
     private fun routeMediaSessionCommand(command: GmMediaControlPolicy.Command) {
-        val keyCode = GmMediaControlPolicy.keyCodeFor(
-            command,
-            enabled = experimentalGmMediaControlsEnabled,
-        )
-        if (keyCode == null) {
-            OalLog.i(TAG, "MediaSession command outcome=rejected: command=$command reason=disabled")
-            return
-        }
+        val keyCode = GmMediaControlPolicy.keyCodeFor(command)
 
         val lifecycle = lifecycleGeneration
         val target = synchronized(sessionStateLock) {
@@ -2761,8 +2700,7 @@ class SessionManager(
         )
         scope.launch {
             val stillCurrent = synchronized(sessionStateLock) {
-                experimentalGmMediaControlsEnabled &&
-                    aasdkSession === targetSession && lifecycle == lifecycleGeneration
+                aasdkSession === targetSession && lifecycle == lifecycleGeneration
             }
             val queued = stillCurrent &&
                 targetSession.sendKeyPress(keyCode, nativeGeneration)
@@ -2786,11 +2724,11 @@ class SessionManager(
                             EXTRA_MASTER_VOLUME_MUTED,
                             lastKnownMasterMuted,
                         )
-                        scope.launch { syncExperimentalHuMuteState("master-broadcast") }
+                        scope.launch { syncGmMuteState("master-broadcast") }
                     }
                     STREAM_MUTE_CHANGED_ACTION -> {
                         if (intent.getIntExtra(EXTRA_VOLUME_STREAM_TYPE, -1) == AudioManager.STREAM_MUSIC) {
-                            scope.launch { syncExperimentalHuMuteState("stream-broadcast") }
+                            scope.launch { syncGmMuteState("stream-broadcast") }
                         }
                     }
                 }
@@ -2819,19 +2757,7 @@ class SessionManager(
         }
     }
 
-    private fun unregisterMuteStateReceiver() {
-        val receiver = muteStateReceiver
-        muteStateReceiver = null
-        if (receiver != null) {
-            try {
-                context?.unregisterReceiver(receiver)
-            } catch (e: Exception) {
-                OalLog.w(TAG, "GM master/stream mute receiver unregister failed: ${e.message}")
-            }
-        }
-    }
-
-    private fun primeExperimentalUnmutedState() {
+    private fun primeUnmutedState() {
         val manager = audioManager ?: return
         val streamMuted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
             .getOrDefault(false)
@@ -2841,12 +2767,12 @@ class SessionManager(
         OalLog.i(
             TAG,
             "AA audio focus sync outcome=${if (primed) "primed" else "deferred"}: " +
-                "state=GAIN source=experimental-initial-unmuted",
+                "state=GAIN source=built-in-initial-unmuted",
         )
     }
 
-    private fun syncExperimentalHuMuteState(reason: String) {
-        synchronized(experimentalMediaControlLock) {
+    private fun syncGmMuteState(reason: String) {
+        synchronized(gmMediaControlLock) {
             val manager = audioManager ?: return
             val masterMuted = lastKnownMasterMuted
             val streamMuted = runCatching { manager.isStreamMute(AudioManager.STREAM_MUSIC) }
@@ -2854,11 +2780,12 @@ class SessionManager(
                     OalLog.w(TAG, "Failed to read HU media-stream mute ($reason): ${it.message}")
                     return
                 }
+            val currentSession = synchronized(sessionStateLock) { aasdkSession }
             val targetMuted = GmMediaControlPolicy.nextMuteState(
-                enabled = experimentalGmMediaControlsEnabled,
                 masterMuted = masterMuted,
                 streamMuted = streamMuted,
                 lastDeliveredMuted = lastDeliveredHuMuted,
+                retainedMuted = currentSession?.desiredHeadUnitMuted,
             ) ?: return
 
             OalLog.i(
@@ -2867,7 +2794,11 @@ class SessionManager(
                     "effective=$targetMuted source=$reason",
             )
             val queued = synchronized(sessionStateLock) {
-                aasdkSession?.setHeadUnitMuted(targetMuted) ?: false
+                if (aasdkSession === currentSession) {
+                    currentSession?.setHeadUnitMuted(targetMuted) ?: false
+                } else {
+                    false
+                }
             }
             if (queued) lastDeliveredHuMuted = targetMuted
             OalLog.i(
@@ -3188,6 +3119,11 @@ class SessionManager(
                     OalLog.i(TAG, "Ignoring PhoneConnected effects from stale session")
                     return
                 }
+                // The native "session started" callback reports CONNECTED. This
+                // PhoneConnected message is the actual STREAMING boundary. Queue
+                // sync outside sessionStateLock so GM/session lock order stays
+                // consistent with settings and broadcast paths.
+                scope.launch { syncGmMuteState("phone-connected") }
                 // Reset the stall watchdog baseline: give the fresh session a
                 // full warmup window before it can fire (avoids a stale
                 // timestamp from a prior session tripping it immediately).

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt
@@ -74,12 +74,6 @@ object AasdkNative {
     external fun nativeSendKeyPress(keyCode: Int, expectedNativeGeneration: Long): Boolean
 
     @JvmStatic
-    external fun nativeSetExperimentalMediaControlsEnabled(
-        enabled: Boolean,
-        expectedNativeGeneration: Long,
-    ): Boolean
-
-    @JvmStatic
     external fun nativeSendGpsLocation(
         lat: Double, lon: Double, alt: Double,
         speed: Float, bearing: Float, timestampMs: Long

--- a/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
+++ b/app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt
@@ -374,10 +374,10 @@ class AasdkSession(
     var onNativeSessionStarting: (() -> Boolean)? = null
 
     /** Desired HU mute state, retained across native transport replacement. */
+    private val headUnitMuteLock = Any()
     @Volatile
     var desiredHeadUnitMuted: Boolean? = null
-    @Volatile
-    var desiredExperimentalMediaControlsEnabled = false
+        private set
     private val nativeSessionGeneration = java.util.concurrent.atomic.AtomicLong(0L)
 
     fun currentNativeSessionGeneration(): Long = nativeSessionGeneration.get()
@@ -559,13 +559,7 @@ class AasdkSession(
 
             try {
                 nativeSessionGeneration.set(AasdkNative.nativeCreateSession())
-                AasdkNative.nativeSetExperimentalMediaControlsEnabled(
-                    desiredExperimentalMediaControlsEnabled,
-                    nativeSessionGeneration.get(),
-                )
-                desiredHeadUnitMuted?.let {
-                    AasdkNative.nativePrimeHeadUnitMuted(it, nativeSessionGeneration.get())
-                }
+                primeDesiredHeadUnitMuteOnNativeSession()
                 AasdkNative.nativeStartSession(pipe, this, sdrConfig)
             } catch (e: Exception) {
                 OalLog.e(TAG, "Native session start failed (USB): ${e.message}")
@@ -654,13 +648,7 @@ class AasdkSession(
 
         try {
             nativeSessionGeneration.set(AasdkNative.nativeCreateSession())
-            AasdkNative.nativeSetExperimentalMediaControlsEnabled(
-                desiredExperimentalMediaControlsEnabled,
-                nativeSessionGeneration.get(),
-            )
-            desiredHeadUnitMuted?.let {
-                AasdkNative.nativePrimeHeadUnitMuted(it, nativeSessionGeneration.get())
-            }
+            primeDesiredHeadUnitMuteOnNativeSession()
             AasdkNative.nativeStartSession(transportPipe!!, this, sdrConfig)
         } catch (e: Exception) {
             OalLog.e(TAG, "Native session start failed: ${e.message}")
@@ -787,14 +775,6 @@ class AasdkSession(
     fun sendKeyPress(keyCode: Int, expectedNativeGeneration: Long): Boolean =
         AasdkNative.nativeSendKeyPress(keyCode, expectedNativeGeneration)
 
-    fun setExperimentalMediaControlsEnabled(enabled: Boolean): Boolean =
-        synchronized(connectionStartLock) {
-            desiredExperimentalMediaControlsEnabled = enabled
-            val generation = nativeSessionGeneration.get()
-            generation != 0L &&
-                AasdkNative.nativeSetExperimentalMediaControlsEnabled(enabled, generation)
-        }
-
     fun sendGpsLocation(lat: Double, lon: Double, alt: Double,
                         speed: Float, bearing: Float, timestampMs: Long) {
         AasdkNative.nativeSendGpsLocation(lat, lon, alt, speed, bearing, timestampMs)
@@ -840,15 +820,27 @@ class AasdkSession(
      * (e.g., pause/resume on mute/unmute).
      */
     fun setHeadUnitMuted(muted: Boolean): Boolean {
-        desiredHeadUnitMuted = muted
-        val generation = nativeSessionGeneration.get()
-        return generation != 0L && AasdkNative.nativeSetHeadUnitMuted(muted, generation)
+        synchronized(headUnitMuteLock) {
+            desiredHeadUnitMuted = muted
+            val generation = nativeSessionGeneration.get()
+            return generation != 0L && AasdkNative.nativeSetHeadUnitMuted(muted, generation)
+        }
     }
 
     fun primeHeadUnitMuted(muted: Boolean): Boolean {
-        desiredHeadUnitMuted = muted
-        val generation = nativeSessionGeneration.get()
-        return generation != 0L && AasdkNative.nativePrimeHeadUnitMuted(muted, generation)
+        synchronized(headUnitMuteLock) {
+            desiredHeadUnitMuted = muted
+            val generation = nativeSessionGeneration.get()
+            return generation != 0L && AasdkNative.nativePrimeHeadUnitMuted(muted, generation)
+        }
+    }
+
+    private fun primeDesiredHeadUnitMuteOnNativeSession() {
+        synchronized(headUnitMuteLock) {
+            desiredHeadUnitMuted?.let {
+                AasdkNative.nativePrimeHeadUnitMuted(it, nativeSessionGeneration.get())
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt
@@ -2506,41 +2506,6 @@ private fun AudioTab(viewModel: SettingsViewModel, uiState: SettingsUiState) {
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Temporary field-test switch. Once vehicle evidence is conclusive this
-        // setting can be removed and the proven behavior made unconditional.
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(0.7f)
-                .padding(vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = "Experimental GM media controls",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = "Route GM's native media controls and master/stream mute state " +
-                        "to Android Auto. Existing steering-wheel key remaps stay active. " +
-                        "Takes effect immediately.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            Switch(
-                checked = uiState.experimentalGmMediaControls,
-                onCheckedChange = { viewModel.updateExperimentalGmMediaControls(it) },
-                modifier = Modifier.testTag("experimentalGmMediaControlsToggle"),
-            )
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
-        HorizontalDivider(modifier = Modifier.fillMaxWidth(0.7f))
-
-        Spacer(modifier = Modifier.height(24.dp))
-
         // --- Per-Purpose Volume Offsets ---
         SectionHeader("Volume Offsets")
 

--- a/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt
@@ -51,8 +51,6 @@ data class SettingsUiState(
     val gpsForwarding: Boolean = AppPreferences.DEFAULT_GPS_FORWARDING,
     val alwaysInPark: Boolean = AppPreferences.DEFAULT_ALWAYS_IN_PARK,
     val clusterNavigation: Boolean = AppPreferences.DEFAULT_CLUSTER_NAVIGATION,
-    val experimentalGmMediaControls: Boolean =
-        AppPreferences.DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS,
     val overlayStatsButton: Boolean = AppPreferences.DEFAULT_OVERLAY_STATS_BUTTON,
     val overlayPhoneSwitchButton: Boolean = AppPreferences.DEFAULT_OVERLAY_PHONE_SWITCH_BUTTON,
     val overlayReconnectButton: Boolean = AppPreferences.DEFAULT_OVERLAY_RECONNECT_BUTTON,
@@ -149,7 +147,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         preferences.simulateIgnitionButton,
         preferences.overlayPhoneSwitchButton,
         preferences.overlayReconnectButton,
-        preferences.experimentalGmMediaControls,
     ) { values: Array<Any> ->
         SettingsUiState(
             videoAutoNegotiate = values[0] as Boolean,
@@ -202,7 +199,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             simulateIgnitionButton = values[47] as Boolean,
             overlayPhoneSwitchButton = values[48] as Boolean,
             overlayReconnectButton = values[49] as Boolean,
-            experimentalGmMediaControls = values[50] as Boolean,
         )
     }.stateIn(
         viewModelScope,
@@ -485,10 +481,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun updateClusterNavigation(enabled: Boolean) {
         viewModelScope.launch { preferences.setClusterNavigation(enabled) }
-    }
-
-    fun updateExperimentalGmMediaControls(enabled: Boolean) {
-        viewModelScope.launch { preferences.setExperimentalGmMediaControls(enabled) }
     }
 
     fun updateOverlayStatsButton(visible: Boolean) {

--- a/app/src/test/java/com/openautolink/app/media/GmMediaControlPolicyTest.kt
+++ b/app/src/test/java/com/openautolink/app/media/GmMediaControlPolicyTest.kt
@@ -1,8 +1,6 @@
 package com.openautolink.app.media
 
 import android.view.KeyEvent
-import com.openautolink.app.data.AppPreferences
-import com.openautolink.app.ui.settings.SettingsUiState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -12,42 +10,26 @@ import org.junit.Test
 class GmMediaControlPolicyTest {
 
     @Test
-    fun `experiment defaults off in storage and Settings state`() {
-        assertFalse(AppPreferences.DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS)
-        assertFalse(SettingsUiState().experimentalGmMediaControls)
-    }
-
-    @Test
-    fun `disabled experiment does not translate MediaSession commands`() {
-        assertNull(
-            GmMediaControlPolicy.keyCodeFor(
-                GmMediaControlPolicy.Command.PLAY,
-                enabled = false,
-            ),
-        )
-    }
-
-    @Test
-    fun `enabled experiment uses the discrete key mapping from GM GAL`() {
+    fun `built-in controls use the discrete key mapping from GM GAL`() {
         assertEquals(
             KeyEvent.KEYCODE_MEDIA_PLAY,
-            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PLAY, enabled = true),
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PLAY),
         )
         assertEquals(
             KeyEvent.KEYCODE_MEDIA_PAUSE,
-            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PAUSE, enabled = true),
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PAUSE),
         )
         assertEquals(
             KeyEvent.KEYCODE_MEDIA_PAUSE,
-            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.STOP, enabled = true),
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.STOP),
         )
         assertEquals(
             KeyEvent.KEYCODE_MEDIA_NEXT,
-            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.NEXT, enabled = true),
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.NEXT),
         )
         assertEquals(
             KeyEvent.KEYCODE_MEDIA_PREVIOUS,
-            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PREVIOUS, enabled = true),
+            GmMediaControlPolicy.keyCodeFor(GmMediaControlPolicy.Command.PREVIOUS),
         )
     }
 
@@ -60,64 +42,77 @@ class GmMediaControlPolicyTest {
     }
 
     @Test
-    fun `mute synchronization emits only enabled state transitions`() {
-        assertNull(
-            GmMediaControlPolicy.nextMuteState(
-                enabled = false,
-                masterMuted = true,
-                streamMuted = false,
-                lastDeliveredMuted = false,
-            ),
-        )
+    fun `mute synchronization emits only state transitions`() {
         assertEquals(
             true,
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = true,
                 streamMuted = false,
                 lastDeliveredMuted = false,
+                retainedMuted = false,
             ),
         )
         assertNull(
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = true,
                 streamMuted = true,
                 lastDeliveredMuted = true,
+                retainedMuted = true,
             ),
         )
         assertEquals(
             false,
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = false,
                 streamMuted = false,
                 lastDeliveredMuted = true,
+                retainedMuted = true,
             ),
         )
         assertNull(
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = false,
                 streamMuted = false,
                 lastDeliveredMuted = null,
+                retainedMuted = false,
             ),
         )
         assertEquals(
             true,
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = true,
                 streamMuted = false,
                 lastDeliveredMuted = null,
+                retainedMuted = false,
             ),
         )
         assertNull(
             GmMediaControlPolicy.nextMuteState(
-                enabled = true,
                 masterMuted = true,
                 streamMuted = false,
                 lastDeliveredMuted = true,
+                retainedMuted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `startup unmute corrects a retained mute without creating an initial transition`() {
+        assertEquals(
+            false,
+            GmMediaControlPolicy.nextMuteState(
+                masterMuted = false,
+                streamMuted = false,
+                lastDeliveredMuted = null,
+                retainedMuted = true,
+            ),
+        )
+        assertNull(
+            GmMediaControlPolicy.nextMuteState(
+                masterMuted = false,
+                streamMuted = false,
+                lastDeliveredMuted = null,
+                retainedMuted = false,
             ),
         )
     }

--- a/app/src/test/java/com/openautolink/app/media/GmMediaControlWiringContractTest.kt
+++ b/app/src/test/java/com/openautolink/app/media/GmMediaControlWiringContractTest.kt
@@ -1,30 +1,47 @@
 package com.openautolink.app.media
 
+import java.io.File
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import java.io.File
 
 class GmMediaControlWiringContractTest {
 
     @Test
-    fun `experimental control mode is off by default and reachable from Settings`() {
-        val preferences = source("app/src/main/java/com/openautolink/app/data/AppPreferences.kt")
-        val settingsVm = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt")
-        val settingsUi = source("app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt")
+    fun `GM media controls are built in with no user or native enable gate`() {
+        val files = listOf(
+            "app/src/main/java/com/openautolink/app/data/AppPreferences.kt",
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsViewModel.kt",
+            "app/src/main/java/com/openautolink/app/ui/settings/SettingsScreen.kt",
+            "app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt",
+            "app/src/main/java/com/openautolink/app/session/SessionManager.kt",
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt",
+            "app/src/main/java/com/openautolink/app/transport/aasdk/AasdkNative.kt",
+            "app/src/main/cpp/aasdk_jni.cpp",
+            "app/src/main/cpp/jni_session.cpp",
+            "app/src/main/cpp/jni_session.h",
+        ).associateWith(::source)
 
-        assertTrue(preferences.contains("EXPERIMENTAL_GM_MEDIA_CONTROLS"))
-        assertTrue(preferences.contains("DEFAULT_EXPERIMENTAL_GM_MEDIA_CONTROLS = false"))
-        assertTrue(preferences.contains("val experimentalGmMediaControls: Flow<Boolean>"))
-        assertTrue(preferences.contains("suspend fun setExperimentalGmMediaControls"))
-        assertTrue(settingsVm.contains("experimentalGmMediaControls"))
-        assertTrue(settingsVm.contains("updateExperimentalGmMediaControls"))
-        assertTrue(settingsUi.contains("Experimental GM media controls"))
-        assertTrue(settingsUi.contains("experimentalGmMediaControlsToggle"))
+        val removedTokens = listOf(
+            "EXPERIMENTAL_GM_MEDIA_CONTROLS",
+            "experimentalGmMediaControls",
+            "experimentalControlsEnabled",
+            "setExperimentalControlsEnabled",
+            "desiredExperimentalMediaControlsEnabled",
+            "setExperimentalMediaControlsEnabled",
+            "experimentalMediaControlsEnabled",
+            "Experimental GM media controls",
+            "experimentalGmMediaControlsToggle",
+        )
+        files.forEach { (path, text) ->
+            removedTokens.forEach { token ->
+                assertFalse("$token must be absent from $path", text.contains(token))
+            }
+        }
     }
 
     @Test
-    fun `enabled MediaSession controls and both GM mute channels reach the current AA session`() {
+    fun `MediaSession controls and both GM mute channels always reach the current AA session`() {
         val media = source("app/src/main/java/com/openautolink/app/media/OalMediaSessionManager.kt")
         val manager = source("app/src/main/java/com/openautolink/app/session/SessionManager.kt")
         val aasdk = source("app/src/main/java/com/openautolink/app/transport/aasdk/AasdkSession.kt")
@@ -35,66 +52,94 @@ class GmMediaControlWiringContractTest {
         assertTrue(media.contains("override fun onStop()"))
         assertTrue(media.contains("GmMediaControlPolicy.Command.STOP"))
         assertTrue(media.contains("PlaybackStateCompat.ACTION_STOP"))
-        assertTrue(media.contains("if (experimentalControlsEnabled) actions = actions or PlaybackStateCompat.ACTION_STOP"))
-        assertTrue(media.contains("buildPlaybackState(lastPushedState, lastPushedPosition)"))
-        assertTrue(manager.contains("setExperimentalControlsEnabled(false)"))
-        assertTrue(manager.contains("setExperimentalControlsEnabled(true)"))
-        assertTrue(manager.contains("preferences.experimentalGmMediaControls.distinctUntilChanged()"))
+        assertTrue(media.contains("mediaControlCallback?.onCommand"))
+
+        assertTrue(manager.contains("installGmMediaControls()"))
+        assertTrue(manager.contains("registerMuteStateReceiver()"))
         assertTrue(manager.contains("MASTER_MUTE_CHANGED_ACTION"))
         assertTrue(manager.contains("STREAM_MUTE_CHANGED_ACTION"))
         assertTrue(manager.contains("EXTRA_MASTER_VOLUME_MUTED"))
         assertTrue(manager.contains("manager.isStreamMute(AudioManager.STREAM_MUSIC)"))
         assertTrue(manager.contains("routeMediaSessionCommand"))
-        assertTrue(manager.contains("syncExperimentalHuMuteState"))
-        assertTrue(manager.contains("primeExperimentalUnmutedState"))
+        assertTrue(manager.contains("syncGmMuteState"))
+        val prepareNativeStart = manager
+            .substringAfter("private fun prepareNativeSessionStart")
+            .substringBefore("private fun startStreamingServicesLocked")
+        assertTrue(
+            prepareNativeStart.contains(
+                "synchronized(gmMediaControlLock) { lastDeliveredHuMuted = null }",
+            ),
+        )
         val receiverBlock = manager
             .substringAfter("private fun registerMuteStateReceiver()")
-            .substringBefore("private fun unregisterMuteStateReceiver()")
-        assertTrue(receiverBlock.contains("scope.launch { syncExperimentalHuMuteState"))
+            .substringBefore("private fun syncGmMuteState")
+        assertTrue(receiverBlock.contains("scope.launch { syncGmMuteState"))
+
         assertTrue(aasdk.contains("fun sendKeyPress"))
         assertTrue(aasdk.contains("currentNativeSessionGeneration"))
         assertTrue(aasdk.contains("fun setHeadUnitMuted"))
-        val nativeGateSetter = aasdk
-            .substringAfter("fun setExperimentalMediaControlsEnabled")
-            .substringBefore("fun sendGpsLocation")
-        assertTrue(nativeGateSetter.contains("synchronized(connectionStartLock)"))
+        assertTrue(aasdk.contains("private val headUnitMuteLock"))
+        assertTrue(aasdk.contains("synchronized(headUnitMuteLock)"))
         assertTrue(nativeApi.contains("nativeSendKeyPress"))
         assertTrue(nativeApi.contains("nativeSetHeadUnitMuted"))
         assertTrue(nativeApi.contains("nativePrimeHeadUnitMuted"))
-        assertTrue(nativeApi.contains("nativeSetExperimentalMediaControlsEnabled"))
         assertTrue(jni.contains("AasdkNative_nativeSendKeyPress"))
         assertTrue(jni.contains("AasdkNative_nativeSetHeadUnitMuted"))
         assertTrue(jni.contains("gSessionGeneration.load() != expectedGeneration"))
+
         val keyPressBody = nativeImpl
             .substringAfter("bool JniSession::sendKeyPress")
             .substringBefore("void JniSession::sendGpsLocation")
         assertTrue(keyPressBody.contains("for (bool down : {true, false})"))
         assertTrue(keyPressBody.contains("edges == 2"))
-        assertTrue(keyPressBody.contains("experimentalMediaControlsEnabled_"))
+        assertFalse(keyPressBody.contains("experimental"))
+
         val muteSetterBody = nativeImpl
             .substringAfter("bool JniSession::setHeadUnitMuted")
             .substringBefore("bool JniSession::flushHeadUnitAudioFocusState")
         assertTrue(muteSetterBody.contains("ioService_->post"))
+        assertTrue(muteSetterBody.contains("flushHeadUnitAudioFocusState(true)"))
         assertFalse(muteSetterBody.contains("controlChannel_"))
         assertFalse(muteSetterBody.contains("strand_"))
+
         val setupFocusBody = nativeImpl
             .substringAfter("void JniSession::sendUnsolicitedAudioFocusGain")
             .substringBefore("bool JniSession::setHeadUnitMuted")
-        assertTrue(setupFocusBody.contains("if (!experimentalMediaControlsEnabled_.load())"))
-        assertTrue(setupFocusBody.contains("AUDIO_FOCUS_STATE_GAIN"))
+        assertTrue(setupFocusBody.contains("flushHeadUnitAudioFocusState(headUnitMuteExplicit_.load())"))
+        assertFalse(setupFocusBody.contains("AUDIO_FOCUS_STATE_GAIN"))
+        val focusFlushBody = nativeImpl
+            .substringAfter("bool JniSession::flushHeadUnitAudioFocusState")
+            .substringBefore("bool JniSession::sendUnsolicitedAudioFocusState")
+        assertTrue(focusFlushBody.contains("!streaming_"))
+        val streamingReady = nativeImpl.indexOf("streaming_ = true;")
+        val sessionStartedCallback = nativeImpl.indexOf(
+            "callVoidCallback(cbMethods_.onSessionStarted);",
+            startIndex = streamingReady,
+        )
+        assertTrue(streamingReady >= 0 && sessionStartedCallback > streamingReady)
+        val phoneConnectedBlock = manager
+            .substringAfter("is ControlMessage.PhoneConnected ->")
+            .substringBefore("is ControlMessage.PhoneDisconnected ->")
+        assertTrue(phoneConnectedBlock.contains("_sessionState.value = SessionState.STREAMING"))
+        assertTrue(
+            phoneConnectedBlock.contains(
+                "scope.launch { syncGmMuteState(\"phone-connected\") }",
+            ),
+        )
         assertTrue(nativeImpl.contains("Key press send complete:"))
         assertTrue(nativeImpl.contains("AA audio focus sync outcome=sent:"))
+        assertTrue(manager.contains("retainedMuted = currentSession?.desiredHeadUnitMuted"))
+        assertTrue(manager.contains("session.primeHeadUnitMuted("))
     }
 
     @Test
-    fun `existing custom key remapping remains independent of experimental MediaSession controls`() {
+    fun `existing custom key remapping remains independent of built-in MediaSession controls`() {
         val steering = source("app/src/main/java/com/openautolink/app/input/SteeringWheelController.kt")
         val customBranch = steering
             .substringAfter("val customMapped = customKeyMap[keycode]")
             .substringBefore("return when")
 
         assertTrue(customBranch.contains("sendButtonToAA(customMapped"))
-        assertFalse(steering.contains("experimentalGmMediaControls"))
         assertFalse(steering.contains("GmMediaControlPolicy"))
     }
 


### PR DESCRIPTION
## Summary

- remove the validated GM media-control preference, Settings switch, and Kotlin/JNI/native enable gates
- install GM MediaSession commands and master/media-stream mute synchronization as built-in behavior
- retain native-generation and lifecycle fences plus the independent custom steering-wheel remap path
- serialize retained mute state with native generation creation and correctly reconcile muted→unmuted startup races without sending a redundant initial Gain

## TDD and verification

- policy/wiring tests were changed first and failed against the toggle-gated implementation
- the native-generation dedupe-lock test failed before its synchronization fix
- the startup retained-mute test failed before the retained-state reconciliation was added
- final car suite: 497 tests, 0 failures/errors/skips
- debug and release native builds passed for arm64-v8a and x86_64; R8, debug APK, and release AAB packaging passed
- strict lint matched clean `origin/main` exactly (no new findings)
- final AAB contains the built-in-control markers in DEX and both native libraries, excludes all old setting/gate markers, and uses 0.1.494 as a negative control
- final independent blocker review passed

Follow-up to #113.
