### PR TITLE
docs: surface GM call privacy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ For Android Auto 17.4 or newer:
 
 Those are the short instructions. Read [Wireless WPP setup](docs/wireless-wpp.md) for the required BSSID, saved-network trade-offs, and multi-phone behavior.
 
+## Keep calls in Android Auto on GM vehicles
+
+To keep the vehicle's native Phone app from covering Android Auto on the center display during incoming and active calls:
+
+1. Open the vehicle's native **Phone** app.
+2. Tap the **Settings** gear.
+3. Turn **Active Call** **OFF**.
+4. Turn **Privacy** **ON**.
+
+Leave the phone pairing's Bluetooth **Phone calls** profile **enabled**. Android Auto displays and controls the call while the vehicle's Bluetooth hands-free system carries microphone and speaker audio. Disabling **Phone calls** can remove call audio and break wireless startup.
+
+See [Phone calls](docs/phone-calls.md) for the setting descriptions, verification steps, and troubleshooting.
+
 ## Demonstrations
 
 ### Current project walkthrough

--- a/docs/phone-calls.md
+++ b/docs/phone-calls.md
@@ -9,16 +9,18 @@ Call UI/control: Android Auto → OpenAutoLink input → phone call action
 Voice audio:     phone ↔ vehicle Bluetooth HFP/SCO ↔ microphone and speakers
 ```
 
-## Vehicle settings
+## GM call privacy settings
 
 Configure this once in the vehicle's native **Phone** app:
+
+> **Phone → Settings → Active Call OFF → Privacy ON**
 
 1. Open the native **Phone** app.
 2. Tap the **Settings** gear.
 3. Turn **Active Call** **OFF**. Its description is **“Show active call view when answering call.”**
 4. Turn **Privacy** **ON**. Its description is **“Only show call alerts in cluster.”**
 
-The native Phone app should then stop replacing Android Auto on the center screen when a call is answered.
+These settings keep native incoming-call alerts in the cluster and stop the native active-call screen from replacing Android Auto on the center display.
 
 ## Bluetooth setting that must remain enabled
 


### PR DESCRIPTION
Adds the GM Active Call OFF and Privacy ON steps to the README and makes the path prominent in the phone-call guide. Keeps the warning to leave Bluetooth Phone calls enabled for hands-free audio and wireless startup.